### PR TITLE
remember member order when order article is deleted

### DIFF
--- a/app/controllers/finance/order_articles_controller.rb
+++ b/app/controllers/finance/order_articles_controller.rb
@@ -42,6 +42,14 @@ class Finance::OrderArticlesController < ApplicationController
 
   def destroy
     @order_article = OrderArticle.find(params[:id])
-    @order_article.destroy
+    # only destroy if there are no associated GroupOrders; if we would, the requested
+    # quantity and tolerance would be gone. Instead of destroying, we set all result
+    # quantities to zero.
+    if @order_article.group_order_articles.count == 0
+      @order_article.destroy
+    else
+      @order_article.group_order_articles.each { |goa| goa.update_attribute(:result, 0) }
+      @order_article.update_results!
+    end
   end
 end

--- a/spec/integration/balancing_spec.rb
+++ b/spec/integration/balancing_spec.rb
@@ -50,6 +50,32 @@ describe 'settling an order', :type => :feature do
       end
     end
 
+    it 'keeps ordered quantities when article is deleted from resulting order' do
+      within("#order_article_#{oa.id}") do
+        click_link I18n.t('ui.delete')
+        page.driver.browser.switch_to.alert.accept
+      end
+      expect(page).to_not have_selector("#order_article_#{oa.id}")
+      expect(OrderArticle.exists?(oa.id)).to be_true
+      oa.reload
+      expect(oa.quantity).to eq(4)
+      expect(oa.tolerance).to eq(0)
+      expect(oa.units_to_order).to eq(0)
+      expect(goa1.reload.result).to eq(0)
+      expect(goa2.reload.result).to eq(0)
+    end
+
+    it 'deletes an OrderArticle with no GroupOrderArticles' do
+      goa1.destroy
+      goa2.destroy
+      within("#order_article_#{oa.id}") do
+        click_link I18n.t('ui.delete')
+        page.driver.browser.switch_to.alert.accept
+      end
+      expect(page).to_not have_selector("#order_article_#{oa.id}")
+      expect(OrderArticle.exists?(oa.id)).to be_false
+    end
+
   end
 
 end


### PR DESCRIPTION
When an article is deleted in the balancing screen, the associated `GroupOrderArticle`s are also deleted, and thus information is lost. This operation cannot be undone.

We have found this to happen when an article was unavailable, and so it was deleted from an order. Then the supplier had a slightly different article as a substitution. We had to ask which member ordered the original article to redistribute.

This patch sets the amount ordered to zero when any `GroupOrderArticle` is associated.

@bennibu / @fsmanuel could you please check if this does not break anything I didn't think of?
