### PR TITLE
Prevent article name from being truncated in StockTaking form

### DIFF
--- a/app/views/stock_takings/_stock_change.html.haml
+++ b/app/views/stock_takings/_stock_change.html.haml
@@ -3,5 +3,5 @@
     = form.hidden_field :stock_article_id
     = "Menge (#{stock_change.stock_article.quantity_available})"
     = form.text_field :quantity, :size => 5, :autocomplete => 'off'
-    %b=h truncate(stock_change.stock_article.name)
+    %b= stock_change.stock_article.name
     = "(#{number_to_currency(stock_change.stock_article.price)} / #{stock_change.stock_article.unit})"


### PR DESCRIPTION
Falls (lange) Artikel sich nur am Ende ihres Namens unterscheiden, ist das Abschneiden ohne weitere Info wirklich hinderlich.

Da genug Platz für die 60 Zeichen vorhanden ist und auch bei schmalerem Viewport die Zeile einfach umbrechen kann, schlage ich vor, das `truncate` rauszunehmen.

Das `h` kann man denke ich auch weglassen.
