### PR TITLE
Add possibility to copy an order

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -63,6 +63,7 @@ class OrdersController < ApplicationController
   # Page to create a new order.
   def new
     @order = Order.new(supplier_id: params[:supplier_id]).init_dates
+    @order.article_ids = Order.find(params[:order_id]).article_ids if params[:order_id]
   end
 
   # Save a new order.

--- a/app/views/orders/index.html.haml
+++ b/app/views/orders/index.html.haml
@@ -58,7 +58,7 @@
                   = link_to t('.action_receive'), receive_order_path(order), class: 'btn btn-small btn-success'
 
               %td
-                = link_to t('ui.edit'), '#', class: 'btn btn-small disabled', tabindex: -1
+                = link_to t('ui.copy'), new_order_path(order_id: order, supplier_id: order.supplier), class: 'btn btn-small'
                 = link_to t('ui.show'), order, class: 'btn btn-small'
                 = link_to t('ui.delete'), order, data: {confirm: t('.confirm_delete')}, method: :delete,
                   class: 'btn btn-small btn-danger'

--- a/app/views/orders/new.html.haml
+++ b/app/views/orders/new.html.haml
@@ -1,10 +1,10 @@
 - title t('.title')
 
 = render 'form'
-
-- content_for :javascript do
-  :javascript
-    // select all articles by default
-    $(function() {
-      $('#checkall').click();
-    });
+- if @order.article_ids.empty?
+  - content_for :javascript do
+    :javascript
+      // select all articles by default
+      $(function() {
+        $('#checkall').click();
+      });

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1649,6 +1649,7 @@ de:
     actions: Aktionen
     cancel: Abbrechen
     close: Schließen
+    copy: Kopieren
     delete: Löschen
     edit: Bearbeiten
     marks:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1658,6 +1658,7 @@ en:
     actions: Actions
     cancel: Cancel
     close: Close
+    copy: Copy
     delete: Delete
     edit: Edit
     marks:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1668,6 +1668,7 @@ fr:
     actions: Actions
     cancel: Annuler
     close: Fermer
+    copy: Copier
     delete: Supprimer
     edit: Modifier
     marks:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -1653,6 +1653,7 @@ nl:
     actions: Acties
     cancel: Annuleren
     close: Sluiten
+    copy: Kopiëren
     delete: Verwijder
     edit: Bewerk
     marks:


### PR DESCRIPTION
If a supplier has a long list of articles, which are all available, but
the order should contain only a subset of them, selecting them for every
order can take a long time. Starting with a copy of an existing order
can safe a lot of time.