### PR TITLE
fix root redirect when using suburi

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -62,9 +62,4 @@ class HomeController < ApplicationController
     redirect_to my_profile_path
   end
 
-  # redirect to root, going to default foodcoop when none given
-  def redirect_to_foodcoop
-    redirect_to root_path
-  end
-
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -31,4 +31,11 @@ class SessionsController < ApplicationController
     session[:return_to] = nil
     redirect_to login_url, :notice => I18n.t('sessions.logged_out')
   end
+
+  # redirect to root, going to default foodcoop when none given
+  # this may not be so much session-related, but it must be somewhere
+  def redirect_to_foodcoop
+    redirect_to root_path
+  end
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Foodsoft::Application.routes.draw do
 
   get "sessions/new"
 
-  root :to => 'home#redirect_to_foodcoop'
+  root :to => 'sessions#redirect_to_foodcoop'
 
 
   scope '/:foodcoop' do


### PR DESCRIPTION
When installing foodsoft not in the web root but a sub uri, the default foodcoop redirect does not function correctly. This fixes that.
