### PR TITLE
Fixed binding of rails server in Dockerfile and compose config.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,4 +37,4 @@ COPY . $WORKDIR
 
 EXPOSE 3000
 
-CMD ["rails", "server"]
+CMD ["rails", "server", "--binding", "0.0.0.0"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,5 @@
 app: &app
   build: .
-  command: bundle exec rails s
   volumes:
     - .:/usr/src/app
   ports:


### PR DESCRIPTION
As with rails 4.2 the internal server now binds to localhost as default. So we have to overwrite this behaviour to access the app within the docker container.

By the way, thanks for the new release. I updated the foodcoops.net hosting.