### PR TITLE
Fix stockit increase formula in javascript

### DIFF
--- a/app/assets/javascripts/ordering.js
+++ b/app/assets/javascripts/ordering.js
@@ -49,7 +49,7 @@ function addData(orderArticleId, itemPrice, itemUnit, itemSubtotal, itemQuantity
 
 function increaseQuantity(item) {
     var value = Number($('#q_' + item).val()) + 1;
-    if (!isStockit || (value <= (quantityAvailable[item] - quantityOthers[item]))) {
+    if (!isStockit || (value <= (quantityAvailable[item] + itemsAllocated[item]))) {
         update(item, value, $('#t_' + item).val());
     }
 }


### PR DESCRIPTION
Ich erlaube mir mal wie gewohnt, in Deutsch zu schreiben.

Ein [Fehler](/balkansalat/foodsoft/issues?state=open), der beim Kaufen aus dem Lager auftritt, falls schon Einkäufe getätigt und bestätigt wurden: Man kann die schon teilweise gekauften Artikel nicht leerkaufen, weil die Javascript-Berechnung, ob ein Artikel noch gekauft werden kann, nicht so recht hinhaut.

Irgendwie hat sich die Berechnung der "verfügbaren" Artikel geändert, sodass in der Javascript-Funktion nun die
- eigenen bereits bestellten und bestätigten Artikel addiert werden müssen sowie
- die bestellten Artikel der anderen Gruppen nicht mehr abgezogen werden dürfen,
