### PR TITLE
Avoid out of range error when using big numbers in financial transactiona

### DIFF
--- a/app/models/financial_transaction.rb
+++ b/app/models/financial_transaction.rb
@@ -3,9 +3,10 @@
 class FinancialTransaction < ActiveRecord::Base
   belongs_to :ordergroup
   belongs_to :user
-  
+
   validates_presence_of :amount, :note, :user_id, :ordergroup_id
-  validates_numericality_of :amount
+  validates_numericality_of :amount, greater_then: -100_000,
+    less_than: 100_000
 
   localize_input_of :amount
 
@@ -14,4 +15,3 @@ class FinancialTransaction < ActiveRecord::Base
     ordergroup.add_financial_transaction! amount, note, user
   end
 end
-


### PR DESCRIPTION
The database schema allows numbers up to (+/-) 999_999.99. But as we are also adding the amount to the Ordergroup#account_balance, we use lower barriers to avoid running in errors when updating the account balance.

So, technically the user has to make 10 times the maximum input to raise an account balance error. This should be sufficient, I hope.
