### PR TITLE
Do not fail upon missing users in Message#recipients.

### DIFF
--- a/plugins/messages/app/models/message.rb
+++ b/plugins/messages/app/models/message.rb
@@ -68,9 +68,9 @@ class Message < ActiveRecord::Base
   end
 
   def recipients
-    User.find(recipients_ids)
+    User.where(id: recipients_ids)
   end
-  
+
   def deliver
     for user in recipients
       if user.receive_email?


### PR DESCRIPTION
I got some errors, when users tries to open old messages with already deleted users in the recipient list. I don't know if this fix is a good solution, but it fixes the problem.