### PR TITLE
Fall back to default_scope if an invalid foodcoop is provided

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -172,6 +172,7 @@ class ApplicationController < ActionController::Base
           # Set Config and database connection
           FoodsoftConfig.select_foodcoop params[:foodcoop]
         rescue => error
+          FoodsoftConfig.select_foodcoop FoodsoftConfig.config[:default_scope]
           redirect_to root_url, alert: error.message
         end
       else


### PR DESCRIPTION
Before this change foodsoft redirect to the last active foodcoop, when
an invalid foodcoop is provided. After this change the default_scope
will be used all the time to avoid data disclosure.