### PR TITLE
Add forum plugin (WiP)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,11 +46,14 @@ gem 'recurring_select'
 gem 'roo', '~> 2.0.0'
 gem 'roo-xls'
 gem 'spreadsheet'
+gem 'forem', :github => "radar/forem", :branch => "rails4"
+gem 'forem-bootstrap', :github => "radar/forem-bootstrap"
 
 # we use the git version of acts_as_versioned, and need to include it in this Gemfile
 gem 'acts_as_versioned', github: 'technoweenie/acts_as_versioned'
 gem 'foodsoft_wiki', path: 'plugins/wiki'
 gem 'foodsoft_messages', path: 'plugins/messages'
+gem 'foodsoft_forum', path: 'plugins/forum'
 
 # plugins not enabled by default
 #gem 'foodsoft_uservoice', path: 'plugins/uservoice'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -85,6 +85,103 @@ ActiveRecord::Schema.define(version: 20150301000000) do
 
   add_index "financial_transactions", ["ordergroup_id"], name: "index_financial_transactions_on_ordergroup_id", using: :btree
 
+  create_table "forem_categories", force: :cascade do |t|
+    t.string   "name",                   null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string   "slug"
+    t.integer  "position",   default: 0
+  end
+
+  add_index "forem_categories", ["slug"], name: "index_forem_categories_on_slug", unique: true
+
+  create_table "forem_forums", force: :cascade do |t|
+    t.string  "name"
+    t.text    "description"
+    t.integer "category_id"
+    t.integer "views_count", default: 0
+    t.string  "slug"
+    t.integer "position",    default: 0
+  end
+
+  add_index "forem_forums", ["slug"], name: "index_forem_forums_on_slug", unique: true
+
+  create_table "forem_groups", force: :cascade do |t|
+    t.string "name"
+  end
+
+  add_index "forem_groups", ["name"], name: "index_forem_groups_on_name"
+
+  create_table "forem_memberships", force: :cascade do |t|
+    t.integer "group_id"
+    t.integer "member_id"
+  end
+
+  add_index "forem_memberships", ["group_id"], name: "index_forem_memberships_on_group_id"
+
+  create_table "forem_moderator_groups", force: :cascade do |t|
+    t.integer "forum_id"
+    t.integer "group_id"
+  end
+
+  add_index "forem_moderator_groups", ["forum_id"], name: "index_forem_moderator_groups_on_forum_id"
+
+  create_table "forem_posts", force: :cascade do |t|
+    t.integer  "topic_id"
+    t.text     "text"
+    t.integer  "user_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.integer  "reply_to_id"
+    t.string   "state",       default: "pending_review"
+    t.boolean  "notified",    default: false
+  end
+
+  add_index "forem_posts", ["reply_to_id"], name: "index_forem_posts_on_reply_to_id"
+  add_index "forem_posts", ["state"], name: "index_forem_posts_on_state"
+  add_index "forem_posts", ["topic_id"], name: "index_forem_posts_on_topic_id"
+  add_index "forem_posts", ["user_id"], name: "index_forem_posts_on_user_id"
+
+  create_table "forem_subscriptions", force: :cascade do |t|
+    t.integer "subscriber_id"
+    t.integer "topic_id"
+  end
+
+  create_table "forem_topics", force: :cascade do |t|
+    t.integer  "forum_id"
+    t.integer  "user_id"
+    t.string   "subject"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.boolean  "locked",       default: false,            null: false
+    t.boolean  "pinned",       default: false
+    t.boolean  "hidden",       default: false
+    t.datetime "last_post_at"
+    t.string   "state",        default: "pending_review"
+    t.integer  "views_count",  default: 0
+    t.string   "slug"
+  end
+
+  add_index "forem_topics", ["forum_id"], name: "index_forem_topics_on_forum_id"
+  add_index "forem_topics", ["slug"], name: "index_forem_topics_on_slug", unique: true
+  add_index "forem_topics", ["state"], name: "index_forem_topics_on_state"
+  add_index "forem_topics", ["user_id"], name: "index_forem_topics_on_user_id"
+
+  create_table "forem_views", force: :cascade do |t|
+    t.integer  "user_id"
+    t.integer  "viewable_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.integer  "count",             default: 0
+    t.string   "viewable_type"
+    t.datetime "current_viewed_at"
+    t.datetime "past_viewed_at"
+  end
+
+  add_index "forem_views", ["updated_at"], name: "index_forem_views_on_updated_at"
+  add_index "forem_views", ["user_id"], name: "index_forem_views_on_user_id"
+  add_index "forem_views", ["viewable_id"], name: "index_forem_views_on_viewable_id"
+
   create_table "group_order_article_quantities", force: :cascade do |t|
     t.integer  "group_order_article_id", limit: 4, default: 0, null: false
     t.integer  "quantity",               limit: 4, default: 0
@@ -342,6 +439,9 @@ ActiveRecord::Schema.define(version: 20150301000000) do
     t.datetime "reset_password_expires"
     t.datetime "last_login"
     t.datetime "last_activity"
+    t.boolean  "forem_admin",                        default: false
+    t.string   "forem_state",                        default: "pending_review"
+    t.boolean  "forem_auto_subscribe",               default: false
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/plugins/forum/README.md
+++ b/plugins/forum/README.md
@@ -1,0 +1,18 @@
+FoodsoftForum
+=================
+
+This plugin adds a forum to foodsoft. A new 'Forum' menu entry is added below the 'Foodcoops' menu in the navigation bar.
+
+This plugin is enabled by default in foodsoft, so you don't need to do anything
+to install it. If you still want to, for example when it has been disabled,
+add the following to foodsoft's Gemfile:
+
+```Gemfile
+gem 'foodsoft_forum', path: 'lib/foodsoft_forum'
+```
+
+This plugin introduces the foodcoop config option `use_forum`, which can be
+set to `false` to disable the forum. May be useful in multicoop deployments.
+
+This plugin is part of the foodsoft package and uses the GPL-3 license (see
+foodsoft's LICENSE for the full license text).

--- a/plugins/forum/Rakefile
+++ b/plugins/forum/Rakefile
@@ -1,0 +1,40 @@
+#!/usr/bin/env rake
+begin
+  require 'bundler/setup'
+rescue LoadError
+  puts 'You must `gem install bundler` and `bundle install` to run rake tasks'
+end
+begin
+  require 'rdoc/task'
+rescue LoadError
+  require 'rdoc/rdoc'
+  require 'rake/rdoctask'
+  RDoc::Task = Rake::RDocTask
+end
+
+RDoc::Task.new(:rdoc) do |rdoc|
+  rdoc.rdoc_dir = 'rdoc'
+  rdoc.title    = 'FoodsoftDocuments'
+  rdoc.options << '--line-numbers'
+  rdoc.rdoc_files.include('README.rdoc')
+  rdoc.rdoc_files.include('lib/**/*.rb')
+end
+
+APP_RAKEFILE = File.expand_path("../test/dummy/Rakefile", __FILE__)
+load 'rails/tasks/engine.rake'
+
+
+
+Bundler::GemHelper.install_tasks
+
+require 'rake/testtask'
+
+Rake::TestTask.new(:test) do |t|
+  t.libs << 'lib'
+  t.libs << 'test'
+  t.pattern = 'test/**/*_test.rb'
+  t.verbose = false
+end
+
+
+task :default => :test

--- a/plugins/forum/app/views/layouts/forem.html.haml
+++ b/plugins/forum/app/views/layouts/forem.html.haml
@@ -1,0 +1,15 @@
+= render layout: 'layouts/header' do
+  .logo
+    = t('layouts.logo').html_safe
+  %ul.nav.nav-pills.pull-right
+    %li= link_to 'Foodsoft', '/f/', title: 'Foodsoft'
+  .clearfix
+
+  = stylesheet_link_tag "forem"
+  = stylesheet_link_tag "forem-bootstrap"
+  = javascript_include_tag "forem"
+
+  = yield
+
+  = render 'layouts/footer'
+  #modalContainer.modal.hide.fade(tabindex="-1" role="dialog")

--- a/plugins/forum/config/initializers/forem.rb
+++ b/plugins/forum/config/initializers/forem.rb
@@ -1,0 +1,8 @@
+Forem.user_class = "User"
+Forem.email_from_address = "foodsoft@foodcoop1040.at"
+Forem.per_page = 20
+Forem.moderate_first_post = false
+
+Rails.application.config.to_prepare do
+  Forem::ApplicationController.layout "forem"
+end

--- a/plugins/forum/config/locales/en.yml
+++ b/plugins/forum/config/locales/en.yml
@@ -1,0 +1,3 @@
+en:
+  navigation:
+    forum: Forum

--- a/plugins/forum/config/routes.rb
+++ b/plugins/forum/config/routes.rb
@@ -1,0 +1,15 @@
+Rails.application.routes.draw do
+
+  scope '/:foodcoop' do
+
+    # This line mounts Forem's routes at /forums by default.
+    # This means, any requests to the /forums URL of your application will go to Forem::ForumsController#index.
+    # If you would like to change where this extension is mounted, simply change the :at option to something different.
+    #
+    # We ask that you don't use the :as option here, as Forem relies on it being the default of "forem"
+
+    mount Forem::Engine, :at => '/forums'
+
+  end
+
+end

--- a/plugins/forum/db/migrate/20150427084420_create_forem_forums.forem.rb
+++ b/plugins/forum/db/migrate/20150427084420_create_forem_forums.forem.rb
@@ -1,0 +1,14 @@
+# This migration comes from forem (originally 20110214221555)
+class CreateForemForums < ActiveRecord::Migration
+  def up
+    create_table :forem_forums do |t|
+      t.string :title
+      t.text :description
+    end
+
+  end
+
+  def down
+    drop_table :forem_forums
+  end
+end

--- a/plugins/forum/db/migrate/20150427084421_create_forem_topics.forem.rb
+++ b/plugins/forum/db/migrate/20150427084421_create_forem_topics.forem.rb
@@ -1,0 +1,12 @@
+# This migration comes from forem (originally 20110221092741)
+class CreateForemTopics < ActiveRecord::Migration
+  def change
+    create_table :forem_topics do |t|
+      t.integer :forum_id
+      t.integer :user_id
+      t.string :subject
+
+      t.timestamps
+    end
+  end
+end

--- a/plugins/forum/db/migrate/20150427084422_create_forem_posts.forem.rb
+++ b/plugins/forum/db/migrate/20150427084422_create_forem_posts.forem.rb
@@ -1,0 +1,12 @@
+# This migration comes from forem (originally 20110221094502)
+class CreateForemPosts < ActiveRecord::Migration
+  def change
+    create_table :forem_posts do |t|
+      t.integer :topic_id
+      t.text :text
+      t.integer :user_id
+
+      t.timestamps
+    end
+  end
+end

--- a/plugins/forum/db/migrate/20150427084423_add_reply_to_to_forem_posts.forem.rb
+++ b/plugins/forum/db/migrate/20150427084423_add_reply_to_to_forem_posts.forem.rb
@@ -1,0 +1,6 @@
+# This migration comes from forem (originally 20110228084940)
+class AddReplyToToForemPosts < ActiveRecord::Migration
+  def change
+    add_column :forem_posts, :reply_to_id, :integer
+  end
+end

--- a/plugins/forum/db/migrate/20150427084424_add_locked_to_forem_topics.forem.rb
+++ b/plugins/forum/db/migrate/20150427084424_add_locked_to_forem_topics.forem.rb
@@ -1,0 +1,6 @@
+# This migration comes from forem (originally 20110519210300)
+class AddLockedToForemTopics < ActiveRecord::Migration
+  def change
+    add_column :forem_topics, :locked, :boolean, :null => false, :default => false
+  end
+end

--- a/plugins/forum/db/migrate/20150427084425_add_pinned_to_forem_topics.forem.rb
+++ b/plugins/forum/db/migrate/20150427084425_add_pinned_to_forem_topics.forem.rb
@@ -1,0 +1,6 @@
+# This migration comes from forem (originally 20110519222000)
+class AddPinnedToForemTopics < ActiveRecord::Migration
+  def change
+    add_column :forem_topics, :pinned, :boolean, :default => false, :nullable => false
+  end
+end

--- a/plugins/forum/db/migrate/20150427084426_add_forem_views.forem.rb
+++ b/plugins/forum/db/migrate/20150427084426_add_forem_views.forem.rb
@@ -1,0 +1,10 @@
+# This migration comes from forem (originally 20110520150056)
+class AddForemViews < ActiveRecord::Migration
+  def change
+    create_table :forem_views do |t|
+      t.integer :user_id
+      t.integer :topic_id
+      t.datetime :created_at
+    end
+  end
+end

--- a/plugins/forum/db/migrate/20150427084427_add_updated_at_and_count_to_forem_views.forem.rb
+++ b/plugins/forum/db/migrate/20150427084427_add_updated_at_and_count_to_forem_views.forem.rb
@@ -1,0 +1,7 @@
+# This migration comes from forem (originally 20110626150056)
+class AddUpdatedAtAndCountToForemViews < ActiveRecord::Migration
+  def change
+    add_column :forem_views, :updated_at, :datetime
+    add_column :forem_views, :count, :integer, :default => 0
+  end
+end

--- a/plugins/forum/db/migrate/20150427084428_add_hidden_to_forem_topics.forem.rb
+++ b/plugins/forum/db/migrate/20150427084428_add_hidden_to_forem_topics.forem.rb
@@ -1,0 +1,6 @@
+# This migration comes from forem (originally 20110626160056)
+class AddHiddenToForemTopics < ActiveRecord::Migration
+  def change
+    add_column :forem_topics, :hidden, :boolean, :default => false
+  end
+end

--- a/plugins/forum/db/migrate/20150427084429_add_indexes_to_topics_posts_views.forem.rb
+++ b/plugins/forum/db/migrate/20150427084429_add_indexes_to_topics_posts_views.forem.rb
@@ -1,0 +1,13 @@
+# This migration comes from forem (originally 20111026143136)
+class AddIndexesToTopicsPostsViews < ActiveRecord::Migration
+  def change
+    add_index :forem_topics, :forum_id
+    add_index :forem_topics, :user_id    
+    add_index :forem_posts, :topic_id
+    add_index :forem_posts, :user_id    
+    add_index :forem_posts, :reply_to_id    
+    add_index :forem_views, :user_id
+    add_index :forem_views, :topic_id    
+    add_index :forem_views, :updated_at 
+  end
+end

--- a/plugins/forum/db/migrate/20150427084430_create_forem_categories.forem.rb
+++ b/plugins/forum/db/migrate/20150427084430_create_forem_categories.forem.rb
@@ -1,0 +1,9 @@
+# This migration comes from forem (originally 20111103210835)
+class CreateForemCategories < ActiveRecord::Migration
+  def change
+    create_table :forem_categories do |t|
+      t.string :name, :null => false
+      t.timestamps
+    end
+  end
+end

--- a/plugins/forum/db/migrate/20150427084431_add_category_id_to_forums.forem.rb
+++ b/plugins/forum/db/migrate/20150427084431_add_category_id_to_forums.forem.rb
@@ -1,0 +1,10 @@
+# This migration comes from forem (originally 20111103214432)
+class AddCategoryIdToForums < ActiveRecord::Migration
+  def change
+    add_column :forem_forums, :category_id, :integer
+
+    if Forem::Forum.count > 0
+      Forem::Forum.update_all :category_id => Forem::Category.first.id
+    end
+  end
+end

--- a/plugins/forum/db/migrate/20150427084432_create_forem_subscriptions.forem.rb
+++ b/plugins/forum/db/migrate/20150427084432_create_forem_subscriptions.forem.rb
@@ -1,0 +1,9 @@
+# This migration comes from forem (originally 20111208014437)
+class CreateForemSubscriptions < ActiveRecord::Migration
+  def change
+    create_table :forem_subscriptions do |t|
+      t.integer :subscriber_id
+      t.integer :topic_id
+    end
+  end
+end

--- a/plugins/forum/db/migrate/20150427084433_add_pending_review_to_forem_posts.forem.rb
+++ b/plugins/forum/db/migrate/20150427084433_add_pending_review_to_forem_posts.forem.rb
@@ -1,0 +1,9 @@
+# This migration comes from forem (originally 20120221195806)
+class AddPendingReviewToForemPosts < ActiveRecord::Migration
+  def change
+    add_column :forem_posts, :pending_review, :boolean, :default => true
+
+    Forem::Post.reset_column_information
+    Forem::Post.update_all :pending_review => false
+  end
+end

--- a/plugins/forum/db/migrate/20150427084434_add_pending_review_to_forem_topics.forem.rb
+++ b/plugins/forum/db/migrate/20150427084434_add_pending_review_to_forem_topics.forem.rb
@@ -1,0 +1,9 @@
+# This migration comes from forem (originally 20120221195807)
+class AddPendingReviewToForemTopics < ActiveRecord::Migration
+  def change
+    add_column :forem_topics, :pending_review, :boolean, :default => true
+
+    Forem::Topic.reset_column_information
+    Forem::Topic.update_all :pending_review => false
+  end
+end

--- a/plugins/forum/db/migrate/20150427084435_add_forem_topics_last_post_at.forem.rb
+++ b/plugins/forum/db/migrate/20150427084435_add_forem_topics_last_post_at.forem.rb
@@ -1,0 +1,15 @@
+# This migration comes from forem (originally 20120222000227)
+class AddForemTopicsLastPostAt < ActiveRecord::Migration
+  def up
+    add_column :forem_topics, :last_post_at, :datetime
+    Forem::Topic.reset_column_information
+    Forem::Topic.includes(:posts).find_each do |t|
+      post = t.posts.last
+      t.update_attribute(:last_post_at, post.updated_at)
+    end
+  end
+
+  def down
+    remove_column :forem_topics, :last_post_at
+  end
+end

--- a/plugins/forum/db/migrate/20150427084436_create_forem_groups.forem.rb
+++ b/plugins/forum/db/migrate/20150427084436_create_forem_groups.forem.rb
@@ -1,0 +1,10 @@
+# This migration comes from forem (originally 20120222155549)
+class CreateForemGroups < ActiveRecord::Migration
+  def change
+    create_table :forem_groups do |t|
+      t.string :name
+    end
+
+    add_index :forem_groups, :name
+  end
+end

--- a/plugins/forum/db/migrate/20150427084437_create_forem_memberships.forem.rb
+++ b/plugins/forum/db/migrate/20150427084437_create_forem_memberships.forem.rb
@@ -1,0 +1,11 @@
+# This migration comes from forem (originally 20120222204450)
+class CreateForemMemberships < ActiveRecord::Migration
+  def change
+    create_table :forem_memberships do |t|
+      t.integer :group_id
+      t.integer :member_id
+    end
+
+    add_index :forem_memberships, :group_id
+  end
+end

--- a/plugins/forum/db/migrate/20150427084438_create_forem_moderator_groups.forem.rb
+++ b/plugins/forum/db/migrate/20150427084438_create_forem_moderator_groups.forem.rb
@@ -1,0 +1,11 @@
+# This migration comes from forem (originally 20120223162058)
+class CreateForemModeratorGroups < ActiveRecord::Migration
+  def change
+    create_table :forem_moderator_groups do |t|
+      t.integer :forum_id
+      t.integer :group_id
+    end
+
+    add_index :forem_moderator_groups, :forum_id
+  end
+end

--- a/plugins/forum/db/migrate/20150427084439_remove_pending_review_add_state_to_forem_posts.forem.rb
+++ b/plugins/forum/db/migrate/20150427084439_remove_pending_review_add_state_to_forem_posts.forem.rb
@@ -1,0 +1,17 @@
+# This migration comes from forem (originally 20120227195911)
+class RemovePendingReviewAddStateToForemPosts < ActiveRecord::Migration
+  def up
+    remove_column :forem_posts, :pending_review
+    add_column :forem_posts, :state, :string, :default => 'pending_review'
+    add_index :forem_posts, :state
+  end
+
+  def down
+    remove_index :forem_posts, :state
+    remove_column :forem_posts, :state
+    add_column :forem_posts, :pending_review, :boolean, :default => true
+
+    Forem::Post.reset_column_information
+    Forem::Post.update_all :pending_review => false
+  end
+end

--- a/plugins/forum/db/migrate/20150427084440_remove_pending_review_from_forem_topics_add_state.forem.rb
+++ b/plugins/forum/db/migrate/20150427084440_remove_pending_review_from_forem_topics_add_state.forem.rb
@@ -1,0 +1,17 @@
+# This migration comes from forem (originally 20120227202639)
+class RemovePendingReviewFromForemTopicsAddState < ActiveRecord::Migration
+  def up
+    remove_column :forem_topics, :pending_review
+    add_column :forem_topics, :state, :string, :default => 'pending_review'
+    add_index :forem_topics, :state
+  end
+
+  def down
+    remove_index :forem_topics, :state
+    remove_column :forem_topics, :state
+    add_column :forem_topics, :pending_review, :boolean, :default => true
+
+    Forem::Topic.reset_column_information
+    Forem::Topic.update_all :pending_review => false
+  end
+end

--- a/plugins/forum/db/migrate/20150427084441_approve_all_topics_and_posts.forem.rb
+++ b/plugins/forum/db/migrate/20150427084441_approve_all_topics_and_posts.forem.rb
@@ -1,0 +1,11 @@
+# This migration comes from forem (originally 20120228194653)
+class ApproveAllTopicsAndPosts < ActiveRecord::Migration
+  def up
+    Forem::Topic.update_all :state => "approved"
+    Forem::Post.update_all :state => "approved"
+  end
+
+  def down
+  end
+end
+

--- a/plugins/forum/db/migrate/20150427084442_add_notified_to_forem_posts.forem.rb
+++ b/plugins/forum/db/migrate/20150427084442_add_notified_to_forem_posts.forem.rb
@@ -1,0 +1,6 @@
+# This migration comes from forem (originally 20120228202859)
+class AddNotifiedToForemPosts < ActiveRecord::Migration
+  def change
+    add_column :forem_posts, :notified, :boolean, :default => false
+  end
+end

--- a/plugins/forum/db/migrate/20150427084443_make_forem_views_polymorphic.forem.rb
+++ b/plugins/forum/db/migrate/20150427084443_make_forem_views_polymorphic.forem.rb
@@ -1,0 +1,13 @@
+# This migration comes from forem (originally 20120229165013)
+class MakeForemViewsPolymorphic < ActiveRecord::Migration
+  def up
+    rename_column :forem_views, :topic_id, :viewable_id
+    add_column :forem_views, :viewable_type, :string
+    Forem::View.update_all("viewable_type='Forem::Topic'")
+  end
+
+  def down
+    remove_column :forem_views, :viewable_type
+    rename_column :forem_views, :viewable_id, :topic_id
+  end
+end

--- a/plugins/forum/db/migrate/20150427084444_add_forem_view_fields.forem.rb
+++ b/plugins/forum/db/migrate/20150427084444_add_forem_view_fields.forem.rb
@@ -1,0 +1,24 @@
+# This migration comes from forem (originally 20120302152918)
+class AddForemViewFields < ActiveRecord::Migration
+  def up
+    add_column :forem_views, :current_viewed_at, :datetime
+    add_column :forem_views, :past_viewed_at, :datetime
+    add_column :forem_topics, :views_count, :integer, :default=>0
+    add_column :forem_forums, :views_count, :integer, :default=>0
+
+    Forem::Topic.find_each do |topic|
+      topic.update_column(:views_count, topic.views.sum(:count))
+    end
+
+    Forem::Forum.find_each do |forum|
+      forum.update_column(:views_count, forum.topics.sum(:views_count))
+    end
+  end
+
+  def down
+    remove_column :forem_views, :current_viewed_at
+    remove_column :forem_views, :past_viewed_at
+    remove_column :forem_topics, :views_count
+    remove_column :forem_forums, :views_count
+  end
+end

--- a/plugins/forum/db/migrate/20150427084445_add_forem_admin.forem.rb
+++ b/plugins/forum/db/migrate/20150427084445_add_forem_admin.forem.rb
@@ -1,0 +1,12 @@
+# This migration comes from forem (originally 20120616193446)
+class AddForemAdmin < ActiveRecord::Migration
+  def change
+    unless column_exists?(user_class, :forem_admin)
+      add_column user_class, :forem_admin, :boolean, :default => false
+    end
+  end
+
+  def user_class
+    Forem.user_class.table_name.downcase.to_sym
+  end
+end

--- a/plugins/forum/db/migrate/20150427084446_add_forem_state.forem.rb
+++ b/plugins/forum/db/migrate/20150427084446_add_forem_state.forem.rb
@@ -1,0 +1,12 @@
+# This migration comes from forem (originally 20120616193447)
+class AddForemState < ActiveRecord::Migration
+  def change
+    unless column_exists?(user_class, :forem_state)
+      add_column user_class, :forem_state, :string, :default => 'pending_review'
+    end
+  end
+
+  def user_class
+    Forem.user_class.table_name.downcase.to_sym
+  end
+end

--- a/plugins/forum/db/migrate/20150427084447_add_forem_auto_subscribe.forem.rb
+++ b/plugins/forum/db/migrate/20150427084447_add_forem_auto_subscribe.forem.rb
@@ -1,0 +1,12 @@
+# This migration comes from forem (originally 20120616193448)
+class AddForemAutoSubscribe < ActiveRecord::Migration
+  def change
+    unless column_exists?(user_class, :forem_auto_subscribe)
+      add_column user_class, :forem_auto_subscribe, :boolean, :default => false
+    end
+  end
+
+  def user_class
+    Forem.user_class.table_name.downcase.to_sym
+  end
+end

--- a/plugins/forum/db/migrate/20150427084448_add_friendly_id_slugs.forem.rb
+++ b/plugins/forum/db/migrate/20150427084448_add_friendly_id_slugs.forem.rb
@@ -1,0 +1,19 @@
+# This migration comes from forem (originally 20120718073130)
+class AddFriendlyIdSlugs < ActiveRecord::Migration
+  def change
+    add_column :forem_forums, :slug, :string
+    add_index :forem_forums, :slug, :unique => true
+    Forem::Forum.reset_column_information
+    Forem::Forum.find_each {|t| t.save! }
+
+    add_column :forem_categories, :slug, :string
+    add_index :forem_categories, :slug, :unique => true
+    Forem::Category.reset_column_information
+    Forem::Category.find_each {|t| t.save! }
+
+    add_column :forem_topics, :slug, :string
+    add_index :forem_topics, :slug, :unique => true
+    Forem::Topic.reset_column_information
+    Forem::Topic.find_each {|t| t.save! }
+  end
+end

--- a/plugins/forum/db/migrate/20150427084449_rename_title_to_name_on_forem_forums.forem.rb
+++ b/plugins/forum/db/migrate/20150427084449_rename_title_to_name_on_forem_forums.forem.rb
@@ -1,0 +1,10 @@
+# This migration comes from forem (originally 20121203093719)
+class RenameTitleToNameOnForemForums < ActiveRecord::Migration
+  def up
+    rename_column :forem_forums, :title, :name
+  end
+
+  def down
+    rename_column :forem_forums, :name, :title
+  end
+end

--- a/plugins/forum/db/migrate/20150427084450_add_position_to_categories.forem.rb
+++ b/plugins/forum/db/migrate/20150427084450_add_position_to_categories.forem.rb
@@ -1,0 +1,6 @@
+# This migration comes from forem (originally 20140917034000)
+class AddPositionToCategories < ActiveRecord::Migration
+  def change
+    add_column :forem_categories, :position, :integer, :default => 0
+  end
+end

--- a/plugins/forum/db/migrate/20150427084451_add_position_to_forums.forem.rb
+++ b/plugins/forum/db/migrate/20150427084451_add_position_to_forums.forem.rb
@@ -1,0 +1,6 @@
+# This migration comes from forem (originally 20140917201619)
+class AddPositionToForums < ActiveRecord::Migration
+  def change
+    add_column :forem_forums, :position, :integer, :default => 0
+  end
+end

--- a/plugins/forum/foodsoft_wiki.gemspec
+++ b/plugins/forum/foodsoft_wiki.gemspec
@@ -1,0 +1,21 @@
+$:.push File.expand_path("../lib", __FILE__)
+
+# Maintain your gem's version:
+require "foodsoft_forum/version"
+
+# Describe your gem and declare its dependencies:
+Gem::Specification.new do |s|
+  s.name        = "foodsoft_forum"
+  s.version     = FoodsoftForum::VERSION
+  s.authors     = ["paroga"]
+  s.email       = ["paroga@paroga.com"]
+  s.homepage    = "https://github.com/foodcoops/foodsoft"
+  s.summary     = "Forum plugin for foodsoft."
+  s.description = "Adds simple forum to foodsoft."
+
+  s.files = Dir["{app,config,db,lib}/**/*"] + ["Rakefile", "README.md"]
+  s.test_files = Dir["test/**/*"]
+
+  s.add_dependency "rails"
+  s.add_development_dependency "sqlite3"
+end

--- a/plugins/forum/lib/foodsoft_forum.rb
+++ b/plugins/forum/lib/foodsoft_forum.rb
@@ -1,0 +1,34 @@
+require 'foodsoft_forum/engine'
+
+module FoodsoftForum
+  # Return whether the forum is used or not.
+  # Enabled by default in {FoodsoftConfig} since it used to be part of the foodsoft core.
+  def self.enabled?
+    FoodsoftConfig[:use_forum]
+  end
+
+  module LoadForum
+    def self.included(base) # :nodoc:
+      base.class_eval do
+        def forem_user
+          current_user
+        end
+        helper_method :forem_user
+      end
+
+      User.class_eval do
+        def forem_admin?
+          role_admin?
+        end
+
+        def forem_name
+          display
+        end
+      end
+    end
+  end
+end
+
+ActiveSupport.on_load(:after_initialize) do
+  ApplicationController.send :include, FoodsoftForum::LoadForum
+end

--- a/plugins/forum/lib/foodsoft_forum/engine.rb
+++ b/plugins/forum/lib/foodsoft_forum/engine.rb
@@ -1,0 +1,20 @@
+module FoodsoftForum
+  class Engine < ::Rails::Engine
+    def navigation(primary, context)
+      return unless FoodsoftForum.enabled?
+      primary.item :forum, I18n.t('navigation.forum'), '/f/forums', id: nil do |subnav|
+        for category in  Forem::Category.all
+          subnav.item :forem_category, category.name, '/f/forums/categories/' + category.name.downcase, id: nil
+        end
+      end
+      # move this last added item to just after the foodcoop menu
+      if i = primary.items.index(primary[:foodcoop])
+        primary.items.insert(i+1, primary.items.delete_at(-1))
+      end
+    end
+
+    def default_foodsoft_config(cfg)
+      cfg[:use_forum] = true
+    end
+  end
+end

--- a/plugins/forum/lib/foodsoft_forum/version.rb
+++ b/plugins/forum/lib/foodsoft_forum/version.rb
@@ -1,0 +1,3 @@
+module FoodsoftForum
+  VERSION = "0.0.1"
+end


### PR DESCRIPTION
Messages alone do not satisfy our communication requirements, so a minimal forum is needed.
- [ ] Fix dependencies (Gemfile, gemspec, README)
- [ ] Use url helpers in navigation menu
- [ ] Figure out how Forem's groups fit together with Foodsoft groups
- [ ] Use Foodsoft layout
- [ ] Include forem assets on forum pages
- [ ] Styling of forem pages
- [ ] Remove gravatar icon
- [ ] Make sense of the navigation menu when no topics are present yet
- [ ] Highlight forem in navigation menu when showing it
- [ ] Move Forem configuration to Foodsoft's configuration section (?)
- [ ] Use Foodsoft configuration for some forem initializer options
- [ ] Use formatter supporting most of current wiki syntax (?) - so users don't need to learn two syntaxes
- [ ] Add link to dashboard (?)
- [ ] Update Foodsoft wiki: plugins need to specify engine source in url helpers
- [ ] Update Foodsoft wiki: engine plugins need to reset `default_url_options`
- [ ] Update Foodsoft wiki: document the use of decorators for monkey-patching Foodsoft
- [ ] ...
