### PR TITLE
Show only suppliers with articles in the dropdown-menu for new orders

### DIFF
--- a/app/views/orders/index.html.haml
+++ b/app/views/orders/index.html.haml
@@ -6,7 +6,7 @@
       = t '.new_order'
       %span.caret
     %ul.dropdown-menu
-      - Supplier.undeleted.order('suppliers.name ASC').each do |supplier|
+      - Supplier.where(id: Article.undeleted.select(:supplier_id).distinct).order('suppliers.name ASC').each do |supplier|
         %li= link_to supplier.name, new_order_path(supplier_id: supplier.id), tabindex: -1
 
 .well


### PR DESCRIPTION
When there are many suppliers to be able to select them for invoices,
the menu for creating new orders gets unclear.