### PR TITLE
Remove apple-touch-icon link

### DIFF
--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -7,10 +7,6 @@
     %title= [t('layouts.foodsoft'), yield(:title)].join(" - ")
     = csrf_meta_tags
     = stylesheet_link_tag "application", :media => "all"
-    %link(href="images/apple-touch-icon-144x144.png" rel="apple-touch-icon-precomposed" sizes="144x144")
-    %link(href="images/apple-touch-icon-114x114.png" rel="apple-touch-icon-precomposed" sizes="114x114")
-    %link(href="images/apple-touch-icon-72x72.png" rel="apple-touch-icon-precomposed" sizes="72x72")
-    %link(href="images/apple-touch-icon.png" rel="apple-touch-icon-precomposed")
     //%link(href="images/favicon.ico" rel="shortcut icon")
 
     = yield(:head)


### PR DESCRIPTION
Addresses #130

Safari will fall back to request the default touch icons if the href of the link 404s, so having them point at nothing generates 4 404s for nothing.
