### PR TITLE
Show tax percent sign in forms

### DIFF
--- a/app/views/articles/_edit_all_table.html.haml
+++ b/app/views/articles/_edit_all_table.html.haml
@@ -28,7 +28,9 @@
           %td= form.text_field 'note', class: 'input-medium'
           %td= form.collection_select 'article_category_id', ArticleCategory.all,
             :id, :name, { :include_blank => true }, class: 'input-small'
-          %td= form.text_field 'tax', class: 'input-mini'
+          %td.input-append
+            = form.text_field 'tax', class: 'input-mini'
+            %span.add-on %
           %td= form.text_field 'deposit', class: 'input-mini'
         - unless article.errors.empty?
           %tr.alert

--- a/app/views/articles/_form.html.haml
+++ b/app/views/articles/_form.html.haml
@@ -16,7 +16,9 @@
     = f.input :price
     = f.input :unit_quantity
     = f.input :order_number
-    = f.input :tax
+    = f.input :tax, :wrapper => :append do
+      = f.input_field :tax
+      %span.add-on %
     = f.input :deposit
   .modal-footer
     = link_to t('ui.close'), '#', class: 'btn', data: {dismiss: 'modal'}

--- a/app/views/articles/sync.html.haml
+++ b/app/views/articles/sync.html.haml
@@ -60,7 +60,9 @@
               %td{:style => highlight_new(attrs, :unit)}= form.text_field 'unit', class: 'input-mini'
               %td{:style => highlight_new(attrs, :unit_quantity)}= form.text_field 'unit_quantity', class: 'input-mini'
               %td{:style => highlight_new(attrs, :price)}= form.text_field 'price', class: 'input-mini'
-              %td{:style => highlight_new(attrs, :tax)}= form.text_field 'tax', class: 'input-mini'
+              %td{:style => highlight_new(attrs, :tax), class: 'input-append'}
+                = form.text_field 'tax', class: 'input-mini'
+                %span.add-on %
               %td{:style => highlight_new(attrs, :deposit)}= form.text_field 'deposit', class: 'input-mini'
               %td= form.select :article_category_id, ArticleCategory.all.map {|a| [ a.name, a.id ] },
                 {include_blank: true}, class: 'input-small'

--- a/app/views/deliveries/_stock_article_form.html.haml
+++ b/app/views/deliveries/_stock_article_form.html.haml
@@ -5,7 +5,10 @@
   = f.input :unit
   = f.input :note
   = f.input :price
-  = f.input :tax
+  = f.input :tax, :wrapper => :append do
+    = f.input_field :tax
+    %span.add-on %
+    -# untested, because this view is currently not included (?)
   = f.input :deposit
   = f.association :article_category
   = f.submit class: 'btn'

--- a/app/views/stock_takings/_stock_article_form.html.haml
+++ b/app/views/stock_takings/_stock_article_form.html.haml
@@ -4,7 +4,10 @@
   = f.input :unit
   = f.input :note
   = f.input :price
-  = f.input :tax
+  = f.input :tax, :wrapper => :append do
+    = f.input_field :tax
+    %span.add-on %
+    -# untested, because this view is currently not included (?)
   = f.input :deposit
   = f.association :article_category
   = f.submit

--- a/app/views/stockit/_form.html.haml
+++ b/app/views/stockit/_form.html.haml
@@ -6,7 +6,9 @@
 
   - if stock_article.new_record?
     = f.input :price
-    = f.input :tax
+    = f.input :tax, :wrapper => :append do
+      = f.input_field :tax
+      %span.add-on %
     = f.input :deposit
   - else
     = f.input :price, :input_html => {:disabled => 'disabled'}, :hint => t('.form.price_hint')


### PR DESCRIPTION
Some days ago I noticed articles in my foodcoop which had a tax of 0.07 % or 0.19 % instead of 7 % or 19 %. The reason for that could be the missing percent sign in forms.

For details, see [issue in Rostock's repo](/foodcoop-rostock/foodsoft/issues/42).
