### PR TITLE
Add missing translations for ArticlePrice attributes

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -27,6 +27,11 @@ de:
       article_category:
         description: Beschreibung
         name: Name
+      article_price:
+        deposit: Pfand
+        price: Nettopreis
+        tax: MwSt
+        unit_quantity: Gebindegröße
       delivery:
         delivered_on: Lieferdatum
         note: Notiz

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -27,6 +27,11 @@ en:
       article_category:
         description: Description
         name: Name
+      article_price:
+        deposit: Deposit
+        price: Price (net)
+        tax: VAT
+        unit_quantity: Unit quantity
       delivery:
         delivered_on: Delivery date
         note: Note

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -27,6 +27,11 @@ fr:
       article_category:
         description: Description
         name: Nom
+      article_price:
+        deposit: Consigne
+        price: Prix net
+        tax: TVA
+        unit_quantity: Unités par lot
       delivery:
         delivered_on: Date de réapprovisionnement
         note: 

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -27,6 +27,11 @@ nl:
       article_category:
         description: Omschrijving
         name: Naam
+      article_price:
+        deposit: Statiegeld
+        price: Netto prijs
+        tax: BTW
+        unit_quantity: Groothandelseenheid
       delivery:
         delivered_on: Leverdatum
         note: Notitie


### PR DESCRIPTION
When editing an `OrderArticle` in the balancing form, the translations for `ArticlePrice` attributes are needed.
