### PR TITLE
Add config option to disable the invites

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -132,7 +132,13 @@ class ApplicationController < ActionController::Base
   #
   def require_plugin_enabled(plugin)
     unless plugin.enabled?
-      redirect_to root_path, alert: I18n.t('application.controller.error_plugin_disabled')
+      redirect_to root_path, alert: I18n.t('application.controller.error_feature_disabled')
+    end
+  end
+
+  def require_config_disabled(config)
+    if FoodsoftConfig[config]
+      redirect_to root_path, alert: I18n.t('application.controller.error_feature_disabled')
     end
   end
 

--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -1,6 +1,7 @@
 class InvitesController < ApplicationController
 
   before_filter :authenticate_membership_or_admin_for_invites
+  before_filter -> { require_config_disabled :disable_invite }
   
   def new
     @invite = Invite.new(:user => @current_user, :group => @group)

--- a/app/views/admin/configs/_tab_others.html.haml
+++ b/app/views/admin/configs/_tab_others.html.haml
@@ -2,5 +2,6 @@
   = config_input form, :use_wiki, as: :boolean
 = config_input form, :use_nick, as: :boolean
 = config_input form, :tolerance_is_costly, as: :boolean
+= config_input form, :disable_invite, as: :boolean
 = config_input form, :help_url, as: :url, input_html: {class: 'input-xlarge'}
 = config_input form, :webstats_tracking_code, as: :text, input_html: {class: 'input-xxlarge', rows: 3}

--- a/app/views/admin/ordergroups/_form.html.haml
+++ b/app/views/admin/ordergroups/_form.html.haml
@@ -1,4 +1,4 @@
-- unless @ordergroup.new_record?
+- unless @ordergroup.new_record? || FoodsoftConfig[:disable_invite]
   %p= t('.first_paragraph', url: link_to(t('.here'), new_invite_path(id: @ordergroup.id), remote: true)).html_safe
 = simple_form_for [:admin, @ordergroup] do |f|
   - captured = capture do

--- a/app/views/admin/workgroups/_form.html.haml
+++ b/app/views/admin/workgroups/_form.html.haml
@@ -1,4 +1,5 @@
-%p= t('.first_paragraph', url: link_to(t('.here'), new_invite_path(id: @workgroup.id), remote: true)).html_safe
+- unless FoodsoftConfig[:disable_invite]
+  %p= t('.first_paragraph', url: link_to(t('.here'), new_invite_path(id: @workgroup.id), remote: true)).html_safe
 = simple_form_for [:admin, @workgroup] do |f|
   - captured = capture do
     %h4= t 'admin.access_to'

--- a/app/views/foodcoop/workgroups/edit.html.haml
+++ b/app/views/foodcoop/workgroups/edit.html.haml
@@ -1,6 +1,7 @@
 - title t('.title')
 
-%p= t('.invite_new', invite_link: link_to(t('.invite_link'), new_invite_path(id: @workgroup.id))).html_safe
+- unless FoodsoftConfig[:disable_invite]
+  %p= t('.invite_new', invite_link: link_to(t('.invite_link'), new_invite_path(id: @workgroup.id))).html_safe
 = simple_form_for [:foodcoop, @workgroup] do |f|
   = render 'shared/group_form_fields', f: f
   .form-actions

--- a/app/views/home/ordergroup.html.haml
+++ b/app/views/home/ordergroup.html.haml
@@ -12,7 +12,8 @@
       %p
         %b= heading_helper(Ordergroup, :user_tokens) + ':'
         = @ordergroup.memberships.map{|m| show_user m.user}.join(', ')
-      = link_to t('.invite'), new_invite_path(:id => @ordergroup), :remote => true, class: 'btn btn-primary'
+      - unless FoodsoftConfig[:disable_invite]
+        = link_to t('.invite'), new_invite_path(:id => @ordergroup), :remote => true, class: 'btn btn-primary'
   .span8
     %h2= t('.account_summary')
     .well.well-small

--- a/app/views/home/profile.html.haml
+++ b/app/views/home/profile.html.haml
@@ -22,8 +22,9 @@
             - else
               = @current_user.ordergroup.name
           %td.right
-            = link_to t('.groups.invite'), new_invite_path(id: @current_user.ordergroup),
-                      remote: true, class: 'btn btn-success btn-small'
+            - unless FoodsoftConfig[:disable_invite]
+              = link_to t('.groups.invite'), new_invite_path(id: @current_user.ordergroup),
+                        remote: true, class: 'btn btn-success btn-small'
     - if @current_user.workgroups.any?
       %h3= User.human_attribute_name(:workgroup, count: 2)
       %table.table.table-striped

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -327,8 +327,8 @@ de:
       error_authn: Anmeldung erforderlich!
       error_denied: Du darfst die gewünschte Seite nicht sehen. Wenn Du denkst, dass Du dürfen solltest, frage eine/n Administrator/in, dass sie/er Dir die entsprechenden Rechte einräumt. Falls Du Zugang zu mehreren Benutzerkonten hast, möchtest Du Dich vielleicht %{sign_in}.
       error_denied_sign_in: als ein anderer Benutzer anmelden
+      error_feature_disabled: Diese Funktion ist derzeit nicht aktiviert.
       error_members_only: Diese Aktion ist nur für Mitglieder der Gruppe erlaubt!
-      error_plugin_disabled: Diese Funktion ist derzeit nicht aktiviert.
       error_token: Zugriff verweigert (ungültiger Token)!
   article_categories:
     create:
@@ -517,6 +517,7 @@ de:
       currency_unit: Währung
       custom_css: Angepasstes CSS
       default_locale: Standardsprache
+      disable_invite: Einladungen deaktivieren
       email_from: Absenderadresse
       email_replyto: Antwortadresse
       email_sender: Senderadresse

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -332,8 +332,8 @@ en:
       error_authn: Authentication required!
       error_denied: You are not allowed to view the requested page. If you think you should, ask an administrator to give you appropriate permissions. If you have access to multiple user accounts, you might want to %{sign_in}.
       error_denied_sign_in: sign in as another user
+      error_feature_disabled: This feature is currently disabled.
       error_members_only: This action is only available to members of the group!
-      error_plugin_disabled: This feature is currently disabled.
       error_token: Access denied (invalid token)!
   article_categories:
     create:
@@ -526,6 +526,7 @@ en:
       currency_unit: Currency
       custom_css: Custom CSS
       default_locale: Default language
+      disable_invite: Disable invites
       email_from: From address
       email_replyto: Reply-to address
       email_sender: Sender address

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -322,8 +322,8 @@ fr:
       error_authn: Identification requise!
       error_denied: Ton compte n'es pas autorisé à accéder à cette page pour le moment. Si tu penses que ce n'est pas normal, demande à un-e administrateur-rice de modifier les permissions. Si tu as plusieurs comptes, il faut peut-être que tu %{sign_in}
       error_denied_sign_in: te reconnectes
+      error_feature_disabled: Cette fonction est désactivée.
       error_members_only: Cette action ne peut être effectuée que par les membres du groupe.
-      error_plugin_disabled: Cette fonction est désactivée.
       error_token: Accès interdit (jeton invalide)!
   article_categories:
     create:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -322,8 +322,8 @@ nl:
       error_authn: Inloggen vereist.
       error_denied: Je hebt geen toegang tot de gevraagde pagina. Als je denkt dat je dat wel zou moeten hebben, vraag dan een beheerder je die rechten te geven. Als je meerdere accounts hebt, wil je mogelijk %{sign_in}.
       error_denied_sign_in: inloggen als een andere gebruiker
+      error_feature_disabled: Deze optie is momenteel uitgeschakeld.
       error_members_only: Deze actie is alleen beschikbaar voor leden van de groep!
-      error_plugin_disabled: Deze optie is momenteel uitgeschakeld.
       error_token: Geen toegang (ongeldig token)!
   article_categories:
     create:


### PR DESCRIPTION
Some foodcoops require that an admin adds all users to have more control
over the users.