### PR TITLE
allow 500 items per page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -143,7 +143,7 @@ class ApplicationController < ActionController::Base
   end
 
   def items_per_page
-    if params[:per_page] && params[:per_page].to_i > 0 && params[:per_page].to_i <= 100
+    if params[:per_page] && params[:per_page].to_i > 0 && params[:per_page].to_i <= 500
       @per_page = params[:per_page].to_i
     else
       @per_page = 20

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -29,7 +29,7 @@ module ApplicationHelper
   
   # Link-collection for per_page-options when using the pagination-plugin
   def items_per_page(options = {})
-    per_page_options = options[:per_page_options] || [20, 50, 100]
+    per_page_options = options[:per_page_options] || [20, 50, 100, 500]
     current = options[:current] || @per_page
     params = params || {}
 


### PR DESCRIPTION
When doing actions on large lists, it can save a lot of time to be able to select 500 items at the same time. Full solution would be to do actions on all items, or make a more intelligent selection (like, only approved ordergroups, or all unavailable articles), but for now this is an improvement.
