### PR TITLE
add fax csv

### DIFF
--- a/app/views/orders/show.html.haml
+++ b/app/views/orders/show.html.haml
@@ -56,6 +56,7 @@
           %li= order_pdf(@order, :matrix, t('.download.matrix_pdf'))
           %li= order_pdf(@order, :fax, t('.download.fax_pdf'))
           %li= link_to t('.download.fax_txt'), order_path(@order, format: :txt), {title: t('.download.download_file')}
+          %li= link_to t('.download.fax_csv'), order_path(@order, format: :csv), {title: t('.download.download_file')}
 
     - if @order.open?
       = link_to t('.action_end'), finish_order_path(@order), method: :post, class: 'btn btn-success',

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1180,6 +1180,7 @@ en:
       download:
         article_pdf: Article PDF
         download_file: Download file
+        fax_csv: Fax CSV
         fax_pdf: Fax PDF
         fax_txt: Fax text
         group_pdf: Group PDF

--- a/lib/order_csv.rb
+++ b/lib/order_csv.rb
@@ -1,0 +1,39 @@
+require 'csv'
+
+class OrderCsv
+  include ActionView::Helpers::NumberHelper
+
+  def initialize(order, options={})
+    @order = order
+  end
+
+  def to_csv
+    CSV.generate do |csv|
+      # header
+      csv << [
+               OrderArticle.human_attribute_name(:units_to_order),
+               Article.human_attribute_name(:order_number),
+               Article.human_attribute_name(:name),
+               Article.human_attribute_name(:unit),
+               ArticlePrice.human_attribute_name(:price),
+               OrderArticle.human_attribute_name(:total_price)
+             ]
+      # data
+      @order.order_articles.ordered.includes([:article, :article_price]).all.map do |oa|
+        csv << [
+                 oa.units_to_order,
+                 oa.article.order_number,
+                 oa.article.name,
+                 oa.article.unit + (oa.price.unit_quantity > 1 ? " × #{oa.price.unit_quantity}" : ''),
+                 number_to_currency(oa.article_price.price * oa.article_price.unit_quantity),
+                 number_to_currency(oa.total_price)
+               ]
+      end
+    end
+  end
+
+  # Helper method to test pdf via rails console: OrderCsv.new(order).save_tmp
+  def save_tmp
+    File.open("#{Rails.root}/tmp/#{self.class.to_s.underscore}.csv", 'w') {|f| f.write(to_csv.force_encoding("UTF-8")) }
+  end
+end

--- a/lib/order_txt.rb
+++ b/lib/order_txt.rb
@@ -1,0 +1,35 @@
+
+class OrderTxt
+  def initialize(order, options={})
+    @order = order
+  end
+
+  # Renders the fax-text-file
+  # e.g. for easier use with online-fax-software, which don't accept pdf-files
+  def to_txt
+    supplier = @order.supplier
+    contact = FoodsoftConfig[:contact].symbolize_keys
+    text = I18n.t('orders.fax.heading', :name => FoodsoftConfig[:name])
+    text += "\n#{Supplier.human_attribute_name(:customer_number)}: #{supplier.customer_number}" unless supplier.customer_number.blank?
+    text += "\n" + I18n.t('orders.fax.delivery_day')
+    text += "\n\n#{supplier.name}\n#{supplier.address}\n#{Supplier.human_attribute_name(:fax)}: #{supplier.fax}\n\n"
+    text += "****** " + I18n.t('orders.fax.to_address') + "\n\n"
+    text += "#{FoodsoftConfig[:name]}\n#{contact[:street]}\n#{contact[:zip_code]} #{contact[:city]}\n\n"
+    text += "****** " + I18n.t('orders.fax.articles') + "\n\n"
+    text += I18n.t('orders.fax.number') + "   " + I18n.t('orders.fax.amount') + "   " + I18n.t('orders.fax.name') + "\n"
+    # now display all ordered articles
+    @order.order_articles.ordered.includes([:article, :article_price]).each do |oa|
+      number = oa.article.order_number
+      (8 - number.size).times { number += " " }
+      quantity = oa.units_to_order.to_i.to_s
+      quantity = " " + quantity if quantity.size < 2
+      text += "#{number}   #{quantity}    #{oa.article.name}\n"
+    end
+    text
+  end
+
+  # Helper method to test pdf via rails console: OrderTxt.new(order).save_tmp
+  def save_tmp
+    File.open("#{Rails.root}/tmp/#{self.class.to_s.underscore}.txt", 'w') {|f| f.write(to_csv.force_encoding("UTF-8")) }
+  end
+end


### PR DESCRIPTION
Adds the option to download a csv file for the order. Some of our suppliers prefer that to a PDF.

Also moves fax txt generation to a separate file, to bring more harmony in how documents are generated.
