### PR TITLE
Fix order by groups document after 020b75c

### DIFF
--- a/app/documents/order_by_groups.rb
+++ b/app/documents/order_by_groups.rb
@@ -86,7 +86,7 @@ class OrderByGroups < OrderPdf
 
   def group_orders
     order.group_orders.ordered.
-      joins(:ordergroup).order('groups.name').
+      includes(:ordergroup).order('groups.name').
       preload(:group_order_articles => {:order_article => [:article, :article_price]})
   end
 


### PR DESCRIPTION
Use a OUTER JOIN instead of a INNER JOIN to include also the stock order
which does not have an entry in the groups table.