### PR TITLE
Allow ERB syntax in the app_config.yml

### DIFF
--- a/lib/foodsoft_config.rb
+++ b/lib/foodsoft_config.rb
@@ -60,7 +60,7 @@ class FoodsoftConfig
     # @param filename [String] Override configuration file
     def init(filename = APP_CONFIG_FILE)
       Rails.logger.info "Loading app configuration from #{APP_CONFIG_FILE}"
-      APP_CONFIG.clear.merge! YAML.load(File.read(File.expand_path(filename, Rails.root)))
+      APP_CONFIG.clear.merge! YAML.load(ERB.new(File.read(File.expand_path(filename, Rails.root))).result)
       # Gather program-default configuration
       self.default_config = get_default_config
       # Load initial config from development or production


### PR DESCRIPTION
This change allows us to refer to envrionment variables in the yml file.
This is helpful if passwords are passed as environment variables in
Docker installations to avoid plain passwords in configuration files.