### PR TITLE
Add more infos to the invoice page

### DIFF
--- a/app/models/delivery.rb
+++ b/app/models/delivery.rb
@@ -20,7 +20,24 @@ class Delivery < ActiveRecord::Base
   def includes_article?(article)
     self.stock_changes.map{|stock_change| stock_change.stock_article.id}.include? article.id
   end
-  
+
+  def sum(type = :gross)
+    total = 0
+    for sc in stock_changes
+      article = sc.stock_article
+      quantity = sc.quantity
+      case type
+        when :net
+          total += quantity * article.price
+        when :gross
+          total += quantity * article.gross_price
+        when :fc
+          total += quantity * article.fc_price
+      end
+    end
+    total
+  end
+
   protected
   
   def stock_articles_must_be_unique

--- a/app/views/finance/invoices/show.html.haml
+++ b/app/views/finance/invoices/show.html.haml
@@ -1,5 +1,7 @@
 - title t('.title', number: @invoice.number)
 
+- total = 0
+
 %p
   %b= heading_helper(Invoice, :created_at) + ':'
   = format_time(@invoice.created_at)
@@ -15,15 +17,21 @@
     %b= heading_helper(Invoice, :deliveries) + ':'
     %span><
       - @invoice.deliveries.order(:delivered_on).each_with_index do |delivery, index|
+        - sum = delivery.sum
+        - total += sum
         = ', ' if index > 0
         = link_to format_date(delivery.delivered_on), [delivery.supplier,delivery]
+        = ' (' + number_to_currency(sum) + ')'
 - if @invoice.orders.any?
   %p
     %b= heading_helper(Invoice, :orders) + ':'
     %span><
       - @invoice.orders.order(:ends).each_with_index do |order, index|
+        - sum = order.sum
+        - total += sum
         = ', ' if index > 0
         = link_to format_date(order.ends), new_finance_order_path(order_id: order)
+        = ' (' + number_to_currency(sum) + ')'
 
 %p
   %b= heading_helper(Invoice, :number) + ':'
@@ -43,6 +51,13 @@
 %p
   %b= heading_helper(Invoice, :deposit_credit) + ':'
   = number_to_currency @invoice.deposit_credit
+%p
+  %b= heading_helper(Invoice, :net_amount) + ':'
+  = number_to_currency @invoice.net_amount
+- if @invoice.deliveries.any? || @invoice.orders.any?
+  %p
+    %b= heading_helper(Invoice, :total) + ':'
+    = number_to_currency total
 %p
   %b= heading_helper(Invoice, :note) + ':'
   =h @invoice.note

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -60,6 +60,7 @@ de:
         deliveries: Lieferung
         deposit: Pfand berechnet
         deposit_credit: Pfand gutgeschrieben
+        net_amount: Pfandbereinigter Betrag
         note: Notiz
         number: Nummer
         orders: Bestellung

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -60,6 +60,7 @@ en:
         deliveries: Delivery
         deposit: Deposit charged
         deposit_credit: Deposit returned
+        net_amount: Amount adjusted for refund
         note: Note
         number: Number
         orders: Order

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -60,6 +60,7 @@ fr:
         deliveries: Réapprovisionnement
         deposit: Consigne facturée
         deposit_credit: Consigne remboursée
+        net_amount: Montant recalculé en excluant les consignes
         note: Note
         number: Numéro
         orders: Commande

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -60,6 +60,7 @@ nl:
         deliveries: Levering
         deposit: Statiegeld in rekening gebracht
         deposit_credit: Statiegeld teruggekregen
+        net_amount: Bedrag gecorrigeerd voor statiegeld
         note: Notitie
         number: Nummer
         orders: Bestelling


### PR DESCRIPTION
When a foodcoop does not use the balancing feature the invoice page is
the main page for informations. Add all related information to it, so
people do not need to open the balancing page.