### PR TITLE
Force update_attributes! in Order#finish; rescue if error raised

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -98,6 +98,8 @@ class OrdersController < ApplicationController
     order = Order.find(params[:id])
     order.finish!(@current_user)
     redirect_to order, notice: I18n.t('orders.finish.notice')
+  rescue => error
+    redirect_to orders_url, alert: I18n.t('errors.general_msg', :msg => error.message)
   end
   
   # Renders the fax-text-file

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -155,7 +155,7 @@ class Order < ActiveRecord::Base
     unless finished?
       Order.transaction do
         # set new order state (needed by notify_order_finished)
-        update_attributes(:state => 'finished', :ends => Time.now, :updated_by => user)
+        update_attributes!(:state => 'finished', :ends => Time.now, :updated_by => user)
 
         # Update order_articles. Save the current article_price to keep price consistency
         # Also save results for each group_order_result


### PR DESCRIPTION
It has randomly happened in our production that an order could not be finished. Every time you tried it for that particular order, the `I18n.t('orders.finish.notice')` was shown and the user was redirected to the order but it was not finished.

There was no success in reproducing the error yet.

This shall care for the transaction (roll it back by raising an error) and show an appropriate error message.
