### PR TITLE
use ruby-units for unit parsing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ gem "rails-settings-cached", "0.3.1"
 gem 'resque'
 gem 'whenever', require: false # For defining cronjobs, see config/schedule.rb
 gem 'protected_attributes'
+gem 'ruby-units'
 
 # we use the git version of acts_as_versioned, and need to include it in this Gemfile
 gem 'acts_as_versioned', git: 'git://github.com/technoweenie/acts_as_versioned.git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -281,6 +281,7 @@ GEM
     rspec-rerun (0.1.3)
       rspec (>= 2.11.0)
     ruby-prof (0.14.2)
+    ruby-units (1.4.4)
     rubyzip (1.1.0)
     sass (3.2.14)
     sass-rails (4.0.1)
@@ -421,6 +422,7 @@ DEPENDENCIES
   rspec-rails
   rspec-rerun
   ruby-prof
+  ruby-units
   sass-rails (~> 4.0.0)
   select2-rails
   selenium-webdriver

--- a/config/app_config.yml.SAMPLE
+++ b/config/app_config.yml.SAMPLE
@@ -81,22 +81,6 @@ default: &defaults
     encoding: utf8
     socket: /opt/lampp/var/mysql/mysql.sock
 
-  # auto-units-conversion
-  # this is used for automatic article-synchronization to handle different units
-  # e.g. when foodcoop-unit should be 500g and supplier-unit is 1kg
-  units:
-    KG: 1
-    1kg: 1
-    500g: 0.5
-    400g: 0.4
-    300g: 0.3
-    250g: 0.25
-    200g: 0.2
-    150g: 0.15
-    125g: 0.125
-    100g: 0.1
-    50g: 0.05
-
 development:
   <<: *defaults
 

--- a/config/initializers/ruby_units.rb
+++ b/config/initializers/ruby_units.rb
@@ -1,0 +1,37 @@
+# add some more units
+
+if defined? RubyUnits
+  RubyUnits::Unit.redefine!('liter') do |unit|
+    unit.aliases   += %w{ltr}
+  end
+
+  RubyUnits::Unit.redefine!('kilogram') do |unit|
+    unit.aliases   += %w{KG}
+  end
+
+  RubyUnits::Unit.redefine!('gram') do |unit|
+    unit.aliases   += %w{gr}
+  end
+
+  RubyUnits::Unit.define('piece') do |unit|
+    unit.definition = RubyUnits::Unit.new('1 each')
+    unit.aliases    = %w{pc pcs piece pieces}   # locale: en
+    unit.aliases   += %w{st stuk stuks}         # locale: nl
+    unit.kind       = :counting
+  end
+
+  # we use pc for piece, not parsec
+  RubyUnits::Unit.redefine!('parsec') do |unit|
+    unit.aliases = unit.aliases.reject {|u| u=='pc'}
+    unit.display_name = 'parsec'
+  end
+
+  # workaround for ruby-units' require mathn warning: "zero and implicit precision is deprecated."
+  # default precision of 8 which same as all database definitions in db/migrate/20131213002332_*.rb
+  class Rational
+    alias orig_to_d to_d
+    def to_d(precision=8)
+      orig_to_d(precision)
+    end
+  end
+end


### PR DESCRIPTION
fixes #200

p.s. Note that [ruby-units](https://github.com/olbrich/ruby-units) depends on [mathn](http://www.ruby-doc.org/stdlib-2.1.1/libdoc/mathn/rdoc/), which affects how Ruby handles some math. Tests pass, so I expect no further problems, though.
