### PR TITLE
Allow large product lists in member order

### DIFF
--- a/app/views/group_orders/_form.html.haml
+++ b/app/views/group_orders/_form.html.haml
@@ -9,7 +9,14 @@
       // create List for search-feature (using list.js, http://listjs.com)
       var listjsResetPlugin = ['reset', {highlightClass: 'btn-primary'}];
       var listjsDelayPlugin = ['delay', {delayedSearchTime: 500}];
-      new List(document.body, { valueNames: ['name'], engine: 'unlist', plugins: [listjsResetPlugin, listjsDelayPlugin] });
+      new List(document.body, {
+        valueNames: ['name'],
+        engine: 'unlist',
+        plugins: [listjsResetPlugin, listjsDelayPlugin],
+        // make large pages work too (as we don't have paging - articles may disappear!)
+        page: 10000,
+        indexAsync: true
+      });
     });
 
 - title t('.title'), false


### PR DESCRIPTION
The default listjs `page` value is 200, so if more than 200 articles are present, they are not shown. This patch enlarges that limit, and enables asynchronous indexing - which is useful to large lists.
