### PR TITLE
Added hint when changing total delivered amount.

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1525,7 +1525,7 @@ de:
       message:
         private: Nachricht erscheint nicht im Foodsoft Posteingang
       order_article:
-        units_to_order: Anzahl gelieferter Gebinde
+        units_to_order: Wenn Du die Gesamtanzahl gelieferter Gebinde änderst, musst Du auch die individuelle Anzahl der einzelnen Bestellgruppen anpassen, indem Du auf den Artikelnamen klickst. Sie werden nicht automatisch neuberechnet und andernfalls werden den Bestellgruppen Artikel in Rechnung gestellt, die nicht geliefert wurden!
         update_current_price: Ändert auch den Preis für aktuelle Bestellungen
       stock_article:
         copy_stock_article:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1530,7 +1530,7 @@ en:
       message:
         private: Message doesn’t show in Foodsoft mail inbox
       order_article:
-        units_to_order: Amount of delivered units
+        units_to_order: If you change the total amount of delivered units, you also have to change individual group amounts by clicking on the article name. They will not be automatically recalculated and otherwise ordergroups will be accounted for undelivered articles!
         update_current_price: Also update the price of the current order
       stock_article:
         copy_stock_article:


### PR DESCRIPTION
This is a quick "fix" for foodcoops/foodsoft#174.

I neither managed to write a test spec that reveals the error nor did I find a quick fix to recalculate group_order_article amounts based on order_article amount.
