### PR TITLE
make apple points optional

### DIFF
--- a/app/models/ordergroup.rb
+++ b/app/models/ordergroup.rb
@@ -85,7 +85,8 @@ class Ordergroup < Group
   # The restriction can be deactivated for each ordergroup.
   # Only ordergroups, which have participated in more than 5 orders in total and more than 2 orders in apple time period
   def not_enough_apples?
-    FoodsoftConfig[:stop_ordering_under].present? and
+    FoodsoftConfig[:use_apple_points] and
+        FoodsoftConfig[:stop_ordering_under].present? and
         !ignore_apple_restriction and
         apples < FoodsoftConfig[:stop_ordering_under] and
         group_orders.count > 5 and

--- a/app/views/admin/ordergroups/_form.html.haml
+++ b/app/views/admin/ordergroups/_form.html.haml
@@ -5,7 +5,8 @@
     = f.input :contact_person
     = f.input :contact_phone
     = f.input :contact_address
-    = f.input :ignore_apple_restriction, :label => false, :inline_label => true
+    - if FoodsoftConfig[:use_apple_points]
+      = f.input :ignore_apple_restriction, :label => false, :inline_label => true
   .form-actions
     = f.button :submit
     = link_to t('ui.or_cancel'), :back

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -27,7 +27,7 @@
   = render :partial => 'shared/open_orders', :locals => {:ordergroup => current_user.ordergroup}
 
 // Stats
-- if current_user.ordergroup
+- if current_user.ordergroup and FoodsoftConfig[:use_apple_points]
   %section
     %h2= t '.ordergroup.title'
     = render :partial => "apple_bar", :locals => {:apple_bar => AppleBar.new(current_user.ordergroup)}

--- a/app/views/shared/_group.html.haml
+++ b/app/views/shared/_group.html.haml
@@ -13,6 +13,6 @@
     - members = group.users
     = "(#{members.size})"
     = members.collect{|u| show_user(u)}.join(", ")
-  - unless group.is_a?(Workgroup)
+  - if group.is_a?(Ordergroup) and FoodsoftConfig[:use_apple_points]
     %dt= t '.apple_limit'
     %dd= group.ignore_apple_restriction ? t('.deactivated') : t('.activated')

--- a/config/app_config.yml.SAMPLE
+++ b/config/app_config.yml.SAMPLE
@@ -48,6 +48,9 @@ default: &defaults
   # Comment out this option to activate this restriction
   # stop_ordering_under: 75
 
+  # Comment out to completely hide apple points (be sure to comment stop_ordering_under)
+  # use_apple_points: false
+
   # ordergroups can only order when their balance is higher than or equal to this
   # not fully enforced right now, since the check is only client-side
   # minimum_balance: 0

--- a/lib/foodsoft_config.rb
+++ b/lib/foodsoft_config.rb
@@ -52,7 +52,8 @@ class FoodsoftConfig
     # configuration files that haven't been updated, still work as they did.
     def set_missing
       config.replace({
-        use_nick: true
+        use_nick: true,
+        use_apple_points: true
       }.merge(config))
     end
 


### PR DESCRIPTION
Not everyone uses the apple points (or even tasks). This allows to hide its functionality. In the future, it may be moved to a plugin.
