### PR TITLE
Add class and type for financial transactions #367

### DIFF
--- a/app/controllers/admin/finances_controller.rb
+++ b/app/controllers/admin/finances_controller.rb
@@ -1,0 +1,13 @@
+class Admin::FinancesController < Admin::BaseController
+  inherit_resources
+
+  def index
+    @financial_transaction_classes = FinancialTransactionClass.order('name ASC')
+  end
+
+  def update_transaction_types
+    @financial_transaction_classes = FinancialTransactionClass.order('name ASC')
+    render :layout => false
+  end
+
+end

--- a/app/controllers/admin/financial_transaction_classes_controller.rb
+++ b/app/controllers/admin/financial_transaction_classes_controller.rb
@@ -1,0 +1,41 @@
+class Admin::FinancialTransactionClassesController < Admin::BaseController
+  inherit_resources
+
+  def new
+    @financial_transaction_class = FinancialTransactionClass.new(params[:financial_transaction_class])
+    render layout: false
+  end
+
+  def create
+    @financial_transaction_class = FinancialTransactionClass.new(params[:financial_transaction_class])
+    if @financial_transaction_class.save
+      redirect_to update_transaction_types_admin_finances_url, status: 303
+    else
+      render action: 'new', layout: false
+    end
+  end
+
+  def edit
+    @financial_transaction_class = FinancialTransactionClass.find(params[:id])
+    render action: 'new', layout: false
+  end
+
+  def update
+    @financial_transaction_class = FinancialTransactionClass.find(params[:id])
+
+    if @financial_transaction_class.update_attributes(params[:financial_transaction_class])
+      redirect_to update_transaction_types_admin_finances_url, status: 303
+    else
+      render action: 'new', layout: false
+    end
+  end
+
+  def destroy
+    @financial_transaction_class = FinancialTransactionClass.find(params[:id])
+    @financial_transaction_class.destroy!
+    redirect_to update_transaction_types_admin_finances_url, status: 303
+  rescue => error
+    flash.now[:alert] = error.message
+    render template: 'shared/alert'
+  end
+end

--- a/app/controllers/admin/financial_transaction_types_controller.rb
+++ b/app/controllers/admin/financial_transaction_types_controller.rb
@@ -1,0 +1,42 @@
+class Admin::FinancialTransactionTypesController < Admin::BaseController
+  inherit_resources
+
+  def new
+    @financial_transaction_type = FinancialTransactionType.new(params[:financial_transaction_type])
+    @financial_transaction_type.financial_transaction_class = FinancialTransactionClass.find_by_id(params[:financial_transaction_class]) if params[:financial_transaction_class]
+    render layout: false
+  end
+
+  def create
+    @financial_transaction_type = FinancialTransactionType.new(params[:financial_transaction_type])
+    if @financial_transaction_type.save
+      redirect_to update_transaction_types_admin_finances_url, status: 303
+    else
+      render action: 'new', layout: false
+    end
+  end
+
+  def edit
+    @financial_transaction_type = FinancialTransactionType.find(params[:id])
+    render action: 'new', layout: false
+  end
+
+  def update
+    @financial_transaction_type = FinancialTransactionType.find(params[:id])
+
+    if @financial_transaction_type.update_attributes(params[:financial_transaction_type])
+      redirect_to update_transaction_types_admin_finances_url, status: 303
+    else
+      render action: 'new', layout: false
+    end
+  end
+
+  def destroy
+    @financial_transaction_type = FinancialTransactionType.find(params[:id])
+    @financial_transaction_type.destroy!
+    redirect_to update_transaction_types_admin_finances_url, status: 303
+  rescue => error
+    flash.now[:alert] = error.message
+    render template: 'shared/alert'
+  end
+end

--- a/app/controllers/finance/balancing_controller.rb
+++ b/app/controllers/finance/balancing_controller.rb
@@ -68,7 +68,8 @@ class Finance::BalancingController < Finance::BaseController
   # Balances the Order, Update of the Ordergroup.account_balances
   def close
     @order = Order.find(params[:id])
-    @order.close!(@current_user)
+    @type = FinancialTransactionType.find_by_id(params.permit(:type))
+    @order.close!(@current_user, @type)
     redirect_to finance_order_index_url, notice: t('finance.balancing.close.notice')
 
   rescue => error

--- a/app/controllers/finance/financial_transactions_controller.rb
+++ b/app/controllers/finance/financial_transactions_controller.rb
@@ -55,10 +55,11 @@ class Finance::FinancialTransactionsController < ApplicationController
 
   def create_collection
     raise I18n.t('finance.financial_transactions.controller.create_collection.error_note_required') if params[:note].blank?
+    type = FinancialTransactionType.find_by_id(params.permit(:type))
     params[:financial_transactions].each do |trans|
       # ignore empty amount fields ...
       unless trans[:amount].blank?
-        Ordergroup.find(trans[:ordergroup_id]).add_financial_transaction!(trans[:amount], params[:note], @current_user)
+        Ordergroup.find(trans[:ordergroup_id]).add_financial_transaction!(trans[:amount], params[:note], @current_user, type)
       end
     end
     redirect_to finance_ordergroups_url, notice: I18n.t('finance.financial_transactions.controller.create_collection.notice')

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -30,6 +30,8 @@ class HomeController < ApplicationController
 
     unless @ordergroup.nil?
 
+      @ordergroup = Ordergroup.include_transaction_class_sum.find(@ordergroup)
+
       if params['sort']
         sort = case params['sort']
         when "date"  then "created_on"

--- a/app/models/financial_transaction.rb
+++ b/app/models/financial_transaction.rb
@@ -4,6 +4,7 @@ class FinancialTransaction < ActiveRecord::Base
   belongs_to :ordergroup
   belongs_to :user
   belongs_to :financial_link
+  belongs_to :financial_transaction_type
 
   validates_presence_of :amount, :note, :user_id, :ordergroup_id
   validates_numericality_of :amount, greater_then: -100_000,
@@ -11,8 +12,18 @@ class FinancialTransaction < ActiveRecord::Base
 
   localize_input_of :amount
 
+  after_initialize do
+    initialize_financial_transaction_type
+  end
+
   # Use this save method instead of simple save and after callback
   def add_transaction!
-    ordergroup.add_financial_transaction! amount, note, user
+    ordergroup.add_financial_transaction! amount, note, user, financial_transaction_type
+  end
+
+  protected
+
+  def initialize_financial_transaction_type
+    self.financial_transaction_type ||= FinancialTransactionType.default
   end
 end

--- a/app/models/financial_transaction_class.rb
+++ b/app/models/financial_transaction_class.rb
@@ -3,4 +3,18 @@ class FinancialTransactionClass < ActiveRecord::Base
 
   validates :name, presence: true
   validates_uniqueness_of :name
+
+  scope :sorted, -> { order(name: :asc) }
+
+  def self.has_multiple_classes
+    FinancialTransactionClass.count > 1
+  end
+
+  def display
+    if FinancialTransactionClass.has_multiple_classes
+      name
+    else
+      I18n.t('activerecord.attributes.financial_transaction.amount')
+    end
+  end
 end

--- a/app/models/financial_transaction_class.rb
+++ b/app/models/financial_transaction_class.rb
@@ -1,0 +1,6 @@
+class FinancialTransactionClass < ActiveRecord::Base
+  has_many :financial_transaction_types, dependent: :destroy
+
+  validates :name, presence: true
+  validates_uniqueness_of :name
+end

--- a/app/models/financial_transaction_type.rb
+++ b/app/models/financial_transaction_type.rb
@@ -1,0 +1,25 @@
+class FinancialTransactionType < ActiveRecord::Base
+  belongs_to :financial_transaction_class
+  has_many :financial_transactions, dependent: :restrict_with_exception
+
+  validates :name, presence: true
+  validates_uniqueness_of :name
+  validates :financial_transaction_class, presence: true
+
+  before_destroy :restrict_deleting_last_financial_transaction_type
+
+  def self.default
+    first
+  end
+
+  def self.has_multiple_types
+    self.count > 1
+  end
+
+  protected
+
+  # check if this is the last financial transaction type and deny
+  def restrict_deleting_last_financial_transaction_type
+    raise I18n.t('model.financial_transaction_type.no_delete_last') if FinancialTransactionType.count == 1
+  end
+end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -231,7 +231,7 @@ class Order < ActiveRecord::Base
   end
 
   # Sets order.status to 'close' and updates all Ordergroup.account_balances
-  def close!(user)
+  def close!(user, transaction_type = nil)
     raise I18n.t('orders.model.error_closed') if closed?
     transaction_note = I18n.t('orders.model.notice_close', :name => name,
                               :ends => ends.strftime(I18n.t('date.formats.default')))
@@ -243,7 +243,7 @@ class Order < ActiveRecord::Base
       for group_order in gos
         if group_order.ordergroup
           price = group_order.price * -1                  # decrease! account balance
-          group_order.ordergroup.add_financial_transaction!(price, transaction_note, user)
+          group_order.ordergroup.add_financial_transaction!(price, transaction_note, user, transaction_type)
         end
       end
 

--- a/app/models/ordergroup.rb
+++ b/app/models/ordergroup.rb
@@ -55,9 +55,9 @@ class Ordergroup < Group
 
   # Creates a new FinancialTransaction for this Ordergroup and updates the account_balance accordingly.
   # Throws an exception if it fails.
-  def add_financial_transaction!(amount, note, user, link = nil)
+  def add_financial_transaction!(amount, note, user, transaction_type, link = nil)
     transaction do
-      t = FinancialTransaction.new(ordergroup: self, amount: amount, note: note, user: user, financial_link: link)
+      t = FinancialTransaction.new(ordergroup: self, amount: amount, note: note, user: user, financial_transaction_type: transaction_type, financial_link: link)
       t.save!
       self.account_balance = financial_transactions.sum('amount')
       save!

--- a/app/views/admin/finances/_form.html.haml
+++ b/app/views/admin/finances/_form.html.haml
@@ -1,0 +1,5 @@
+= simple_form_for [:admin, @financial_transaction_class] do |f|
+  = f.input :name
+  .form-actions
+    = f.button :submit
+    = link_to t('ui.or_cancel'), :back

--- a/app/views/admin/finances/_transaction_types.html.haml
+++ b/app/views/admin/finances/_transaction_types.html.haml
@@ -1,0 +1,23 @@
+%table.table.table-striped
+  %thead
+    %tr
+      %th= t '.name'
+      %th= t 'ui.actions'
+  %tbody
+    - for financial_transaction_class in @financial_transaction_classes
+      %tr
+        %td
+          %strong= financial_transaction_class.name
+        %td
+          = link_to t('ui.edit'), edit_admin_financial_transaction_class_path(financial_transaction_class), remote: true, class: 'btn btn-mini'
+          = link_to t('ui.delete'), [:admin, financial_transaction_class], :data => {:confirm => t('ui.confirm_delete', name: financial_transaction_class.name)},
+            :method => :delete, remote: true, class: 'btn btn-mini btn-danger'
+          = link_to t('.new_financial_transaction_type'), new_admin_financial_transaction_type_path(financial_transaction_class: financial_transaction_class), remote: true, class: 'btn btn-success btn-mini'
+      - for financial_transaction_type in financial_transaction_class.financial_transaction_types
+        %tr
+          %td{:style => "padding-left: #{25}px"}
+            = financial_transaction_type.name
+          %td
+            = link_to t('ui.edit'), edit_admin_financial_transaction_type_path(financial_transaction_type), remote: true, class: 'btn btn-mini'
+            = link_to t('ui.delete'), [:admin, financial_transaction_type], :data => {:confirm => t('ui.confirm_delete', name: financial_transaction_type.name)},
+              :method => :delete, remote: true, class: 'btn btn-mini btn-danger'

--- a/app/views/admin/finances/index.html.haml
+++ b/app/views/admin/finances/index.html.haml
@@ -1,0 +1,9 @@
+- title t '.title'
+
+- content_for :actionbar do
+  = link_to t('.new_financial_transaction_class'), new_admin_financial_transaction_class_path, remote: true, class: 'btn btn-primary'
+
+- content_for :sidebar do
+  %p= t('.first_paragraph').html_safe
+
+#transaction_types_table= render 'transaction_types'

--- a/app/views/admin/finances/update_transaction_types.js.haml
+++ b/app/views/admin/finances/update_transaction_types.js.haml
@@ -1,0 +1,2 @@
+$('#transaction_types_table').html('#{escape_javascript(render("admin/finances/transaction_types"))}');
+$('#modalContainer').modal('hide');

--- a/app/views/admin/financial_transaction_classes/_form.html.haml
+++ b/app/views/admin/financial_transaction_classes/_form.html.haml
@@ -1,0 +1,9 @@
+= simple_form_for [:admin, @financial_transaction_class], :validate => true, :remote => true do |f|
+  .modal-header
+    = close_button :modal
+    %h3= @financial_transaction_class.new_record? ? t('.title_new') : t('.title_edit')
+  .modal-body
+    = f.input :name
+  .modal-footer
+    = link_to t('ui.close'), '#', class: 'btn', data: {dismiss: 'modal'}
+    = f.submit class: 'btn btn-primary'

--- a/app/views/admin/financial_transaction_classes/new.js.haml
+++ b/app/views/admin/financial_transaction_classes/new.js.haml
@@ -1,0 +1,2 @@
+$('#modalContainer').html('#{j(render("form"))}');
+$('#modalContainer').modal();

--- a/app/views/admin/financial_transaction_types/_form.html.haml
+++ b/app/views/admin/financial_transaction_types/_form.html.haml
@@ -1,0 +1,10 @@
+= simple_form_for [:admin, @financial_transaction_type], :validate => true, :remote => true do |f|
+  .modal-header
+    = close_button :modal
+    %h3= @financial_transaction_type.new_record? ? t('.title_new') : t('.title_edit')
+  .modal-body
+    = f.input :name
+    = f.association :financial_transaction_class, :include_blank => false
+  .modal-footer
+    = link_to t('ui.close'), '#', class: 'btn', data: {dismiss: 'modal'}
+    = f.submit class: 'btn btn-primary'

--- a/app/views/admin/financial_transaction_types/new.js.haml
+++ b/app/views/admin/financial_transaction_types/new.js.haml
@@ -1,0 +1,2 @@
+$('#modalContainer').html('#{j(render("form"))}');
+$('#modalContainer').modal();

--- a/app/views/finance/balancing/confirm.html.haml
+++ b/app/views/finance/balancing/confirm.html.haml
@@ -1,10 +1,14 @@
--title t('.title')
-%p!= t('.first_paragraph')
-%table.table.table-striped{:style => "width:35em"}
-  - for group_order in @order.group_orders
-    %tr{:class => cycle('even', 'odd')}
-      %td= group_order.ordergroup_name
-      %td.numeric= number_to_currency(group_order.price)
-.form-actions
-  = link_to t('.clear'), close_finance_order_path(@order), method: :patch, class: 'btn btn-primary'
-  = link_to t('.or_cancel'), new_finance_order_path(order_id: @order.id)
+= form_tag close_finance_order_path(@order) do
+  %p!= t('.first_paragraph')
+  - if FinancialTransactionType.has_multiple_types
+    %p
+      %b= heading_helper FinancialTransaction, :financial_transaction_type
+      = select_tag :type, options_for_select(FinancialTransactionType.order(:name).map { |t| [ t.name, t.id ] })
+  %table.table.table-striped{:style => "width:35em"}
+    - for group_order in @order.group_orders
+      %tr{:class => cycle('even', 'odd')}
+        %td= group_order.ordergroup_name
+        %td.numeric= number_to_currency(group_order.price)
+  .form-actions
+    = submit_tag t('.clear'), class: 'btn btn-primary'
+    = link_to t('.or_cancel'), new_finance_order_path(order_id: @order.id)

--- a/app/views/finance/financial_transactions/_transactions.html.haml
+++ b/app/views/finance/financial_transactions/_transactions.html.haml
@@ -16,8 +16,12 @@
       - if with_ordergroup
         %th= heading_helper FinancialTransaction, :ordergroup
       %th= heading_helper FinancialTransaction, :user
+      - if FinancialTransactionType.has_multiple_types
+        %th= heading_helper FinancialTransaction, :financial_transaction_type
       %th= sort_link_helper heading_helper(FinancialTransaction, :note), "note"
-      %th= sort_link_helper heading_helper(FinancialTransaction, :amount), "amount"
+      - FinancialTransactionClass.sorted.each do |c|
+        %th
+          = sort_link_helper c.display, "amount"
   %tbody
     - @financial_transactions.each do |t|
       %tr
@@ -29,5 +33,10 @@
         - if with_ordergroup
           %td= h link_to t.ordergroup.name, finance_ordergroup_transactions_path(t.ordergroup)
         %td= h show_user(t.user)
+        - if FinancialTransactionType.has_multiple_types
+          %td= h t.financial_transaction_type.name
         %td= h t.note
-        %td.currency{:style => "color:#{t.amount < 0 ? 'red' : 'black'}; width:5em"}= number_to_currency(t.amount)
+        - FinancialTransactionClass.sorted.each do |c|
+          %td.currency{:style => "color:#{t.amount < 0 ? 'red' : 'black'}; width:5em"}
+            - if t.financial_transaction_type.financial_transaction_class == c
+              = number_to_currency(t.amount)

--- a/app/views/finance/financial_transactions/new.html.haml
+++ b/app/views/finance/financial_transactions/new.html.haml
@@ -5,6 +5,8 @@
 = simple_form_for @financial_transaction, :url => finance_ordergroup_transactions_path(@ordergroup),
   :validate => true do |f|
   = f.hidden_field :ordergroup_id
+  - if FinancialTransactionType.has_multiple_types
+    = f.association :financial_transaction_type, :as => :radio_buttons
   = f.input :amount
   = f.input :note, :as => :text
   .form-actions

--- a/app/views/finance/financial_transactions/new_collection.html.haml
+++ b/app/views/finance/financial_transactions/new_collection.html.haml
@@ -34,6 +34,10 @@
   .well.well-small= t('.sidebar')
 
 = form_tag finance_create_transaction_collection_path do
+  - if FinancialTransactionType.has_multiple_types
+    %p
+      %b= heading_helper FinancialTransaction, :financial_transaction_type
+      = select_tag :type, options_for_select(FinancialTransactionType.order(:name).map { |t| [ t.name, t.id ] })
   %p
     %b= heading_helper FinancialTransaction, :note
     = text_field_tag :note, params[:note], class: 'input-xlarge', required: 'required'

--- a/app/views/finance/ordergroups/_ordergroups.html.haml
+++ b/app/views/finance/ordergroups/_ordergroups.html.haml
@@ -6,15 +6,19 @@
     %tr
       %th= sort_link_helper heading_helper(Ordergroup, :name), "name", :per_page => @per_page
       %th= heading_helper Ordergroup, :contact
-      %th.numeric= sort_link_helper heading_helper(Ordergroup, :account_balance), "account_balance", :per_page => @per_page
+      - FinancialTransactionClass.sorted.each do |c|
+        - name = FinancialTransactionClass.has_multiple_classes ? c.display : heading_helper(Ordergroup, :account_balance)
+        %th.numeric= sort_link_helper name, "sum_of_class_#{c.id}"
       %th
   %tbody
     - for ordergroup in @ordergroups
       %tr
         %td= ordergroup.name
         %td= ordergroup.contact
-        %td.numeric= number_to_currency(ordergroup.account_balance)
+        - FinancialTransactionClass.sorted.each do |c|
+          - amount = ordergroup["sum_of_class_#{c.id}"]
+          %td.numeric{:style => "color:#{amount < 0 ? 'red' : 'black'}"}
+            = number_to_currency amount
         %td
           = link_to t('.new_transaction'), new_finance_ordergroup_transaction_path(ordergroup), class: 'btn btn-mini'
           = link_to t('.account_statement'), finance_ordergroup_transactions_path(ordergroup), class: 'btn btn-mini'
-        

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -67,15 +67,24 @@
         %tr
           %th= heading_helper FinancialTransaction, :created_on
           %th= heading_helper FinancialTransaction, :user
+          - if FinancialTransactionType.has_multiple_types
+            %th= heading_helper FinancialTransaction, :financial_transaction_type
           %th= heading_helper FinancialTransaction, :note
-          %th= heading_helper FinancialTransaction, :amount
+          - FinancialTransactionClass.sorted.each do |fc|
+            %th
+              = fc.display
         - for ft in current_user.ordergroup.financial_transactions.limit(5).order('created_on DESC')
           %tr
             %td= format_time(ft.created_on)
             %td= h(show_user(ft.user))
+            - if FinancialTransactionType.has_multiple_types
+              %td= h(ft.financial_transaction_type.name)
             %td= h(ft.note)
             - color = ft.amount < 0 ? 'red' : 'black'
-            %td{:style => "color:#{color}; width:5em", :class => "currency"}= number_to_currency(ft.amount)
+            - FinancialTransactionClass.sorted.each do |fc|
+              %td{:style => "color:#{color}; width:5em", :class => "currency"}
+                - if ft.financial_transaction_type.financial_transaction_class == fc
+                  = number_to_currency(ft.amount)
 
 -# placeholder deface to add content using erb[silent]:contains()
 - '<dashboard_bottom_mark>'

--- a/app/views/home/ordergroup.html.haml
+++ b/app/views/home/ordergroup.html.haml
@@ -13,6 +13,11 @@
         %p
           %b= heading_helper(Ordergroup, :available_funds) + ':'
           = number_to_currency(@ordergroup.get_available_funds())
+      - if FinancialTransactionClass.has_multiple_classes
+        - FinancialTransactionClass.sorted.each do |c|
+          %p
+            %b= c.display + ':'
+            = number_to_currency(@ordergroup["sum_of_class_#{c.id}"])
       %p
         %b= heading_helper(Ordergroup, :user_tokens) + ':'
         = @ordergroup.memberships.map{|m| show_user m.user}.join(', ')

--- a/app/views/shared/alert.js.erb
+++ b/app/views/shared/alert.js.erb
@@ -1,0 +1,1 @@
+$('div.container-fluid').prepend('<%= bootstrap_flash_patched %>');

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1401,6 +1401,8 @@ de:
   model:
     delivery:
       each_stock_article_must_be_unique: Lieferung darf jeden Lagerartikel höchstens einmal auflisten.
+    financial_transaction_type:
+      no_delete_last: Es muss mindestens ein Finanztransaktionstyp existieren.
     group_order:
       stock_ordergroup_name: Lager (%{user})
     invoice:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -49,6 +49,11 @@ de:
         note: Notiz
         ordergroup: Bestellgruppe
         user: Eingetragen von
+      financial_transaction_class:
+        name: Name
+      financial_transaction_type:
+        name: Name
+        financial_transaction_class: Finanztransaktionsklasse
       group_order:
         price: Bestellsumme
         updated_by: Zuletzt bestellt
@@ -235,6 +240,8 @@ de:
       article_category: Kategorie
       delivery: Lieferung
       financial_transaction: Kontotransaktion
+      financial_transaction_class: Finanztransaktionsklasse
+      financial_transaction_type: Finanztransaktionstyp
       invoice: Rechnung
       message: Nachricht
       messagegroup: Nachrichtengruppe
@@ -289,6 +296,22 @@ de:
       update:
         notice: Einstellungen gespeichert.
     confirm: Bist Du sicher?
+    finances:
+      index:
+        first_paragraph: Hier kannst du die Finanztransaktionsklassen und die dazugehörigen Finanztransaktionstypen verwalten. Jede Finanztansaktion hat einen bestimmten Typ, den du bei jeder Transaktion auswählen muss, falls du mehr als einen Typ angelegt hast. Die Finanztransaktionsklassen können zur Gruppierung der Finanztransaktionstypen verwendet werden und werden in der Kontoübersicht als weitere Spalten angezeigt, falls mehrere angelegt wurden.
+        new_financial_transaction_class: Neue Finanztransaktionsklasse anlegen
+        title: Finanzen
+      transaction_types:
+        name: Name
+        new_financial_transaction_type: Neuen Finanztransaktionstyp anlegen
+    financial_transaction_classes:
+      form:
+        title_edit: Finanztransaktionsklasse bearbeiten
+        title_new: Finanztransaktionsklasse anlegen
+    financial_transaction_types:
+      form:
+        title_edit: Finanztransaktionstyp bearbeiten
+        title_new: Finanztransaktionstyp anlegen
     mail_delivery_status:
       destroy_all:
         notice: Alle E-Mail Probleme wurden gelöscht

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1418,6 +1418,7 @@ de:
   navigation:
     admin:
       config: Einstellungen
+      finance: Finanzen
       home: Übersicht
       mail_delivery_status: E-Mail Probleme
       messagegroups: Nachrichtengruppen

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -49,6 +49,11 @@ en:
         note: Note
         ordergroup: Ordergroup
         user: Entered by
+      financial_transaction_class:
+        name: Name
+      financial_transaction_type:
+        name: Name
+        financial_transaction_class: Financial transaction class
       group_order:
         price: Order sum
         updated_by: Last ordered by
@@ -235,6 +240,8 @@ en:
       article_category: Category
       delivery: Delivery
       financial_transaction: Financial transaction
+      financial_transaction_class: Financial transaction class
+      financial_transaction_type: Financial transaction type
       invoice: Invoice
       message: Message
       messagegroup: Message group
@@ -291,6 +298,22 @@ en:
       update:
         notice: Configuration saved.
     confirm: Are you sure?
+    finances:
+      index:
+        first_paragraph: Here you can manage the financial transaction classes and the corresponding financial transaction types. Every financial transaction has a type, which you have to select at every transaction, if you created more than one type. The financial transaction classes can be use to group the financial transaction types and will be shown as additional columns in the account overview, if there have been created more than one.
+        new_financial_transaction_class: Add new financial transaction class
+        title: Finances
+      transaction_types:
+        name: Name
+        new_financial_transaction_type: Add new financial transaction type
+    financial_transaction_classes:
+      form:
+        title_edit: Edit financial transaction class
+        title_new: Add new financial transaction class
+    financial_transaction_types:
+      form:
+        title_edit: Edit financial transaction type
+        title_new: Add new financial transaction type
     mail_delivery_status:
       destroy_all:
         notice: All email problems were deleted

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1411,6 +1411,8 @@ en:
   model:
     delivery:
       each_stock_article_must_be_unique: Each stock article must not be listed more than once.
+    financial_transaction_type:
+      no_delete_last: At least one financial transaction type must exist.
     group_order:
       stock_ordergroup_name: Stock (%{user})
     invoice:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1428,6 +1428,7 @@ en:
   navigation:
     admin:
       config: Configuration
+      finance: Finances
       home: Overview
       mail_delivery_status: Email problems
       messagegroups: Message groups

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1416,6 +1416,7 @@ fr:
   navigation:
     admin:
       config: Configuration
+      finance: Trésorerie
       home: Aperçu
       mail_delivery_status: 
       messagegroups: 

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -1418,6 +1418,7 @@ nl:
   navigation:
     admin:
       config: Instellingen
+      finance: Financiën
       home: Overzicht
       mail_delivery_status: Emailproblemen
       messagegroups: Berichtengroepen

--- a/config/navigation.rb
+++ b/config/navigation.rb
@@ -46,6 +46,7 @@ SimpleNavigation::Configuration.run do |navigation|
       subnav.item :ordergroups, I18n.t('navigation.admin.ordergroups'), admin_ordergroups_path
       subnav.item :workgroups, I18n.t('navigation.admin.workgroups'), admin_workgroups_path
       subnav.item :mail_delivery_status, I18n.t('navigation.admin.mail_delivery_status'), admin_mail_delivery_status_index_path
+      subnav.item :finances, I18n.t('navigation.admin.finance'), admin_finances_path
       subnav.item :config, I18n.t('navigation.admin.config'), admin_config_path
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -179,6 +179,13 @@ Foodsoft::Application.routes.draw do
     namespace :admin do
       root to: 'base#index'
 
+      resources :finances, only: [:index] do
+        get :update_transaction_types, on: :collection
+      end
+
+      resources :financial_transaction_classes
+      resources :financial_transaction_types
+
       resources :users do
         post :restore, on: :member
         post :sudo, on: :member

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -149,7 +149,7 @@ Foodsoft::Application.routes.draw do
           put :update_note
 
           get :confirm
-          patch :close
+          post :close
           patch :close_direct
 
           get :new_on_order_article_create

--- a/db/migrate/20160219123220_create_financial_transaction_class_and_types.rb
+++ b/db/migrate/20160219123220_create_financial_transaction_class_and_types.rb
@@ -1,0 +1,26 @@
+class CreateFinancialTransactionClassAndTypes < ActiveRecord::Migration
+  def change
+    create_table :financial_transaction_classes do |t|
+      t.string :name, :null => false
+    end
+
+    create_table :financial_transaction_types do |t|
+      t.string :name, :null => false
+      t.references :financial_transaction_class, :null => false
+    end
+
+    change_table :financial_transactions do |t|
+      t.references :financial_transaction_type
+    end
+
+    reversible do |dir|
+      dir.up do
+        execute "INSERT INTO financial_transaction_classes (id, name) VALUES (1, 'Standard')"
+        execute "INSERT INTO financial_transaction_types (id, name, financial_transaction_class_id) VALUES (1, 'Foodsoft', 1)"
+        execute "UPDATE financial_transactions SET financial_transaction_type_id = 1"
+      end
+    end
+
+    change_column_null :financial_transactions, :financial_transaction_type_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -92,13 +92,23 @@ ActiveRecord::Schema.define(version: 20171110000000) do
     t.text "note"
   end
 
+  create_table "financial_transaction_classes", force: :cascade do |t|
+    t.string "name", null: false
+  end
+
+  create_table "financial_transaction_types", force: :cascade do |t|
+    t.string  "name",                           null: false
+    t.integer "financial_transaction_class_id", null: false
+  end
+
   create_table "financial_transactions", force: :cascade do |t|
-    t.integer  "ordergroup_id",     limit: 4,                             default: 0, null: false
-    t.decimal  "amount",                          precision: 8, scale: 2, default: 0, null: false
-    t.text     "note",              limit: 65535,                                     null: false
-    t.integer  "user_id",           limit: 4,                             default: 0, null: false
-    t.datetime "created_on",                                                          null: false
+    t.integer  "ordergroup_id",                 limit: 4,                             default: 0, null: false
+    t.decimal  "amount",                                      precision: 8, scale: 2, default: 0, null: false
+    t.text     "note",                          limit: 65535,                                     null: false
+    t.integer  "user_id",                       limit: 4,                             default: 0, null: false
+    t.datetime "created_on",                                                                      null: false
     t.integer  "financial_link_id"
+    t.integer  "financial_transaction_type_id",                                                   null: false
   end
 
   add_index "financial_transactions", ["ordergroup_id"], name: "index_financial_transactions_on_ordergroup_id", using: :btree

--- a/db/seeds/minimal.seeds.rb
+++ b/db/seeds/minimal.seeds.rb
@@ -21,5 +21,9 @@ User.create(
     :groups => [administrators]
 )
 
+# First entry for financial transaction types
+financial_transaction_class = FinancialTransactionClass.create(:name => "Other")
+FinancialTransactionType.create(:name => "Foodcoop", :financial_transaction_class_id => financial_transaction_class.id)
+
 # First entry for article categories
 ArticleCategory.create(:name => "Other", :description => "other, misc, unknown")

--- a/db/seeds/small.en.seeds.rb
+++ b/db/seeds/small.en.seeds.rb
@@ -178,8 +178,12 @@ seed_group_orders
 
 ## Finances
 
-FinancialTransaction.create(:id => 1, :ordergroup_id => 5, :amount => -0.35E2, :note => "Membership fee for ordergroup", :user_id => 0, :created_on => 'Sat, 18 Jan 2014 00:38:48 UTC +00:00')
-FinancialTransaction.create(:id => 3, :ordergroup_id => 6, :amount => -0.35E2, :note => "Membership fee for ordergroup", :user_id => 0, :created_on => 'Sat, 25 Jan 2014 20:20:37 UTC +00:00')
-FinancialTransaction.create(:id => 4, :ordergroup_id => 7, :amount => -0.35E2, :note => "Membership fee for ordergroup", :user_id => 0, :created_on => 'Mon, 27 Jan 2014 16:22:14 UTC +00:00')
-FinancialTransaction.create(:id => 5, :ordergroup_id => 5, :amount => 0.35E2, :note => "iDEAL payment", :user_id => 1, :created_on => 'Wed, 05 Feb 2014 16:49:24 UTC +00:00')
-FinancialTransaction.create(:id => 6, :ordergroup_id => 8, :amount => 0.90E2, :note => "Bank transfer", :user_id => 2, :created_on => 'Mon, 17 Feb 2014 16:19:34 UTC +00:00')
+FinancialTransactionClass.create(:id => 1, :name => "Other")
+
+FinancialTransactionType.create(:id => 1, :name => "Foodcoop", :financial_transaction_class_id => 1)
+
+FinancialTransaction.create(:id => 1, :ordergroup_id => 5, :amount => -0.35E2, :note => "Membership fee for ordergroup", :user_id => 0, :created_on => 'Sat, 18 Jan 2014 00:38:48 UTC +00:00', :financial_transaction_type_id => 1)
+FinancialTransaction.create(:id => 3, :ordergroup_id => 6, :amount => -0.35E2, :note => "Membership fee for ordergroup", :user_id => 0, :created_on => 'Sat, 25 Jan 2014 20:20:37 UTC +00:00', :financial_transaction_type_id => 1)
+FinancialTransaction.create(:id => 4, :ordergroup_id => 7, :amount => -0.35E2, :note => "Membership fee for ordergroup", :user_id => 0, :created_on => 'Mon, 27 Jan 2014 16:22:14 UTC +00:00', :financial_transaction_type_id => 1)
+FinancialTransaction.create(:id => 5, :ordergroup_id => 5, :amount => 0.35E2, :note => "iDEAL payment", :user_id => 1, :created_on => 'Wed, 05 Feb 2014 16:49:24 UTC +00:00', :financial_transaction_type_id => 1)
+FinancialTransaction.create(:id => 6, :ordergroup_id => 8, :amount => 0.90E2, :note => "Bank transfer", :user_id => 2, :created_on => 'Mon, 17 Feb 2014 16:19:34 UTC +00:00', :financial_transaction_type_id => 1)

--- a/db/seeds/small.nl.seeds.rb
+++ b/db/seeds/small.nl.seeds.rb
@@ -178,8 +178,12 @@ seed_group_orders
 
 ## Finances
 
-FinancialTransaction.create(:id => 1, :ordergroup_id => 5, :amount => -0.35E2, :note => "Membership fee for ordergroup", :user_id => 0, :created_on => 'Sat, 18 Jan 2014 00:38:48 UTC +00:00')
-FinancialTransaction.create(:id => 3, :ordergroup_id => 6, :amount => -0.35E2, :note => "Membership fee for ordergroup", :user_id => 0, :created_on => 'Sat, 25 Jan 2014 20:20:37 UTC +00:00')
-FinancialTransaction.create(:id => 4, :ordergroup_id => 7, :amount => -0.35E2, :note => "Membership fee for ordergroup", :user_id => 0, :created_on => 'Mon, 27 Jan 2014 16:22:14 UTC +00:00')
-FinancialTransaction.create(:id => 5, :ordergroup_id => 5, :amount => 0.35E2, :note => "iDEAL payment", :user_id => 1, :created_on => 'Wed, 05 Feb 2014 16:49:24 UTC +00:00')
-FinancialTransaction.create(:id => 6, :ordergroup_id => 8, :amount => 0.90E2, :note => "Bank transfer", :user_id => 2, :created_on => 'Mon, 17 Feb 2014 16:19:34 UTC +00:00')
+FinancialTransactionClass.create(:id => 1, :name => "Other")
+
+FinancialTransactionType.create(:id => 1, :name => "Foodcoop", :financial_transaction_class_id => 1)
+
+FinancialTransaction.create(:id => 1, :ordergroup_id => 5, :amount => -0.35E2, :note => "Membership fee for ordergroup", :user_id => 0, :created_on => 'Sat, 18 Jan 2014 00:38:48 UTC +00:00', :financial_transaction_type_id => 1)
+FinancialTransaction.create(:id => 3, :ordergroup_id => 6, :amount => -0.35E2, :note => "Membership fee for ordergroup", :user_id => 0, :created_on => 'Sat, 25 Jan 2014 20:20:37 UTC +00:00', :financial_transaction_type_id => 1)
+FinancialTransaction.create(:id => 4, :ordergroup_id => 7, :amount => -0.35E2, :note => "Membership fee for ordergroup", :user_id => 0, :created_on => 'Mon, 27 Jan 2014 16:22:14 UTC +00:00', :financial_transaction_type_id => 1)
+FinancialTransaction.create(:id => 5, :ordergroup_id => 5, :amount => 0.35E2, :note => "iDEAL payment", :user_id => 1, :created_on => 'Wed, 05 Feb 2014 16:49:24 UTC +00:00', :financial_transaction_type_id => 1)
+FinancialTransaction.create(:id => 6, :ordergroup_id => 8, :amount => 0.90E2, :note => "Bank transfer", :user_id => 2, :created_on => 'Mon, 17 Feb 2014 16:19:34 UTC +00:00', :financial_transaction_type_id => 1)

--- a/spec/factories/financial_transaction_type.rb
+++ b/spec/factories/financial_transaction_type.rb
@@ -1,0 +1,14 @@
+require 'factory_bot'
+
+FactoryBot.define do
+
+  factory :financial_transaction_class do
+    sequence(:name) { |n| Faker::Lorem.characters(rand(2..12)) + " ##{n}" }
+  end
+
+  factory :financial_transaction_type do
+    financial_transaction_class
+    sequence(:name) { |n| Faker::Lorem.words(rand(2..4)).join(' ') + " ##{n}" }
+  end
+
+end

--- a/spec/integration/balancing_spec.rb
+++ b/spec/integration/balancing_spec.rb
@@ -1,6 +1,7 @@
 require_relative '../spec_helper'
 
 feature 'settling an order', js: true do
+  let(:ftt) { create :financial_transaction_type }
   let(:admin) { create :user, groups:[create(:workgroup, role_finance: true)] }
   let(:user) { create :user, groups:[create(:ordergroup)] }
   let(:supplier) { create :supplier }

--- a/spec/integration/product_distribution_example_spec.rb
+++ b/spec/integration/product_distribution_example_spec.rb
@@ -1,6 +1,7 @@
 require_relative '../spec_helper'
 
 feature 'product distribution', js: true do
+  let(:ftt) { create :financial_transaction_type }
   let(:admin) { create :admin }
   let(:user_a) { create :user, groups: [create(:ordergroup)] }
   let(:user_b) { create :user, groups: [create(:ordergroup)] }
@@ -13,7 +14,7 @@ feature 'product distribution', js: true do
     # make sure users have enough money to order
     [user_a, user_b].each do |user|
       ordergroup = Ordergroup.find(user.ordergroup.id)
-      ordergroup.add_financial_transaction! 5000, 'for ordering', admin
+      ordergroup.add_financial_transaction! 5000, 'for ordering', admin, ftt
     end
     order # make sure order is referenced
   end

--- a/spec/models/ordergroup_spec.rb
+++ b/spec/models/ordergroup_spec.rb
@@ -1,0 +1,30 @@
+require_relative '../spec_helper'
+
+describe Ordergroup do
+  let(:ftc1) { create :financial_transaction_class }
+  let(:ftc2) { create :financial_transaction_class }
+  let(:ftt1) { create :financial_transaction_type, financial_transaction_class: ftc1 }
+  let(:ftt2) { create :financial_transaction_type, financial_transaction_class: ftc2 }
+  let(:ftt3) { create :financial_transaction_type, financial_transaction_class: ftc2 }
+  let(:user) { create :user, groups:[create(:ordergroup)] }
+
+  it 'has correct FinancialTransactionClass sums' do
+    og = user.ordergroup
+    og.add_financial_transaction!(-1, '-1', user, ftt1)
+    og.add_financial_transaction!(2, '2', user, ftt1)
+    og.add_financial_transaction!(3, '3', user, ftt1)
+
+    og.add_financial_transaction!(-10, '-10', user, ftt2)
+    og.add_financial_transaction!(20, '20', user, ftt2)
+    og.add_financial_transaction!(30, '30', user, ftt2)
+
+    og.add_financial_transaction!(-100, '-100', user, ftt3)
+    og.add_financial_transaction!(200, '200', user, ftt3)
+    og.add_financial_transaction!(300, '300', user, ftt3)
+
+    result = Ordergroup.include_transaction_class_sum.where(id: og).first
+    expect(result["sum_of_class_#{ftc1.id}"]).to eq 4
+    expect(result["sum_of_class_#{ftc2.id}"]).to eq 440
+  end
+
+end


### PR DESCRIPTION
This change introduces two new data types to group the financial
transactions. Now every transaction has a "type", which itself belongs
to a "class".
Types should be used add structured information to an transaction, instead
of writing it into the notice textfield. E.g. this could be used to have
different types depending on the source of money (cash vs. bank transfer).
Classes are shown as different columns in the tables and will be uses to
group transactions of specific types. They should be used if not the whole
amount of ordergroup should be used to order fodd. E.g. if there is a
deposit or membership fee, which is independent of the normal credit.
This will allow us to implement additional features based on classes in
the future. E.g. the sum of transactions in the "membership fee" class
must be positive to allow food orders or show a big warning if it is bellow
a certain value.
