### PR TITLE
Allow to specify an order schedule for new orders.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,8 @@ gem 'whenever', require: false # For defining cronjobs, see config/schedule.rb
 gem 'protected_attributes'
 gem 'ruby-units'
 gem 'attribute_normalizer'
+gem 'ice_cube', github: 'wvengen/ice_cube', branch: 'issues/50-from_ical-rebased' # fork until merged
+gem 'recurring_select'
 
 # we use the git version of acts_as_versioned, and need to include it in this Gemfile
 gem 'acts_as_versioned', github: 'technoweenie/acts_as_versioned'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,13 @@ GIT
     acts_as_versioned (0.6.0)
       activerecord (>= 3.0.9)
 
+GIT
+  remote: git://github.com/wvengen/ice_cube.git
+  revision: addacaab715c70c5a9b736767ae98032e8efab92
+  branch: issues/50-from_ical-rebased
+  specs:
+    ice_cube (0.12.1)
+
 PATH
   remote: lib/foodsoft_messages
   specs:
@@ -266,6 +273,12 @@ GEM
       activesupport (>= 3.0)
       i18n
       polyamorous (~> 1.1)
+    recurring_select (1.2.1)
+      coffee-rails (>= 3.1)
+      ice_cube (>= 0.11)
+      jquery-rails (>= 3.0)
+      rails (>= 3.2)
+      sass-rails (>= 3.1)
     redis (3.1.0)
     redis-namespace (1.5.1)
       redis (~> 3.0, >= 3.0.4)
@@ -423,6 +436,7 @@ DEPENDENCIES
   haml-rails
   i18n-js (~> 3.0.0.rc6)
   i18n-spec
+  ice_cube!
   inherited_resources
   jquery-rails
   kaminari
@@ -442,6 +456,7 @@ DEPENDENCIES
   rails-i18n
   rails-settings-cached
   ransack
+  recurring_select
   resque
   rspec-core (~> 2.99)
   rspec-rails

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -18,6 +18,7 @@
 //= require stupidtable
 //= require touchclick
 //= require delta_input
+//= require recurring_select
 
 // Load following statements, when DOM is ready
 $(function() {

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -4,4 +4,5 @@
 *= require token-input-bootstrappy
 *= require bootstrap-datepicker
 *= require list.unlist
+*= require recurring_select
 */

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -62,7 +62,7 @@ class OrdersController < ApplicationController
 
   # Page to create a new order.
   def new
-    @order = Order.new starts: Time.now, ends: 4.days.from_now, supplier_id: params[:supplier_id]
+    @order = Order.new(supplier_id: params[:supplier_id]).init_dates
   end
 
   # Save a new order.

--- a/app/views/admin/configs/_tab_payment.html.haml
+++ b/app/views/admin/configs/_tab_payment.html.haml
@@ -10,3 +10,9 @@
   .input-prepend
     %span.add-on= t 'number.currency.format.unit'
     = config_input_field form, :minimum_balance, as: :decimal, class: 'input-small'
+
+= form.simple_fields_for :order_schedule do |fields|
+  = fields.simple_fields_for 'ends' do |fields|
+    .fold-line
+      = config_input fields, 'recurr', as: :select_recurring, input_html: {class: 'input-xlarge'}
+      = config_input fields, 'time', input_html: {class: 'input-mini'}

--- a/config/app_config.yml.SAMPLE
+++ b/config/app_config.yml.SAMPLE
@@ -64,6 +64,15 @@ default: &defaults
   # not fully enforced right now, since the check is only client-side
   # minimum_balance: 0
 
+  # default order schedule, used to provide initial dates for new orders
+  # (recurring dates in ical format; no spaces!)
+  #order_schedule:
+  #  ends:
+  #    recurr: FREQ=WEEKLY;INTERVAL=2;BYDAY=MO
+  #    time: '9:00'
+  #  # reference point, this is generally the first pickup day; empty is often ok
+  #  #initial:
+
   # When use_nick is enabled, there will be a nickname field in the user form,
   # and the option to show a nickname instead of full name to foodcoop members.
   # Members of a user's groups and administrators can still see full names.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -458,6 +458,11 @@ en:
       mailing_list_subscribe: Email address where members can send an email to for subscribing.
       minimum_balance: Members can only order when their account balance is above or equal to this amount.
       name: The name of your foodcoop.
+      order_schedule:
+        initial: Schedule starts at this date.
+        ends:
+          recurr: Schedule for default order closing date.
+          time: Default time when orders are closed.
       page_footer: Shown on each page at the bottom. Enter "blank" to disable the footer completely.
       pdf_add_page_breaks:
         order_by_articles: Put each article on a separate page.
@@ -496,6 +501,11 @@ en:
       mailing_list_subscribe: Mailing-list subscribe
       minimum_balance: Minimum account balance
       name: Name
+      order_schedule:
+        initial: Schedule start
+        ends:
+          recurr: Order ends
+          time: time
       page_footer: Page footer
       pdf_add_page_breaks: Page breaks
       pdf_font_size: Font size

--- a/lib/date_time_attribute_validate.rb
+++ b/lib/date_time_attribute_validate.rb
@@ -42,7 +42,7 @@ module DateTimeAttributeValidate
           self.instance_variable_get("@#{attribute}_date_value") || self.send("#{attribute}_date").try {|e| e.strftime('%Y-%m-%d')}
         end
         define_method("#{attribute}_time_value") do
-          self.instance_variable_get("@#{attribute}_time_value") || self.send("#{attribute}_time").try {|e| e.strftime('%H:%m')}
+          self.instance_variable_get("@#{attribute}_time_value") || self.send("#{attribute}_time").try {|e| e.strftime('%H:%M')}
         end
 
         private

--- a/lib/foodsoft_date_util.rb
+++ b/lib/foodsoft_date_util.rb
@@ -1,0 +1,30 @@
+module FoodsoftDateUtil
+  # find next occurence given a recurring ical string and time
+  def self.next_occurrence(start=Time.now, from=start, options={})
+    if options[:recurr]
+      schedule = IceCube::Schedule.new(start)
+      schedule.add_recurrence_rule rule_from(options[:recurr])
+      # @todo handle ical parse errors
+      occ = (schedule.next_occurrence(from).to_time rescue nil)
+    else
+      occ = start
+    end
+    if occ and options[:time]
+      occ = occ.beginning_of_day.advance(seconds: Time.parse(options[:time]).seconds_since_midnight)
+    end
+    occ
+  end
+
+  # @param p [String, Symbol, Hash, IceCube::Rule] What to return a rule from.
+  # @return [IceCube::Rule] Recurring rule
+  def self.rule_from(p)
+    if p.is_a? String
+      IceCube::Rule.from_ical(p)
+    elsif p.is_a? Hash
+      IceCube::Rule.from_hash(p)
+    else
+      p
+    end
+  end
+
+end

--- a/spec/integration/config_spec.rb
+++ b/spec/integration/config_spec.rb
@@ -48,9 +48,18 @@ describe 'admin/configs', type: :feature do
 
     def get_full_config
       cfg = FoodsoftConfig.to_hash.deep_dup
-      cfg.each {|k,v| v.reject! {|k,v| v.blank?} if v.is_a? Hash}
-      cfg.reject! {|k,v| v.blank?}
-      cfg
+      compact_hash_deep!(cfg)
+    end
+
+    def compact_hash_deep!(h)
+      h.each do |k,v|
+        if v.is_a? Hash
+          compact_hash_deep!(v)
+          v.reject! {|k,v| v.blank?}
+        end
+      end
+      h.reject! {|k,v| v.blank?}
+      h
     end
 
   end

--- a/spec/integration/order_spec.rb
+++ b/spec/integration/order_spec.rb
@@ -1,0 +1,61 @@
+require_relative '../spec_helper'
+
+describe Order, type: :feature do
+  let(:admin) { create :user, groups:[create(:workgroup, role_orders: true)] }
+  let(:article) { create :article, unit_quantity: 1 }
+  let(:order) { create :order, supplier: article.supplier, article_ids: [article.id] } # need to ref article
+  let(:go1) { create :group_order, order: order }
+  let(:oa) { order.order_articles.find_by_article_id(article.id) }
+  let(:goa1) { create :group_order_article, group_order: go1, order_article: oa }
+
+  describe type: :feature, js: true do
+    before { login admin }
+
+    it 'can get to the new order page' do
+      article.supplier
+      visit orders_path
+      click_link_or_button I18n.t('orders.index.new_order')
+      click_link_or_button order.name
+      expect(page).to have_text I18n.t('orders.new.title')
+      expect(page).to have_text article.name
+    end
+
+    it 'fills in the end date with a schedule' do
+      FoodsoftConfig[:time_zone] = 'UTC'
+      FoodsoftConfig[:order_schedule] = {ends: {recurr: 'FREQ=MONTHLY;BYMONTHDAY=1', time: '12:00'}}
+      visit new_order_path(supplier_id: article.supplier.id)
+      expect(page).to have_text I18n.t('orders.new.title')
+      expect(find_field('order_ends_time_value').value).to eq '12:00'
+      expect(find_field('order_ends_date_value').value).to eq Date.today.next_month.at_beginning_of_month.strftime('%Y-%m-%d')
+    end
+
+    it 'can create a new order' do
+      visit new_order_path(supplier_id: article.supplier.id)
+      expect(page).to have_text I18n.t('orders.new.title')
+      find('input[type="submit"]').click
+      expect(Order.count).to eq 1
+      expect(Order.first.supplier).to eq article.supplier
+    end
+
+    it 'can close an order' do
+      setup_and_close_order
+      expect(order).to be_finished
+      expect(page).to_not have_link I18n.t('orders.index.action_end')
+      expect(oa.units_to_order).to eq 1
+    end
+  end
+
+  def setup_and_close_order
+    # have at least something ordered
+    goa1.update_quantities 1, 0
+    oa.update_results!
+    # and close the order
+    visit orders_path
+    click_link_or_button I18n.t('orders.index.action_end')
+    accept_alert
+    sleep 0.8
+    order.reload
+    oa.reload
+  end
+
+end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -44,4 +44,21 @@ describe Order do
 
   end
 
+  describe 'with a default end date' do
+    let(:order) { create :order }
+    before do
+      FoodsoftConfig[:order_schedule] = {ends: {recurr: 'FREQ=WEEKLY;BYDAY=MO', time: '9:00'}}
+      order.init_dates
+    end
+
+    it 'to have a correct date' do
+      expect(order.ends.to_date).to eq Date.today.next_week.at_beginning_of_week(:monday)
+    end
+
+    it 'to have a correct time' do
+      expect(order.ends.strftime('%H:%M')).to eq '09:00'
+    end
+
+  end
+
 end


### PR DESCRIPTION
Especially when working with several suppliers, it can be a little cumbersome to open all orders. This change allows a foodcoop to specify a schedule for the order end date, so that it is filled in automatically when creating a new order (it can still be changed for the order when needed).

The configuration option ended up in the 'finance' tab. I considered to rename it to 'orders', but as it contains VAT it doesn't fully make sense either. I'm a bit careful to add more and more tabs. For now, I'd be ok with this, until some growth of options brings out a more sensible division between tabs.

Also adds integration tests for opening orders. Yay!
