### PR TITLE
fix+workaround for annoying password autocompletion

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -94,6 +94,22 @@ $(function() {
         $(this).parents('form').submit();
     });
 
+    // The autocomplete attribute is used for both autocompletion and storing
+    // for passwords, it's nice to store it when editing one's own profile,
+    // but never autocomplete. When the data-autocomplete attribute is 'off',
+    // any autocompleted values are removed again.
+    // This is only implemented for passwords.
+    $('input[type="password"][autocomplete="off"]').each(function() {
+      // add dummy password field for autocompletion after losing username field focus
+      $(this).before('<input type="password" name="_x_autocomplete_workaround" style="display:none"/>');
+      // make sure we don't receive the remembered password by accident
+      $(this).parentsUntil('form').on('submit', function(ev) {
+        $('input[name="_x_autocomplete_workaround"]').val('');
+      });
+      // if the browser already filled it in here, clear the password
+      $(this).val('');
+    });
+
     $('[data-redirect-to]').bind('change', function() {
         var newLocation = $(this).children(':selected').val();
         if (newLocation != "") {

--- a/app/views/shared/_user_form_fields.html.haml
+++ b/app/views/shared/_user_form_fields.html.haml
@@ -1,12 +1,15 @@
-- if FoodsoftConfig[:use_nick]
-  -# use_nil option to user model validators break required mark
-  = f.input :nick, required: true
 = f.input :first_name
 = f.input :last_name
 = f.input :email
+/ need :required because :use_nil option to user model validators break the required mark
+= f.input :nick, required: true if FoodsoftConfig[:use_nick]
+/ Don't autocomplete passwords. When editing one's own profile page, it only fills
+/ in one of the two passwords fields, which is annoying when editing other preferences.
+/ When an admin edits another user's profile, this will fill in his own password,
+/ which is dangerous.
+= f.input :password, :required => f.object.new_record?, input_html: {autocomplete: 'off'}
+= f.input :password_confirmation, :required => f.object.new_record?, input_html: {autocomplete: 'off'}
 = f.input :phone
-= f.input :password, :required => f.object.new_record?
-= f.input :password_confirmation
 
 = f.simple_fields_for :settings_attributes do |s|
   = s.simple_fields_for :profile, defaults: { inline_label: true } do |profile|
@@ -22,7 +25,7 @@
         = profile.input 'phone_is_public',  as: :boolean, label: false, input_html: { checked: f.object.settings.profile['phone_is_public'] }
         = profile.input 'email_is_public',  as: :boolean, label: false, input_html: { checked: f.object.settings.profile['email_is_public'] }
         - if FoodsoftConfig[:use_nick]
-          = profile.input 'name_is_public',   as: :boolean, label: false, input_html: { checked: f.object.settings.profile['name_is_public'] }
+          = profile.input 'name_is_public', as: :boolean, label: false, input_html: { checked: f.object.settings.profile['name_is_public'] }
   
     .settings-group
       %div{class: 'control-group'}


### PR DESCRIPTION
When entering the profile page with a browser remembering passwords, only one of the two password fields in filled in. This means that the user needs to enter his password, or remove the existing one. This pull request disables autocompletion on password fields in the profile page. Also useful for admins editing other users' preferences.

The order of fields is also changed, so that when browsers still offer to store passwords (like Firefox currently) uses the correct username field (which must be just before the first password field).
