### PR TITLE
Center table rows vertically

### DIFF
--- a/app/assets/stylesheets/bootstrap_and_overrides.css.less
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css.less
@@ -224,6 +224,18 @@ tr.unavailable {
   dd { margin-left: 170px; }
 }
 
+// center table rows vertically (including form elements)
+table.table {
+  td, th {
+    vertical-align: middle;
+  }
+  select, textarea, input, .uneditable-input,
+  .input-append, .input-prepend {
+    margin-bottom: 0;
+    margin-top: 0;
+  }
+}
+
 .settings {
   .settings-group {
     margin-bottom: 10px;


### PR DESCRIPTION
for all `table.table`s. Feels a lot cleaner to me.

As a side-effect, it changes the look of "edit all" articles screen, where there is now less space between the rows. I think that's actually a good thing.

This came up in foodcoops#222.
