### PR TITLE
Add color marking to items in group orders that have missing items

### DIFF
--- a/app/assets/javascripts/ordering.js
+++ b/app/assets/javascripts/ordering.js
@@ -118,11 +118,25 @@ function update(item, quantity, tolerance) {
     $('#price_' + item + '_display').html(I18n.l("currency", itemTotal[item]));
 
     // update missing units
-    var missing_units = unit[item] - (((quantityOthers[item] + Number(quantity)) % unit[item]) + Number(tolerance) + toleranceOthers[item])
-    if (missing_units < 0 || missing_units == unit[item]) {
+    var missing_units = unit[item] - (((quantityOthers[item] + Number(quantity)) % unit[item]) + Number(tolerance) + toleranceOthers[item]),
+        missing_units_css = '';
+    if (missing_units < 0) {
         missing_units = 0;
+        missing_units_css = '';
+    } else if (missing_units == unit[item]) {
+        missing_units = 0;
+        missing_units_css = 'missing-none';
+    } else if (missing_units == 1) {
+        missing_units_css = 'missing-few';
+    } else {
+        missing_units_css = 'missing-many';
     }
-    $('#missing_units_' + item).html(String(missing_units));
+    $('#missing_units_' + item)
+        .html(String(missing_units))
+        .closest('tr')
+        .removeClass('missing-many missing-few missing-none')
+        .addClass(missing_units_css);
+
 
     // update balance
     updateBalance();

--- a/app/assets/javascripts/ordering.js
+++ b/app/assets/javascripts/ordering.js
@@ -118,14 +118,16 @@ function update(item, quantity, tolerance) {
     $('#price_' + item + '_display').html(I18n.l("currency", itemTotal[item]));
 
     // update missing units
-    var missing_units = unit[item] - (((quantityOthers[item] + Number(quantity)) % unit[item]) + Number(tolerance) + toleranceOthers[item]),
+    var missing_units = calcMissingItems(unit[item], quantityOthers[item] + Number(quantity), toleranceOthers[item] + Number(tolerance)),
         missing_units_css = '';
-    if (missing_units < 0) {
+
+    if (missing_units <= 0 || missing_units == unit[item]) {
         missing_units = 0;
-        missing_units_css = '';
-    } else if (missing_units == unit[item]) {
-        missing_units = 0;
-        missing_units_css = 'missing-none';
+        if (units > 0) {
+            missing_units_css = 'missing-none';
+        } else {
+            missing_units_css = '';
+        }
     } else if (missing_units == 1) {
         missing_units_css = 'missing-few';
     } else {
@@ -146,6 +148,11 @@ function calcUnits(unitSize, quantity, tolerance) {
     var units = Math.floor(quantity / unitSize)
     var remainder = quantity % unitSize
     return units + ((remainder > 0) && (remainder + tolerance >= unitSize) ? 1 : 0)
+}
+
+function calcMissingItems(unitSize, quantity, tolerance) {
+    var remainder = quantity % unitSize
+    return remainder > 0 && remainder + tolerance < unitSize ? unitSize - remainder - tolerance : 0
 }
 
 function unitCompletedFromTolerance(unitSize, quantity, tolerance) {

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -4,5 +4,6 @@
 *= require token-input-bootstrappy
 *= require bootstrap-datepicker
 *= require list.unlist
+*= require list.missing
 *= require recurring_select
 */

--- a/app/assets/stylesheets/list.missing.css
+++ b/app/assets/stylesheets/list.missing.css
@@ -7,5 +7,5 @@
 }
 
 .list .missing-none td, .list .missing-none:hover td {
-	background-color: #cff5be;
+	background-color: #E4EED6;
 }

--- a/app/assets/stylesheets/list.missing.css
+++ b/app/assets/stylesheets/list.missing.css
@@ -1,0 +1,11 @@
+.list .missing-many td, .list .missing-many:hover td {
+	background-color: #ebbebe;
+}
+
+.list .missing-few td, .list .missing-few:hover td {
+	background-color: #ffee75;
+}
+
+.list .missing-none td, .list .missing-none:hover td {
+	background-color: #cff5be;
+}

--- a/app/helpers/group_orders_helper.rb
+++ b/app/helpers/group_orders_helper.rb
@@ -43,4 +43,14 @@ module GroupOrdersHelper
 
     {group_order_article: goa, quantity: quantity, tolerance: tolerance, result: result, sub_total: sub_total}
   end
+
+  def get_missing_units_css_class(quantity_missing)
+    if ( quantity_missing == 1 )
+      return 'missing-few';
+    elsif ( quantity_missing == 0 )
+      return ''
+    else
+      return 'missing-many'
+    end
+  end
 end

--- a/app/views/group_orders/_form.html.haml
+++ b/app/views/group_orders/_form.html.haml
@@ -88,7 +88,7 @@
             %i.icon-tag
           %td{colspan: "9"}
         - order_articles.each do |order_article|
-          %tr{class: "#{cycle('even', 'odd', name: 'articles')} order-article", valign: "top"}
+          %tr{class: "#{cycle('even', 'odd', name: 'articles')} order-article #{get_missing_units_css_class(@ordering_data[:order_articles][order_article.id][:missing_units])}", valign: "top"}
             %td.name= order_article.article.name
             - if @order.stockit?
               %td= truncate order_article.article.supplier.name, length: 15


### PR DESCRIPTION
In our foodcoop the request occurred to make it more obvious when items just need a few more items, this patch does this by adding background-colors to the `tr`s.

I am a RoR newbie, so feel free to improve this patch or ask for improvements before merging.

more than 1 item missing:
![missing-many](https://cloud.githubusercontent.com/assets/203408/7446183/d04a3ad4-f1d0-11e4-9457-7bfb213bf818.png)

1 item missing:
![missing-few](https://cloud.githubusercontent.com/assets/203408/7446186/d434466c-f1d0-11e4-9e9a-960a0c0e4720.png)

no items missing (just used through JavaScript when the count reaches 0)
![missing-none](https://cloud.githubusercontent.com/assets/203408/7446187/d7e9708e-f1d0-11e4-8e06-ddbb5497ee10.png)
