### PR TITLE
Improved Docker Setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,38 @@
-FROM ruby:2.1-slim
+# Based on ruby image, packed with a lot of development dependencies
+FROM ruby:2.3
 
+# Install all dependencies for development and testing
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
       mysql-client \
-      git \
-      make \
-      gcc \
-      g++ \
-      patch \
-      libsqlite3-dev \
       libv8-dev \
       libmysqlclient-dev \
-      libxml2-dev \
-      libxslt1-dev \
-      libffi-dev \
-      libreadline-dev \
       xvfb \
       iceweasel && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean
 
-ENV WORKDIR /usr/src/app
+# Run app and all commands as user 'app'. This avoids changing permissions
+# for files in mounted volume.
+RUN adduser --gecos GECOS --disabled-password --shell /bin/bash app
+USER app
 
-RUN mkdir -p $WORKDIR
-WORKDIR $WORKDIR
+# Create an directory to store the application code.
+RUN mkdir /home/app/src
+WORKDIR /home/app/src
 
 # Copy plugins before the rest to allow bundler loading gemspecs
 # TODO: Move plugins to gems and add them to Gemfile instead
-COPY plugins $WORKDIR/plugins
+COPY plugins ./plugins
 
-COPY Gemfile $WORKDIR/
-COPY Gemfile.lock $WORKDIR/
-RUN bundle install --jobs 4
+# Add Gemfiles and run bundle.
+COPY Gemfile Gemfile.lock ./
+ENV BUNDLE_JOBS=4 BUNDLE_PATH=/home/app/bundle \
+    BUNDLE_APP_CONFIG=/home/app/bundle/config
+RUN bundle install
 
-COPY . $WORKDIR
+# Copy the application code. (Excluded files see .dockerignore)
+COPY . ./
 
 EXPOSE 3000
 

--- a/doc/SETUP_DOCKER.md
+++ b/doc/SETUP_DOCKER.md
@@ -4,8 +4,8 @@ This document explains setting up and using Foodsoft with Docker.
 
 ## Requirements
 
-* Docker (=> 1.5)
-* Docker Compose (=> 1.1)
+* Docker (=> 1.9.1)
+* Docker Compose (=> 1.4)
 * Nothing more, no ruby, mysql, redis etc!
 
 For installing instructions see https://docs.docker.com/installation/.
@@ -49,19 +49,16 @@ Jump in a running container for debugging.
 
     docker exec -ti foodsoft_app_1 bash
 
+Receiving mails
+
+Go to http://localhost:1080.
+
 ## Notes
 
 ### Gemfile updates
 
-This is bit tricky, as the gemfiles are stored in the container and so we have
-to rebuild the container each time we change the Gemfile. To avoid installing
-all the gems from scratch we can use this workaround:
-
-```bash
-docker-compose run app bundle update rails # Update Gemfile.lock file
-docker ps -a # Look for the last exited container and grab the Container ID
-docker commit -m "Updated rails" <Container ID> foodsoft_app
-```
+As we use a special container (`bundle`, see `docker-compose.yml`) you only
+have to run the bundle command as normally: `docker-compose run app bundle`
 
 ### Database configuration
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,16 @@
+bundle:
+  image: foodsoft_app
+  command: /bin/true
+  volumes:
+    - /home/app/bundle
+
 app: &app
   build: .
   command: bundle exec rails server --binding 0.0.0.0
+  volumes_from:
+    - bundle
   volumes:
-    - .:/usr/src/app
+    - .:/home/app/src
   ports:
     - "3000:3000"
   links:
@@ -10,10 +18,10 @@ app: &app
     - redis
     - mailcatcher
   environment:
-    - DATABASE_URL=mysql2://root:secret@mysql/development
+    - DATABASE_URL=mysql2://root:secret@mysql/development?encoding=utf8
     - REDIS_URL=redis://redis:6379
     - QUEUE=foodsoft_notifier
-    - TEST_DATABASE_URL=mysql2://root:secret@mysql/test
+    - TEST_DATABASE_URL=mysql2://root:secret@mysql/test?encoding=utf8
 
 resque:
   <<: *app


### PR DESCRIPTION
* Use ruby version 3 with most dependencies already shipped
* Use bundle container
* Run rails commands as app user
* Set Database encoding

Sadly, I couldn't get the test suite to run without some errors. But I guess, this has nothing to do with the docker update as there are also errors in latest travis build.