### PR TITLE
Add option to show account balance instead of available funds

### DIFF
--- a/app/models/group_order.rb
+++ b/app/models/group_order.rb
@@ -22,6 +22,7 @@ class GroupOrder < ActiveRecord::Base
   # Generate some data for the javascript methods in ordering view
   def load_data
     data = {}
+    data[:account_balance] = ordergroup.account_balance
     data[:available_funds] = ordergroup.nil? ? BigDecimal.new('+Infinity') : ordergroup.get_available_funds(self)
 
     # load prices and other stuff....

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -259,7 +259,7 @@ class Order < ActiveRecord::Base
   # Close the order directly, without automaticly updating ordergroups account balances
   def close_direct!(user)
     raise I18n.t('orders.model.error_closed') if closed?
-    comments.create(user: user, text: I18n.t('orders.model.close_direct_message'))
+    comments.create(user: user, text: I18n.t('orders.model.close_direct_message')) unless FoodsoftConfig[:charge_members_manually]
     update_attributes! state: 'closed', updated_by: user
   end
 

--- a/app/views/admin/configs/_tab_payment.html.haml
+++ b/app/views/admin/configs/_tab_payment.html.haml
@@ -10,6 +10,7 @@
   .input-prepend
     %span.add-on= t 'number.currency.format.unit'
     = config_input_field form, :minimum_balance, as: :decimal, class: 'input-small'
+= config_input form, :charge_members_manually, as: :boolean
 = config_input form, :use_iban, as: :boolean
 
 %h4= t '.schedule_title'

--- a/app/views/finance/balancing/new.html.haml
+++ b/app/views/finance/balancing/new.html.haml
@@ -53,13 +53,16 @@
       class: 'btn'
   .btn-group
     - unless @order.closed?
-      = link_to t('.confirm_order'), confirm_finance_order_path(@order), class: 'btn btn-primary'
-      = link_to '#', data: {toggle: 'dropdown'}, class: 'btn dropdown-toggle' do
-        %span.caret
-      %ul.dropdown-menu
-        %li= link_to t('.confirm_order'), confirm_finance_order_path(@order)
-        %li= link_to t('.close_direct'), close_direct_finance_order_path(@order), method: :patch,
-          data: {confirm: t('.close_direct_confirm')}
+      - if FoodsoftConfig[:charge_members_manually]
+        = link_to t('.confirm_order'), close_direct_finance_order_path(@order), class: 'btn btn-primary', method: :patch
+      - else
+        = link_to t('.confirm_order'), confirm_finance_order_path(@order), class: 'btn btn-primary'
+        = link_to '#', data: {toggle: 'dropdown'}, class: 'btn dropdown-toggle' do
+          %span.caret
+        %ul.dropdown-menu
+          %li= link_to t('.confirm_order'), confirm_finance_order_path(@order)
+          %li= link_to t('.close_direct'), close_direct_finance_order_path(@order), method: :patch,
+            data: {confirm: t('.close_direct_confirm')}
 
   #editOrderNav.btn-group
     = link_to '#', data: {toggle: 'dropdown'}, class: 'btn dropdown-toggle' do

--- a/app/views/group_orders/_form.html.haml
+++ b/app/views/group_orders/_form.html.haml
@@ -1,8 +1,9 @@
 - content_for :javascript do
+  - group_balance = FoodsoftConfig[:charge_members_manually] ? @ordering_data[:account_balance] : @ordering_data[:available_funds]
   :javascript
     $(function() {
       #{data_to_js(@ordering_data)}
-      setGroupBalance(#{@ordering_data[:available_funds]});
+      setGroupBalance(#{group_balance});
       setMinimumBalance(#{FoodsoftConfig[:minimum_balance] or 0});
       setToleranceBehaviour(#{FoodsoftConfig[:tolerance_is_costly]});
       setStockit(#{@order.stockit?});
@@ -45,8 +46,11 @@
         %dd
           = show_user(@group_order.updated_by)
           (#{format_time(@group_order.updated_on)})
-      %dt= heading_helper Ordergroup, :available_funds
-      %dd= number_to_currency(@ordering_data[:available_funds])
+      %dt= heading_helper Ordergroup, :account_balance
+      %dd= number_to_currency(@ordering_data[:account_balance])
+      - unless FoodsoftConfig[:charge_members_manually]
+        %dt= heading_helper Ordergroup, :available_funds
+        %dd= number_to_currency(@ordering_data[:available_funds])
 
   .well.pull-right
     = close_button :alert
@@ -156,13 +160,19 @@
           %td.currency
             %span#total_price= number_to_currency(@group_order.price)
         %tr
-          %td= heading_helper(Ordergroup, :available_funds) + ':'
-          %td.currency= number_to_currency(@ordering_data[:available_funds])
+          - if FoodsoftConfig[:charge_members_manually]
+            - old_balance = @ordering_data[:account_balance]
+            %td= heading_helper(Ordergroup, :account_balance) + ':'
+            %td.currency= number_to_currency(@ordering_data[:account_balance])
+          - else
+            - old_balance = @ordering_data[:available_funds]
+            %td= heading_helper(Ordergroup, :available_funds) + ':'
+            %td.currency= number_to_currency(@ordering_data[:available_funds])
         %tr
           %td= t('.new_funds') + ':'
           %td.currency
             %strong
-              %span#new_balance= number_to_currency(@ordering_data[:available_funds] - @group_order.price)
+              %span#new_balance= number_to_currency(old_balance - @group_order.price)
       #order-button
         = submit_tag( t('.action_save'), id: 'submit_button', class: 'btn btn-primary' )
         #{link_to t('ui.or_cancel'), group_orders_path}

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -45,8 +45,13 @@
     %h2= t '.my_ordergroup.title'
     %p
       %b= current_user.ordergroup.name
-      = t '.my_ordergroup.funds'
-      = number_to_currency(current_user.ordergroup.get_available_funds)
+      = ' | '
+      - if FoodsoftConfig[:charge_members_manually]
+        = heading_helper(Ordergroup, :account_balance) + ':'
+        = number_to_currency(current_user.ordergroup.account_balance)
+      - else
+        = heading_helper(Ordergroup, :available_funds) + ':'
+        = number_to_currency(current_user.ordergroup.get_available_funds)
       %small= t '.my_ordergroup.last_update', when: distance_of_time_in_words(Time.now, current_user.ordergroup.account_updated)
       %h3= t '.my_ordergroup.transactions.title'
       %table.table.table-striped

--- a/app/views/home/ordergroup.html.haml
+++ b/app/views/home/ordergroup.html.haml
@@ -7,8 +7,12 @@
       - unless @ordergroup.description.blank?
         %p= @ordergroup.description
       %p
-        %b= heading_helper(Ordergroup, :available_funds) + ':'
-        = number_to_currency(@ordergroup.get_available_funds())
+        %b= heading_helper(Ordergroup, :account_balance) + ':'
+        = number_to_currency(@ordergroup.account_balance)
+      - unless FoodsoftConfig[:charge_members_manually]
+        %p
+          %b= heading_helper(Ordergroup, :available_funds) + ':'
+          = number_to_currency(@ordergroup.get_available_funds())
       %p
         %b= heading_helper(Ordergroup, :user_tokens) + ':'
         = @ordergroup.memberships.map{|m| show_user m.user}.join(', ')

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -487,6 +487,7 @@ de:
   config:
     hints:
       applepear_url: Seite, auf der das Äpfel- und Birnensystem für Aufgaben erklärt wird.
+      charge_members_manually: Wann die Aufzeichnungen über was wer bekommen hat wo anders (z.B. auf Papier) geführt werden und nicht in die Foosoft eingetragen werden, sollte diese Option aktiviert werden. Die Abrechnung muss dann manuell (mittels "Neue Überweisungen eingeben") eingetragen werden. Bestellungen müssen nach wie vor abgerechnet werden, aber das belastet nicht die Konten der Mitglieder.
       contact:
         email: E-Mail Adresse zur allgemeinen Kontaktaufnahme, die auf der Webseite und in einigen Formularen gezeigt wird.
         street: Anschrift; üblicherweise ist dies Euer Liefer- und Abholort.
@@ -534,6 +535,7 @@ de:
       webstats_tracking_code: Tracking Code für Webseitenanalyse (wie Piwik oder Google Analytics), leer lassen wenn keine Analyse erfolgt
     keys:
       applepear_url: Hilfe URL für das Äpfel Punktesystem zum Engagement
+      charge_members_manually: Mitglieder manuell abrechnen
       contact:
         city: Stadt
         country: Land
@@ -1053,7 +1055,6 @@ de:
           text: "%{messages} oder %{threads} anzeigen"
           threads: Nachrichtenverläufe
       my_ordergroup:
-        funds: "| Verfügbares Guthaben:"
         last_update: Letzte Aktualisierung vor %{when}
         title: Meine Bestellgruppe
         transactions:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -489,6 +489,7 @@ en:
   config:
     hints:
       applepear_url: Website where the apple and pear system for tasks is explained.
+      charge_members_manually: When you keep track of who received what elsewhere (e.g. on paper), and you don't want to enter this into Foodsoft, select this. You'll need to charge member accounts manually (using "Add new transactions"). You still need to settle orders in the balancing screen, but this will not charge any member accounts.
       contact:
         email: General contact email address, shown on website as well as some forms.
         street: Address, typically this will be your delivery and pick-up location.
@@ -536,6 +537,7 @@ en:
       webstats_tracking_code: Tracking code for web analytics (like Piwik or Google analytics). Leave empty for no tracking.
     keys:
       applepear_url: Apple system help URL
+      charge_members_manually: Charge members manually
       contact:
         city: City
         country: Country
@@ -1055,7 +1057,6 @@ en:
           text: Show %{messages} or %{threads}
           threads: threads
       my_ordergroup:
-        funds: "| Available Credit:"
         last_update: Last update was %{when} ago
         title: My ordergroup
         transactions:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1056,7 +1056,6 @@ fr:
           text: Afficher %{messages} ou %{threads}
           threads: 
       my_ordergroup:
-        funds: "| Crédit disponible:"
         last_update: La dernière mise à jour date du %{when}
         title: Ta cellule
         transactions:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -1047,7 +1047,6 @@ nl:
           text: "%{messages} of %{threads} bekijken"
           threads: conversaties
       my_ordergroup:
-        funds: "| Beschikbaar tegoed:"
         last_update: Laatst gewijzigd %{when} geleden
         title: Mijn huishouden
         transactions:


### PR DESCRIPTION
Some foodcoops do not use the accounting feature of the foodsoft, which
results in wrong calculation of the available credit. To avoid
confusions show the current account balance instead.
