### PR TITLE
add pdf configuration options

### DIFF
--- a/app/documents/order_by_articles.rb
+++ b/app/documents/order_by_articles.rb
@@ -25,8 +25,8 @@ class OrderByArticles < OrderPdf
       rows.unshift I18n.t('documents.order_by_articles.rows') # table header
 
       text "#{order_article.article.name} (#{order_article.article.unit} | #{order_article.price.unit_quantity.to_s} | #{number_with_precision(order_article.price.fc_price, precision: 2)})",
-           style: :bold, size: 10
-      table rows, cell_style: {size: 8, overflow: :shrink_to_fit} do |table|
+           style: :bold, size: fontsize(10)
+      table rows, cell_style: {size: fontsize(8), overflow: :shrink_to_fit} do |table|
         table.column(0).width = 200
         table.columns(1..3).align = :right
         table.column(2).font_style = :bold
@@ -36,7 +36,8 @@ class OrderByArticles < OrderPdf
         # dim rows which were ordered but not received
         dimrows.each { |ri| table.row(ri).text_color = '999999' }
       end
-      move_down 10
+
+      down_or_page
     end
   end
 

--- a/app/documents/order_by_groups.rb
+++ b/app/documents/order_by_groups.rb
@@ -35,8 +35,8 @@ class OrderByGroups < OrderPdf
       rows << [ I18n.t('documents.order_by_groups.sum'), nil, nil, nil, nil, nil, number_with_precision(total, precision: 2)]
       rows.unshift I18n.t('documents.order_by_groups.rows') # Table Header
 
-      text group_order.ordergroup.name, size: 9, style: :bold
-      table rows, width: 500, cell_style: {size: 8, overflow: :shrink_to_fit} do |table|
+      text group_order.ordergroup.name, size: fontsize(9), style: :bold
+      table rows, width: 500, cell_style: {size: fontsize(8), overflow: :shrink_to_fit} do |table|
         # borders
         table.cells.borders = []
         table.row(0).borders = [:bottom]
@@ -54,7 +54,7 @@ class OrderByGroups < OrderPdf
         dimrows.each { |ri| table.row(ri).text_color = '999999' }
       end
 
-      move_down 15
+      down_or_page 15
     end
 
   end

--- a/app/documents/order_fax.rb
+++ b/app/documents/order_fax.rb
@@ -14,22 +14,22 @@ class OrderFax < OrderPdf
 
     # From paragraph
     bounding_box [margin_box.right-200,margin_box.top], width: 200 do
-      text FoodsoftConfig[:name], size: 9, align: :right
+      text FoodsoftConfig[:name], size: fontsize(9), align: :right
       move_down 5
-      text contact[:street], size: 9, align: :right
+      text contact[:street], size: fontsize(9), align: :right
       move_down 5
-      text "#{contact[:zip_code]} #{contact[:city]}", size: 9, align: :right
+      text "#{contact[:zip_code]} #{contact[:city]}", size: fontsize(9), align: :right
       move_down 5
       unless @order.supplier.try(:customer_number).blank?
-        text "#{Supplier.human_attribute_name :customer_number}: #{@order.supplier[:customer_number]}", size: 9, align: :right
+        text "#{Supplier.human_attribute_name :customer_number}: #{@order.supplier[:customer_number]}", size: fontsize(9), align: :right
         move_down 5
       end
       unless contact[:phone].blank?
-        text "#{Supplier.human_attribute_name :phone}: #{contact[:phone]}", size: 9, align: :right
+        text "#{Supplier.human_attribute_name :phone}: #{contact[:phone]}", size: fontsize(9), align: :right
         move_down 5
       end
       unless contact[:email].blank?
-        text "#{Supplier.human_attribute_name :email}: #{contact[:email]}", size: 9, align: :right
+        text "#{Supplier.human_attribute_name :email}: #{contact[:email]}", size: fontsize(9), align: :right
       end
     end
 
@@ -70,7 +70,7 @@ class OrderFax < OrderPdf
        number_to_currency(subtotal)]
     end
     data << [I18n.t('documents.order_fax.total'), nil, nil, nil, nil, nil, number_to_currency(total)]
-    table data, cell_style: {size: 8, overflow: :shrink_to_fit} do |table|
+    table data, cell_style: {size: fontsize(8), overflow: :shrink_to_fit} do |table|
       table.header = true
       table.cells.border_width = 1
       table.cells.border_color = '666666'
@@ -82,7 +82,7 @@ class OrderFax < OrderPdf
       table.row(data.length-1).columns(0).borders = [:top, :bottom, :left]
       table.row(data.length-1).border_top_width = 2
     end
-              #font_size: 8,
+              #font_size: fontsize(8),
               #vertical_padding: 3,
               #border_style: :grid,
               #headers: ["BestellNr.", "Menge","Name", "Gebinde", "Einheit","Preis/Einheit"],

--- a/app/documents/order_matrix.rb
+++ b/app/documents/order_matrix.rb
@@ -17,7 +17,7 @@ class OrderMatrix < OrderPdf
 
     text I18n.t('documents.order_matrix.heading'), style: :bold
     move_down 5
-    text I18n.t('documents.order_matrix.total', :count => order_articles.size), size: 8
+    text I18n.t('documents.order_matrix.total', :count => order_articles.size), size: fontsize(8)
     move_down 10
 
     order_articles_data = [I18n.t('documents.order_matrix.rows')]
@@ -30,7 +30,7 @@ class OrderMatrix < OrderPdf
                               a.units]
     end
 
-    table order_articles_data, cell_style: {size: 8, overflow: :shrink_to_fit} do |table|
+    table order_articles_data, cell_style: {size: fontsize(8), overflow: :shrink_to_fit} do |table|
       table.cells.border_width = 1
       table.cells.border_color = '666666'
     end
@@ -75,7 +75,7 @@ class OrderMatrix < OrderPdf
       # Make table
       column_widths = [85]
       (MAX_ARTICLES_PER_PAGE + 1).times { |i| column_widths << 41 unless i == 0 }
-      table groups_data, column_widths: column_widths, cell_style: {size: 8, overflow: :shrink_to_fit} do |table|
+      table groups_data, column_widths: column_widths, cell_style: {size: fontsize(8), overflow: :shrink_to_fit} do |table|
         table.cells.border_width = 1
         table.cells.border_color = '666666'
         table.row_colors = ['ffffff','ececec']

--- a/config/app_config.yml.SAMPLE
+++ b/config/app_config.yml.SAMPLE
@@ -67,6 +67,14 @@ default: &defaults
   # Members of a user's groups and administrators can still see full names.
   use_nick: false
 
+  # Base font size for generated PDF documents
+  #pdf_font_size: 12
+  # Page size for generated PDF documents
+  #pdf_page_size: A4
+  # Some documents (like group and article PDFs) can include page breaks
+  # after each sublist.
+  #pdf_add_page_breaks: true
+
   # email address to be used as sender
   email_sender: foodsoft@foodcoop.test
 

--- a/lib/order_pdf.rb
+++ b/lib/order_pdf.rb
@@ -4,7 +4,7 @@ class OrderPdf < Prawn::Document
   include ActionView::Helpers::NumberHelper
 
   def initialize(order, options = {})
-    options[:page_size] ||= "A4"
+    options[:page_size] ||= FoodsoftConfig[:pdf_page_size] || "A4"
     #options[:left_margin]   ||= 40
     #options[:right_margin]  ||= 40
     options[:top_margin]    ||= 50
@@ -15,10 +15,12 @@ class OrderPdf < Prawn::Document
   end
 
   def to_pdf
+    font_size fontsize(12)
+
     # Define header
     repeat :all, dynamic: true do
-      draw_text title, size: 10, style: :bold, at: [bounds.left, bounds.top+20] if title # Header
-      draw_text I18n.t('lib.order_pdf.page', :number => page_number), size: 8, at: [bounds.left, bounds.bottom-10] # Footer
+      draw_text title, size: fontsize(10), style: :bold, at: [bounds.left, bounds.top+20] if title # Header
+      draw_text I18n.t('lib.order_pdf.page', :number => page_number), size: fontsize(8), at: [bounds.left, bounds.bottom-10] # Footer
     end
 
     body  # Add content, which is defined in subclasses
@@ -34,5 +36,24 @@ class OrderPdf < Prawn::Document
   # XXX avoid underscore instead of unicode whitespace in pdf :/
   def number_to_currency(number, options={})
     super(number, options).gsub("\u202f", ' ')
+  end
+
+  # return fontsize after scaling it with any configured factor
+  # please use this wherever you're setting a fontsize
+  def fontsize(n)
+    if FoodsoftConfig[:pdf_font_size]
+      n * FoodsoftConfig[:pdf_font_size].to_f/12
+    else
+      n
+    end
+  end
+
+  # add pagebreak or vertical whitespace, depending on configuration
+  def down_or_page(space=10)
+    if FoodsoftConfig[:pdf_add_page_breaks]
+      start_new_page
+    else
+      move_down space
+    end
   end
 end


### PR DESCRIPTION
allow foodcoops to configure
- PDF base font size
- PDF page size (for non-european countries)
- whether to add page breaks in group and article PDFs
