### PR TITLE
Fix StockArticle#derive title i18n

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1361,6 +1361,8 @@ de:
       title: Lagerartikel kopieren
     create:
       notice: Neuer Lagerartikel »%{name}« gespeichert.
+    derive:
+      title: Lagerartikel aus Vorlage erstellen
     destroy:
       notice: Artikel %{name} gelöscht.
     edit:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1365,6 +1365,8 @@ en:
       title: Copy stock article
     create:
       notice: New stock article "%{name}" was created.
+    derive:
+      title: Add stock article using template
     destroy:
       notice: Article %{name} was deleted.
     edit:


### PR DESCRIPTION
This adds one missing string in the locales.

Problably they were not added automatically because the view is a `derive.js.erb`, i.e., not a `*.html.haml`.
