### PR TITLE
Fix translations of messages plugin

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1041,7 +1041,10 @@ de:
       due_date_format: "%A, %d. %b"
       messages:
         title: Neueste Nachrichten
-        view_all: Alle Nachrichten einsehen
+        view_all:
+          text: '%{messages} oder %{threads} anzeigen'
+          messages: Nachrichten
+          threads: Nachrichtenverläufe
       my_ordergroup:
         funds: "| Verfügbares Guthaben:"
         last_update: Letzte Aktualisierung vor %{when}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1043,7 +1043,10 @@ en:
       due_date_format: "%A %d %B"
       messages:
         title: Newest Messages
-        view_all: See all messages
+        view_all:
+          text: 'Show %{messages} or %{threads}'
+          messages: all messages
+          threads: threads
       my_ordergroup:
         funds: "| Available Credit:"
         last_update: Last update was %{when} ago

--- a/plugins/messages/config/locales/de.yml
+++ b/plugins/messages/config/locales/de.yml
@@ -30,8 +30,8 @@ de:
       messages:
         view_all:
           text: '%{messages} oder %{threads} anzeigen'
-          messages:
-          threads:
+          messages: Nachrichten
+          threads: Nachrichtenverläufe
   messagegroups:
     index:
       body: Du kannst jede der Nachrichtengruppen beitreten oder sie wieder verlassen.
@@ -47,9 +47,9 @@ de:
       leave: Nachrichtengruppe verlassen
   messages:
     actionbar:
-      message_threads:
-      messagegroups:
-      messages:
+      message_threads: Als Verläufe anzeigen
+      messagegroups: Nachrichtengruppen beitreten
+      messages: Als Liste anzeigen
       new: Neue Nachricht
     thread:
       all_message_threads: Alle Nachrichtenverläufe
@@ -70,3 +70,6 @@ de:
   navigation:
     admin:
       messagegroups: Nachrichtengruppen
+  shared:
+    user_form_fields:
+      messagegroups: Nachrichtengruppen beitreten oder verlassen


### PR DESCRIPTION
We need to copy the locales of overrides into the main locales files
to work properly. Also add the missing German translations.