### PR TITLE
Clear return_to URL in session when signing out.

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -28,6 +28,7 @@ class SessionsController < ApplicationController
 
   def destroy
     session[:user_id] = nil
+    session[:return_to] = nil
     redirect_to login_url, :notice => I18n.t('sessions.logged_out')
   end
 end


### PR DESCRIPTION
Otherwise you might get an unexpected start page on a client, where someone else got an _access denied_ error in the previous session.
