### PR TITLE
Add optional boxfill phase to orders (+ bootstrap buttons)

### DIFF
--- a/app/assets/javascripts/ordering.js
+++ b/app/assets/javascripts/ordering.js
@@ -5,11 +5,11 @@
 //
 // Call setDecimalSeparator(char) to overwrite the default character "." with a localized value.
 
-var modified = false    		// indicates if anything has been clicked on this page
-var groupBalance = 0;			// available group money
-var minimumBalance = 0;                 // minimum group balance for the order to be succesful
+var modified = false;           // indicates if anything has been clicked on this page
+var groupBalance = 0;           // available group money
+var minimumBalance = 0;         // minimum group balance for the order to be succesful
 var toleranceIsCostly = true;   // default tolerance behaviour
-var isStockit = false;          // Wheter the order is from stock oder normal supplier
+var isStockit = false;          // Whether the order is from stock oder normal supplier
 
 // Article data arrays:
 var price = new Array();
@@ -139,8 +139,6 @@ function update(item, quantity, tolerance) {
         .removeClass('missing-many missing-few missing-none')
         .addClass(missing_units_css);
 
-
-    // update balance
     updateBalance();
 }
 
@@ -185,16 +183,16 @@ function updateBalance() {
 }
 
 $(function() {
-    $('input[data-increase_quantity]').on('touchclick', function() {
+    $('a[data-increase_quantity]').on('touchclick', function() {
         increaseQuantity($(this).data('increase_quantity'));
     });
-    $('input[data-decrease_quantity]').on('touchclick', function() {
+    $('a[data-decrease_quantity]').on('touchclick', function() {
         decreaseQuantity($(this).data('decrease_quantity'));
     });
-    $('input[data-increase_tolerance]').on('touchclick', function() {
+    $('a[data-increase_tolerance]').on('touchclick', function() {
         increaseTolerance($(this).data('increase_tolerance'));
     });
-    $('input[data-decrease_tolerance]').on('touchclick', function() {
+    $('a[data-decrease_tolerance]').on('touchclick', function() {
         decreaseTolerance($(this).data('decrease_tolerance'));
     });
 

--- a/app/assets/stylesheets/bootstrap_and_overrides.css.less
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css.less
@@ -48,7 +48,7 @@ body {
 
 
 // Fix empty dd tags in horizontal dl, see https://github.com/twitter/bootstrap/issues/4062
-.dl-horizontal { 
+.dl-horizontal {
     dd { .clearfix(); }
 }
 
@@ -129,7 +129,7 @@ table {
   th.left, td.left     { text-align: left; }
   th.right, td.right   { text-align: right; }
   th.center, td.center { text-align: center; }
-  
+
   td.main_info {
     font-weight: bold;
   }
@@ -194,9 +194,16 @@ table {
 }
 .unused {
   color: @articleUnusedColor;
+  margin-right: 0.5em;
 }
 .partused {
   color: @articlePartusedColor;
+}
+.btn-ordering, .btn-group .btn-ordering {
+  font-size: 10px;
+  line-height: 14px;
+  padding: 4px 8px;
+  margin-top: -2px;
 }
 
 #order-footer, .article-info {

--- a/app/controllers/admin/configs_controller.rb
+++ b/app/controllers/admin/configs_controller.rb
@@ -40,7 +40,7 @@ class Admin::ConfigsController < Admin::BaseController
   # turn recurring rules into something palatable
   def parse_recurring_selects!(config)
     if config
-      for k in [:pickup, :ends] do
+      for k in [:pickup, :boxfill, :ends] do
         if config[k]
           # allow clearing it using dummy value '{}' ('' would break recurring_select)
           if config[k][:recurr].present? && config[k][:recurr] != '{}'

--- a/app/helpers/admin/configs_helper.rb
+++ b/app/helpers/admin/configs_helper.rb
@@ -54,7 +54,8 @@ module Admin::ConfigsHelper
       checked_value = options.delete(:checked_value) || 'true'
       unchecked_value = options.delete(:unchecked_value) || 'false'
       options[:checked] = 'checked' if v=options.delete(:value) && v!='false'
-      form.hidden_field(key, value: unchecked_value, as: :hidden) + form.check_box(key, options, checked_value, false)
+      # different key for hidden field so that allow clocking on label focuses the control
+      form.hidden_field(key, id: "#{key}_", value: unchecked_value, as: :hidden) + form.check_box(key, options, checked_value, false)
     elsif options[:as] == :select_recurring
       options[:value] = FoodsoftDateUtil.rule_from(options[:value])
       options[:rules] ||= []
@@ -109,6 +110,13 @@ module Admin::ConfigsHelper
     else
       value
     end
+  end
+
+  # @return [String] Tooltip element (span)
+  # @param form [ActionView::Helpers::FormBuilder] Form object.
+  # @param key [Symbol, String] Configuration key of a boolean (e.g. +use_messages+).
+  def config_tooltip(form, key, options={}, &block)
+    content_tag :span, config_input_tooltip_options(form, key, options), &block
   end
 
   private

--- a/app/models/group_order.rb
+++ b/app/models/group_order.rb
@@ -28,7 +28,7 @@ class GroupOrder < ActiveRecord::Base
     data[:order_articles] = {}
     order.articles_grouped_by_category.each do |article_category, order_articles|
       order_articles.each do |order_article|
-        
+
         # Get the result of last time ordering, if possible
         goa = group_order_articles.detect { |goa| goa.order_article_id == order_article.id }
 
@@ -58,8 +58,10 @@ class GroupOrder < ActiveRecord::Base
       group_order_article = group_order_articles.where(order_article_id: order_article.id).first_or_create
 
       # Get ordered quantities and update group_order_articles/_quantities...
-      quantities = group_order_articles_attributes.fetch(order_article.id.to_s, {:quantity => 0, :tolerance => 0})
-      group_order_article.update_quantities(quantities[:quantity].to_i, quantities[:tolerance].to_i)
+      if group_order_articles_attributes
+        quantities = group_order_articles_attributes.fetch(order_article.id.to_s, {:quantity => 0, :tolerance => 0})
+        group_order_article.update_quantities(quantities[:quantity].to_i, quantities[:tolerance].to_i)
+      end
 
       # Also update results for the order_article
       logger.debug "[save_group_order_articles] update order_article.results!"
@@ -86,4 +88,3 @@ class GroupOrder < ActiveRecord::Base
   end
 
 end
-

--- a/app/models/group_order_article.rb
+++ b/app/models/group_order_article.rb
@@ -27,9 +27,9 @@ class GroupOrderArticle < ActiveRecord::Base
     group_order.try!(:ordergroup_id)
   end
 
-  # Updates the quantity/tolerance for this GroupOrderArticle by updating both GroupOrderArticle properties 
+  # Updates the quantity/tolerance for this GroupOrderArticle by updating both GroupOrderArticle properties
   # and the associated GroupOrderArticleQuantities chronologically.
-  # 
+  #
   # See description of the ordering algorithm in the general application documentation for details.
   def update_quantities(quantity, tolerance)
     logger.debug("GroupOrderArticle[#{id}].update_quantities(#{quantity}, #{tolerance})")
@@ -104,7 +104,7 @@ class GroupOrderArticle < ActiveRecord::Base
 
   # Determines how many items of this article the Ordergroup receives.
   # Returns a hash with three keys: :quantity / :tolerance / :total
-  # 
+  #
   # See description of the ordering algorithm in the general application documentation for details.
   def calculate_result(total = nil)
     # return memoized result unless a total is given
@@ -199,5 +199,3 @@ class GroupOrderArticle < ActiveRecord::Base
     result != result_computed unless result.nil?
   end
 end
-
-

--- a/app/models/order_article.rb
+++ b/app/models/order_article.rb
@@ -32,7 +32,7 @@ class OrderArticle < ActiveRecord::Base
     units_to_order
   end
 
-  # Count quantities of belonging group_orders. 
+  # Count quantities of belonging group_orders.
   # In balancing this can differ from ordered (by supplier) quantity for this article.
   def group_orders_sum
     quantity = group_order_articles.collect(&:result).sum
@@ -42,10 +42,11 @@ class OrderArticle < ActiveRecord::Base
   # Update quantity/tolerance/units_to_order from group_order_articles
   def update_results!
     if order.open?
-      quantity = group_order_articles.collect(&:quantity).sum
-      tolerance = group_order_articles.collect(&:tolerance).sum
-      update_attributes(:quantity => quantity, :tolerance => tolerance,
-                        :units_to_order => calculate_units_to_order(quantity, tolerance))
+      self.quantity = group_order_articles.collect(&:quantity).sum
+      self.tolerance = group_order_articles.collect(&:tolerance).sum
+      self.units_to_order = calculate_units_to_order(quantity, tolerance)
+      enforce_boxfill if order.boxfill?
+      save!
     elsif order.finished?
       update_attribute(:units_to_order, group_order_articles.collect(&:result).sum)
     end
@@ -186,19 +187,20 @@ class OrderArticle < ActiveRecord::Base
 
   # @return [Number] Units missing for the last +unit_quantity+ of the article.
   def missing_units
-    units = price.unit_quantity - ((quantity  % price.unit_quantity) + tolerance)
-    units = 0 if units < 0
-    units = 0 if units == price.unit_quantity
-    units
+    _missing_units(price.unit_quantity, quantity, tolerance)
   end
-  
+
+  def missing_units_was
+    _missing_units(price.unit_quantity, quantity_was, tolerance_was)
+  end
+
   # Check if the result of any associated GroupOrderArticle was overridden manually
   def result_manually_changed?
     group_order_articles.any? {|goa| goa.result_manually_changed?}
   end
 
   private
-  
+
   def article_and_price_exist
     errors.add(:article, I18n.t('model.order_article.error_price')) if !(article = Article.find(article_id)) || article.fc_price.nil?
   rescue
@@ -219,5 +221,26 @@ class OrderArticle < ActiveRecord::Base
     order.group_orders.each(&:update_price!)
   end
 
-end
+  # Throws an exception when the changed article decreases the amount of filled boxes.
+  def enforce_boxfill
+    # Either nothing changes, or
+    # missing_units becomes less and the amount doesn't decrease, or
+    # tolerance was moved to quantity. Only then are changes allowed in the boxfill phase.
+    delta_q = quantity - quantity_was
+    delta_t = tolerance - tolerance_was
+    delta_mis = missing_units - missing_units_was
+    delta_box = units_to_order - units_to_order_was
+    unless (delta_q == 0 && delta_t == 0) ||
+           (delta_mis < 0 && delta_box >= 0 && delta_t >= 0) ||
+           (delta_q > 0 && delta_q == -delta_t)
+      raise ActiveRecord::RecordNotSaved.new("Change not acceptable in boxfill phase, sorry.", self)
+    end
+  end
 
+  def _missing_units(unit_quantity, quantity, tolerance)
+    units = unit_quantity - ((quantity  % unit_quantity) + tolerance)
+    units = 0 if units < 0
+    units = 0 if units == unit_quantity
+    units
+  end
+end

--- a/app/models/order_article.rb
+++ b/app/models/order_article.rb
@@ -223,17 +223,17 @@ class OrderArticle < ActiveRecord::Base
 
   # Throws an exception when the changed article decreases the amount of filled boxes.
   def enforce_boxfill
-    # Either nothing changes, or
-    # missing_units becomes less and the amount doesn't decrease, or
+    # Either nothing changes, or the tolerance increases,
+    # missing_units decreases and the amount doesn't decrease, or
     # tolerance was moved to quantity. Only then are changes allowed in the boxfill phase.
     delta_q = quantity - quantity_was
     delta_t = tolerance - tolerance_was
     delta_mis = missing_units - missing_units_was
     delta_box = units_to_order - units_to_order_was
-    unless (delta_q == 0 && delta_t == 0) ||
+    unless (delta_q == 0 && delta_t >= 0) ||
            (delta_mis < 0 && delta_box >= 0 && delta_t >= 0) ||
            (delta_q > 0 && delta_q == -delta_t)
-      raise ActiveRecord::RecordNotSaved.new("Change not acceptable in boxfill phase, sorry.", self)
+      raise ActiveRecord::RecordNotSaved.new("Change not acceptable in boxfill phase for '#{article.name}', sorry.", self)
     end
   end
 

--- a/app/models/supplier.rb
+++ b/app/models/supplier.rb
@@ -116,6 +116,11 @@ class Supplier < ActiveRecord::Base
     end
   end
 
+  # @return [Boolean] Whether there are articles that would use tolerance (unit_quantity > 1)
+  def has_tolerance?
+    articles.where('articles.unit_quantity > 1').any?
+  end
+
   protected
 
   # make sure the shared_sync_method is allowed for the shared supplier

--- a/app/views/admin/configs/_tab_payment.html.haml
+++ b/app/views/admin/configs/_tab_payment.html.haml
@@ -11,8 +11,18 @@
     %span.add-on= t 'number.currency.format.unit'
     = config_input_field form, :minimum_balance, as: :decimal, class: 'input-small'
 
+%h4= t '.schedule_title'
 = form.simple_fields_for :order_schedule do |fields|
+  #boxfill-schedule.collapse{class: ('in' if FoodsoftConfig[:use_boxfill])}
+    = fields.simple_fields_for 'boxfill' do |fields|
+      .fold-line
+        = config_input fields, 'recurr', as: :select_recurring, input_html: {class: 'input-xlarge'}
+        = config_input fields, 'time', input_html: {class: 'input-mini'}
   = fields.simple_fields_for 'ends' do |fields|
     .fold-line
       = config_input fields, 'recurr', as: :select_recurring, input_html: {class: 'input-xlarge'}, allow_blank: true
       = config_input fields, 'time', input_html: {class: 'input-mini'}
+  -# can't use collapse and tooltip on same element :/
+  = config_input form, :use_boxfill, as: :boolean do
+    = config_tooltip form, :use_boxfill do
+      = config_input_field form, :use_boxfill, as: :boolean, title: '', data: {toggle: 'collapse', target: '#boxfill-schedule'}

--- a/app/views/group_orders/_form.html.haml
+++ b/app/views/group_orders/_form.html.haml
@@ -102,7 +102,7 @@
                 %span{id: "missing_units_#{order_article.id}"}= @ordering_data[:order_articles][order_article.id][:missing_units]
 
             %td.quantity
-              %input{id: "q_#{order_article.id}", name: "group_order[group_order_articles_attributes][#{order_article.id}][quantity]", size: "2", type: "hidden", value: @ordering_data[:order_articles][order_article.id][:quantity]}/
+              %input{id: "q_#{order_article.id}", name: "group_order[group_order_articles_attributes][#{order_article.id}][quantity]", type: "hidden", value: @ordering_data[:order_articles][order_article.id][:quantity], 'data-min' => (@ordering_data[:order_articles][order_article.id][:quantity] if @order.boxfill?), 'data-max' => (@ordering_data[:order_articles][order_article.id][:quantity]+@ordering_data[:order_articles][order_article.id][:missing_units] if @order.boxfill?)}/
               %span.used{id: "q_used_#{order_article.id}"}= @ordering_data[:order_articles][order_article.id][:used_quantity]
               +
               %span.unused{id: "q_unused_#{order_article.id}"}= @ordering_data[:order_articles][order_article.id][:quantity] - @ordering_data[:order_articles][order_article.id][:used_quantity]
@@ -113,7 +113,7 @@
                   %i.icon-minus
 
             %td.tolerance{style: ('display:none' if @order.stockit?)}
-              %input{id: "t_#{order_article.id}", name: "group_order[group_order_articles_attributes][#{order_article.id}][tolerance]", size: "2", type: "hidden", value: @ordering_data[:order_articles][order_article.id][:tolerance]}/
+              %input{id: "t_#{order_article.id}", name: "group_order[group_order_articles_attributes][#{order_article.id}][tolerance]", type: "hidden", value: @ordering_data[:order_articles][order_article.id][:tolerance], 'data-min' => (@ordering_data[:order_articles][order_article.id][:tolerance] if @order.boxfill?)}/
               - if (@ordering_data[:order_articles][order_article.id][:unit] > 1)
                 %span.used{id: "t_used_#{order_article.id}"}= @ordering_data[:order_articles][order_article.id][:used_tolerance]
                 +

--- a/app/views/group_orders/_form.html.haml
+++ b/app/views/group_orders/_form.html.haml
@@ -106,8 +106,11 @@
               %span.used{id: "q_used_#{order_article.id}"}= @ordering_data[:order_articles][order_article.id][:used_quantity]
               +
               %span.unused{id: "q_unused_#{order_article.id}"}= @ordering_data[:order_articles][order_article.id][:quantity] - @ordering_data[:order_articles][order_article.id][:used_quantity]
-              %input{type: 'button', value: '+', 'data-increase_quantity' => order_article.id}
-              %input{type: 'button', value: '-', 'data-decrease_quantity' => order_article.id}
+              .btn-group
+                %a.btn.btn-ordering{'data-increase_quantity' => order_article.id}
+                  %i.icon-plus
+                %a.btn.btn-ordering{'data-decrease_quantity' => order_article.id}
+                  %i.icon-minus
 
             %td.tolerance{style: ('display:none' if @order.stockit?)}
               %input{id: "t_#{order_article.id}", name: "group_order[group_order_articles_attributes][#{order_article.id}][tolerance]", size: "2", type: "hidden", value: @ordering_data[:order_articles][order_article.id][:tolerance]}/
@@ -115,8 +118,11 @@
                 %span.used{id: "t_used_#{order_article.id}"}= @ordering_data[:order_articles][order_article.id][:used_tolerance]
                 +
                 %span.unused{id: "t_unused_#{order_article.id}"}= @ordering_data[:order_articles][order_article.id][:tolerance] - @ordering_data[:order_articles][order_article.id][:used_tolerance]
-                %input{type: 'button', value: '+', 'data-increase_tolerance' => order_article.id}
-                %input{type: 'button', value: '-', 'data-decrease_tolerance' => order_article.id}
+                .btn-group
+                  %a.btn.btn-ordering{'data-increase_tolerance' => order_article.id}
+                    %i.icon-plus
+                  %a.btn.btn-ordering{'data-decrease_tolerance' => order_article.id}
+                    %i.icon-minus
 
             %td{id: "td_price_#{order_article.id}", style: "text-align:right; padding-right:10px; width:4em"}
               %span{id: "price_#{order_article.id}_display"}= number_to_currency(@ordering_data[:order_articles][order_article.id][:total_price])

--- a/app/views/orders/_form.html.haml
+++ b/app/views/orders/_form.html.haml
@@ -2,6 +2,7 @@
   = f.hidden_field :supplier_id
   .fold-line
     = f.input :starts, as: :date_picker_time
+    = f.input :boxfill, as: :date_picker_time if @order.is_boxfill_useful?
     = f.input :ends, as: :date_picker_time
   = f.input :note, input_html: {rows: 2, class: 'input-xxlarge'}
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -71,6 +71,7 @@ en:
         sent_to_all: Send to all members
         subject: Subject
       order:
+        boxfill: Fill boxes after
         closed_by: Settled by
         created_by: Created by
         ends: Ends at
@@ -237,6 +238,8 @@ en:
         pdf_title: PDF documents
       tab_messages:
         emails_title: Sending email
+      tab_payment:
+        schedule_title: Ordering schedule
       tab_tasks:
         periodic_title: Periodic tasks
       tabs:
@@ -478,6 +481,9 @@ en:
         ends:
           recurr: Schedule for default order closing date.
           time: Default time when orders are closed.
+        boxfill:
+          recurr: Schedule for when the box-fill phase starts by default.
+          time: Default time when the box-fill phase of the ordering starts.
         initial: Schedule starts at this date.
       page_footer: Shown on each page at the bottom. Enter "blank" to disable the footer completely.
       pdf_add_page_breaks:
@@ -492,6 +498,7 @@ en:
       tax_default: Default VAT percentage for new articles.
       tolerance_is_costly: Order as much of the member tolerance as possible (compared to only as much needed to fill the last box). Enabling this also includes the tolerance in the total price of the open member order.
       use_apple_points: When the apple point system is enabled, members are required to do some tasks to be able to keep ordering.
+      use_boxfill: When enabled, near end of an order, members are only able to change their order when increases the total amount ordered. This helps to fill any remaining boxes. You still need to set a box-fill date for the orders.
       use_messages: Allow members to communicate with each other within Foodsoft.
       use_nick: Show and use nicknames instead of real names. When enabling this, please check that each user has a nickname.
       use_wiki: Enable editable wiki pages.
@@ -523,6 +530,9 @@ en:
         ends:
           recurr: Order ends
           time: time
+        boxfill:
+          recurr: Box fill after
+          time: time
         initial: Schedule start
       page_footer: Page footer
       pdf_add_page_breaks: Page breaks
@@ -536,6 +546,7 @@ en:
       time_zone: Time zone
       tolerance_is_costly: Tolerance is costly
       use_apple_points: Apple points
+      use_boxfill: Box-fill phase
       use_messages: Messages
       use_nick: Use nicknames
       use_wiki: Enable wiki
@@ -1279,6 +1290,8 @@ en:
       close_direct_message: Order settled without charging member accounts.
       error_closed: Order was already settled
       error_nosel: At least one article must be selected. You may want to delete the order instead?
+      error_boxfill_before_ends: must be after the box-fill date (or remain empty)
+      error_starts_before_boxfill: must be after the start date (or remain empty)
       error_starts_before_ends: must be after the start date (or remain empty)
       notice_close: 'Order: %{name}, until %{ends}'
       stock: Stock

--- a/db/migrate/20150923190747_add_boxfill_to_order.rb
+++ b/db/migrate/20150923190747_add_boxfill_to_order.rb
@@ -1,0 +1,5 @@
+class AddBoxfillToOrder < ActiveRecord::Migration
+  def change
+    add_column :orders, :boxfill, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150301000000) do
+ActiveRecord::Schema.define(version: 20150923190747) do
 
   create_table "article_categories", force: :cascade do |t|
     t.string "name",        limit: 255, default: "", null: false
@@ -37,7 +37,7 @@ ActiveRecord::Schema.define(version: 20150301000000) do
     t.integer  "article_category_id", limit: 4,                           default: 0,    null: false
     t.string   "unit",                limit: 255,                         default: "",   null: false
     t.string   "note",                limit: 255
-    t.boolean  "availability",        limit: 1,                           default: true, null: false
+    t.boolean  "availability",                                            default: true, null: false
     t.string   "manufacturer",        limit: 255
     t.string   "origin",              limit: 255
     t.datetime "shared_updated_on"
@@ -61,7 +61,7 @@ ActiveRecord::Schema.define(version: 20150301000000) do
   create_table "assignments", force: :cascade do |t|
     t.integer "user_id",  limit: 4, default: 0,     null: false
     t.integer "task_id",  limit: 4, default: 0,     null: false
-    t.boolean "accepted", limit: 1, default: false
+    t.boolean "accepted",           default: false
   end
 
   add_index "assignments", ["user_id", "task_id"], name: "index_assignments_on_user_id_and_task_id", unique: true, using: :btree
@@ -127,18 +127,18 @@ ActiveRecord::Schema.define(version: 20150301000000) do
     t.string   "description",              limit: 255
     t.decimal  "account_balance",                        precision: 12, scale: 2, default: 0,     null: false
     t.datetime "created_on",                                                                      null: false
-    t.boolean  "role_admin",               limit: 1,                              default: false, null: false
-    t.boolean  "role_suppliers",           limit: 1,                              default: false, null: false
-    t.boolean  "role_article_meta",        limit: 1,                              default: false, null: false
-    t.boolean  "role_finance",             limit: 1,                              default: false, null: false
-    t.boolean  "role_orders",              limit: 1,                              default: false, null: false
+    t.boolean  "role_admin",                                                      default: false, null: false
+    t.boolean  "role_suppliers",                                                  default: false, null: false
+    t.boolean  "role_article_meta",                                               default: false, null: false
+    t.boolean  "role_finance",                                                    default: false, null: false
+    t.boolean  "role_orders",                                                     default: false, null: false
     t.datetime "deleted_at"
     t.string   "contact_person",           limit: 255
     t.string   "contact_phone",            limit: 255
     t.string   "contact_address",          limit: 255
     t.text     "stats",                    limit: 65535
     t.integer  "next_weekly_tasks_number", limit: 4,                              default: 8
-    t.boolean  "ignore_apple_restriction", limit: 1,                              default: false
+    t.boolean  "ignore_apple_restriction",                                        default: false
   end
 
   add_index "groups", ["name"], name: "index_groups_on_name", unique: true, using: :btree
@@ -184,7 +184,7 @@ ActiveRecord::Schema.define(version: 20150301000000) do
     t.string   "subject",        limit: 255,                   null: false
     t.text     "body",           limit: 65535
     t.integer  "email_state",    limit: 4,     default: 0,     null: false
-    t.boolean  "private",        limit: 1,     default: false
+    t.boolean  "private",                      default: false
     t.datetime "created_at"
     t.integer  "reply_to",       limit: 4
     t.integer  "group_id",       limit: 4
@@ -224,6 +224,7 @@ ActiveRecord::Schema.define(version: 20150301000000) do
     t.integer  "updated_by_user_id", limit: 4
     t.decimal  "foodcoop_result",                  precision: 8, scale: 2
     t.integer  "created_by_user_id", limit: 4
+    t.datetime "boxfill"
   end
 
   add_index "orders", ["state"], name: "index_orders_on_state", using: :btree
@@ -316,7 +317,7 @@ ActiveRecord::Schema.define(version: 20150301000000) do
     t.string   "name",                   limit: 255, default: "",    null: false
     t.string   "description",            limit: 255
     t.date     "due_date"
-    t.boolean  "done",                   limit: 1,   default: false
+    t.boolean  "done",                               default: false
     t.integer  "workgroup_id",           limit: 4
     t.datetime "created_on",                                         null: false
     t.datetime "updated_on",                                         null: false


### PR DESCRIPTION
To help reduce missing units, [Vokomokum](http://www.vokomokum.nl/) uses an order cycle where the in last couple of days that the order is open, members can only reduce shortages. This PR implements that feature for Foodsoft.

The feature needs to be enabled in the configuration screen, before it can be used. Then orders that have articles with a unit_quantity>1 will show the option to set a date for the boxfill phase.

As a bonus, the member ordering screen now uses bootstrap buttons, and shows them disabled when the minimum value (0) is reached.

![foodsoft_-_orders_-_2015-10-13_23 36 01](https://cloud.githubusercontent.com/assets/503804/10469083/306bb3e0-7203-11e5-909d-6db4362a326c.png)
