### PR TITLE
Add break to ordergroup

### DIFF
--- a/app/views/admin/ordergroups/_form.html.haml
+++ b/app/views/admin/ordergroups/_form.html.haml
@@ -5,6 +5,8 @@
     = f.input :contact_person
     = f.input :contact_phone
     = f.input :contact_address
+    = f.input :break_start, as: :date_picker
+    = f.input :break_end, as: :date_picker
     - if FoodsoftConfig[:use_apple_points]
       = f.input :ignore_apple_restriction, :label => false, :inline_label => true
   = render 'shared/group_form_fields', f: f, captured: captured

--- a/app/views/foodcoop/ordergroups/_ordergroups.html.haml
+++ b/app/views/foodcoop/ordergroups/_ordergroups.html.haml
@@ -7,6 +7,7 @@
     %tr
       %th= heading_helper Ordergroup, :name
       %th= heading_helper Ordergroup, :user_tokens
+      %th= heading_helper Ordergroup, :break
       %th= heading_helper Ordergroup, :last_user_activity
       %th= heading_helper Ordergroup, :last_order
 
@@ -15,5 +16,9 @@
       %tr
         %td= ordergroup.name
         %td=h ordergroup.users.collect { |u| show_user(u) }.join(", ")
+        - if ordergroup.break_start? or ordergroup.break_end?
+          %td= raw t '.break', start: format_date(ordergroup.break_start), end: format_date(ordergroup.break_end)
+        - else
+          %td
         %td= format_date ordergroup.last_user_activity
         %td= format_date ordergroup.last_order.try(:starts)

--- a/app/views/shared/_group.html.haml
+++ b/app/views/shared/_group.html.haml
@@ -6,6 +6,9 @@
     %dd=h group.contact
     %dt= heading_helper(Ordergroup, :contact_address) + ':'
     %dd= link_to_gmaps group.contact_address
+  %dt= heading_helper(Ordergroup, :break) + ':'
+  - if group.break_start? or group.break_end?
+    %dd= raw t '.break', start: format_date(group.break_start), end: format_date(group.break_end)
   - if group.is_a?(Workgroup)
     %dt= t('.access') + ':'
     %dd= format_roles(group)

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -99,6 +99,7 @@ de:
       ordergroup:
         account_balance: Kontostand
         available_funds: Verfügbares Guthaben
+        break: (Letzte) Pause
         contact: Kontakt
         contact_address: Adresse
         contact_person: Kontaktperson
@@ -805,6 +806,8 @@ de:
         only_active: Nur aktive
         only_active_desc: "(mindestens einmal in den letzten 3 Monaten bestellt)"
         title: Bestellgruppen
+      ordergroups:
+        break: '%{start} - %{end}'
     users:
       index:
         body: "<p>Hier kannst Du den Mitgliedern Deiner Foodcoop eine Nachricht schreiben. Damit Deine Kontaktdaten einzusehen sind, musst Du sie unter %{profile_link} freigeben.</p>"
@@ -1444,6 +1447,7 @@ de:
       access: Zugriff auf
       activated: aktiviert
       apple_limit: "Äpfel-Bestellbeschränkung"
+      break: 'von %{start} bis %{end}'
       deactivated: deaktiviert
     group_form_fields:
       search: Suche ...

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -100,6 +100,7 @@ en:
       ordergroup:
         account_balance: Account balance
         available_funds: Available credit
+        break: (Last) break
         contact: Contact
         contact_address: Address
         contact_person: Contact person
@@ -818,6 +819,8 @@ en:
         only_active: Only active groups
         only_active_desc: "(have placed order at least once in the last 3 months)"
         title: Ordergroups
+      ordergroups:
+        break: '%{start} - %{end}'
     users:
       index:
         body: "<p>Here you can write a message to the members of your Foodcoop. If you'd like others to contact you, please enable it in your %{profile_link}.</p>"
@@ -1466,6 +1469,7 @@ en:
       access: Access to
       activated: activated
       apple_limit: Apple points order limit
+      break: 'from %{start} to %{end}'
       deactivated: deactivated
     group_form_fields:
       search: Search ...

--- a/db/migrate/20160217164552_add_break_to_group.rb
+++ b/db/migrate/20160217164552_add_break_to_group.rb
@@ -1,0 +1,6 @@
+class AddBreakToGroup < ActiveRecord::Migration
+  def change
+    add_column :groups, :break_start, :date
+    add_column :groups, :break_end, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -141,6 +141,8 @@ ActiveRecord::Schema.define(version: 20160217194036) do
     t.integer  "next_weekly_tasks_number", limit: 4,                              default: 8
     t.boolean  "ignore_apple_restriction",                                        default: false
     t.boolean  "role_invoices",                                                   default: false, null: false
+    t.date     "break_start"
+    t.date     "break_end"
   end
 
   add_index "groups", ["name"], name: "index_groups_on_name", unique: true, using: :btree


### PR DESCRIPTION
I like to keep the break-info for unlimited time. If it's irrelevant people can remove the data from the group settings anyway