### PR TITLE
Prevent sold-out articles from being removed from stock order when editing

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -48,8 +48,9 @@ class Article < ActiveRecord::Base
     order_article ? order_article.order : nil
   end
   memoize :in_open_order
-
-  def ordered?(order)
+  
+  # Returns true if the article has been ordered in the given order at least once
+  def ordered_in_order?(order)
     order.order_articles.where(article_id: id).where('quantity > 0').one?
   end
   

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -38,9 +38,11 @@ class Order < ActiveRecord::Base
 
   def articles_for_ordering
     if stockit?
+      # make sure to include those articles which are no longer available
+      # but which have already been ordered in this stock order
       StockArticle.available.all(:include => :article_category,
         :order => 'article_categories.name, articles.name').reject{ |a|
-        a.quantity_available <= 0 and not a.ordered?(self)
+        a.quantity_available <= 0 and not a.ordered_in_order?(self)
       }.group_by { |a| a.article_category.name }
     else
       supplier.articles.available.all.group_by { |a| a.article_category.name }


### PR DESCRIPTION
Dieses [Problem](/balkansalat/foodsoft/issues/12) ist recht kritisch. Zusammenfassung: Sollte ein Lagerartikel in einer laufenden Lagerbestellung ausverkauft werden, so sinkt seine Verfügbarkeit richtigerweise auf 0. Falls man anschließend die Lagerbestellung bearbeitet, wird der ausverkaufte Artikel deshalb **nicht zur Auswahl gestellt, obwohl er in der laufenden Lagerbestellung bereits bestellt (=gekauft) wurde**. Ein Speichern führt bisher zum Entfernen des Lagerartikels aus der Lagerbestellung und damit zum Verändern der Abrechnung zu Lasten der Coop.

Dieser Fix soll zunächst die Anzeige der betroffenen Lagerartikel Wiederherstellen. Der nächste Schritt ist, auch das bewusste Abwählen zu verbieten.
