### PR TITLE
do not store GroupOrderArticles with zero quantity and tolerance

### DIFF
--- a/app/models/group_order_article.rb
+++ b/app/models/group_order_article.rb
@@ -13,7 +13,7 @@ class GroupOrderArticle < ActiveRecord::Base
   validates_inclusion_of :tolerance, :in => 0..99
   validates_uniqueness_of :order_article_id, :scope => :group_order_id    # just once an article per group order
 
-  scope :ordered, -> { includes(:group_order => :ordergroup).where('group_order_articles.result > 0 OR group_order_articles.quantity > 0 OR group_order_articles.tolerance > 0').order('groups.name') }
+  scope :ordered, -> { includes(:group_order => :ordergroup).order(:groups => :name) }
 
   localize_input_of :result
 
@@ -34,6 +34,13 @@ class GroupOrderArticle < ActiveRecord::Base
   def update_quantities(quantity, tolerance)
     logger.debug("GroupOrderArticle[#{id}].update_quantities(#{quantity}, #{tolerance})")
     logger.debug("Current quantity = #{self.quantity}, tolerance = #{self.tolerance}")
+
+    # When quantity and tolerance are zero, we don't serve any purpose
+    if quantity == 0 and tolerance == 0
+      logger.debug("Self-destructing since requested quantity and tolerance are zero")
+      destroy!
+      return
+    end
 
     # Get quantities ordered with the newest item first.
     quantities = group_order_article_quantities.order('created_on DESC').to_a

--- a/db/migrate/20140318173000_delete_empty_group_order_articles.rb
+++ b/db/migrate/20140318173000_delete_empty_group_order_articles.rb
@@ -1,0 +1,9 @@
+class DeleteEmptyGroupOrderArticles < ActiveRecord::Migration
+  def up
+    # up until recently, group_order_articles with all quantities zero were saved
+    GroupOrderArticle.where(quantity: 0, tolerance: 0, result: [0, nil], result_computed: [0, nil]).delete_all
+  end
+
+  def down
+  end
+end

--- a/spec/integration/receive_spec.rb
+++ b/spec/integration/receive_spec.rb
@@ -22,15 +22,16 @@ describe 'receiving an order', :type => :feature do
 
   # reload all group_order_articles
   def reload_articles
-    [goa1, goa2].map(&:reload)
+    goa1.reload unless goa1.destroyed?
+    goa2.reload unless goa2.destroyed?
     oa.reload
   end
 
   def check_quantities(units, q1, q2)
     reload_articles
     expect(oa.units).to eq units
-    expect(goa1.result).to be_within(1e-3).of q1
-    expect(goa2.result).to be_within(1e-3).of q2
+    expect(goa1.destroyed? ? 0 : goa1.result).to be_within(1e-3).of q1
+    expect(goa2.destroyed? ? 0 : goa2.result).to be_within(1e-3).of q2
   end
 
 

--- a/spec/models/group_order_article_spec.rb
+++ b/spec/models/group_order_article_spec.rb
@@ -9,7 +9,6 @@ describe GroupOrderArticle do
   it 'has zero quantity by default'    do expect(goa.quantity).to eq(0) end
   it 'has zero tolerance by default'   do expect(goa.tolerance).to eq(0) end
   it 'has zero result by default'      do expect(goa.result).to eq(0) end
-  it 'is not ordered by default'       do expect(GroupOrderArticle.ordered.where(:id => goa.id).exists?).to be_false end
   it 'has zero total price by default' do expect(goa.total_price).to eq(0) end
 
   describe do
@@ -39,8 +38,7 @@ describe GroupOrderArticle do
     it 'can unorder a product' do
       goa.update_quantities(rand(1..99), rand(0..99))
       goa.update_quantities(0, 0)
-      expect(goa.quantity).to eq(0)
-      expect(goa.tolerance).to eq(0)
+      expect(GroupOrderArticle.exists?(goa.id)).to be_false
     end
   end
 


### PR DESCRIPTION
In `GroupOrderArticle` there is a scope `ordered` which means both "those articles that have been ordered", as well as "ordered by group name". In other models, `ordered` is used as the latter.

Cleaning this up, I could not find a reason why to keep `GroupOrderArticle`s where all quantities are zero. These records are currently the bulk of the records in this table, and consume quite some computation and disk access time (reference to foodcoops#49).

I've tested this on a copy of a production database with 1117655 `GroupOrderArticles`, which were reduced to a mere  12372 after the migration (the migration took 5 seconds on my development machine).

@bennibu as this affects the ordering algorithm, would you please comment if this is a good thing to do?

p.s. in the show group order page, articles not ordered are still presented (unless hidden by javascript)
