### PR TITLE
make touch device events work on buttons

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,6 +10,19 @@
 //= require_self
 //= require ordering
 
+// allow touch devices to work on click events
+//   http://stackoverflow.com/a/16221066
+$.fn.extend({ _on: (function(){ return $.fn.on; })() });
+$.fn.extend({
+    on: (function(){
+        var isTouchSupported = 'ontouchstart' in window || window.DocumentTouch && document instanceof DocumentTouch;
+        return function( types, selector, data, fn, one ) {
+            if (typeof types == 'string' && isTouchSupported && !(types.match(/touch/gi))) types = types.replace(/click/gi, 'touchstart');
+            return this._on( types, selector, data, fn);
+        };
+    }()),
+});
+
 // Load following statements, when DOM is ready
 $(function() {
 


### PR DESCRIPTION
closes foodcoop-rostock/foodsoft#34, closes foodcoops/foodsoft#104
