### PR TITLE
only add undeleted articles in balancing screen

### DIFF
--- a/app/helpers/finance/order_articles_helper.rb
+++ b/app/helpers/finance/order_articles_helper.rb
@@ -4,7 +4,7 @@ module Finance::OrderArticlesHelper
     if @order.stockit?
       StockArticle.order('articles.name')
     else
-      @order.supplier.articles.order('articles.name')
+      @order.supplier.articles.undeleted.order('articles.name')
     end
   end
 end


### PR DESCRIPTION
At the moment also deleted are included when adding articles in the balancing screen. I think that should only be not deleted articles. Am I right?
