### PR TITLE
Enhanced matrix pdf

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'rails-i18n'
 
 gem 'mysql2'
 gem 'prawn'
-gem 'prawn-table'
+gem 'prawn-table', :git => 'https://github.com/straydogstudio/prawn-table.git', ref: '759a27b6'
 gem 'haml-rails'
 gem 'kaminari'
 gem 'simple_form'

--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'rails-i18n'
 
 gem 'mysql2'
 gem 'prawn'
-gem 'prawn-table', :git => 'https://github.com/straydogstudio/prawn-table.git', ref: '759a27b6'
+gem 'prawn-table'
 gem 'haml-rails'
 gem 'kaminari'
 gem 'simple_form'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,13 +5,6 @@ GIT
     localize_input (0.1.0)
 
 GIT
-  remote: https://github.com/straydogstudio/prawn-table.git
-  revision: 759a27b6fef2e682c035fc83f2182e53c3270279
-  ref: 759a27b6
-  specs:
-    prawn-table (0.2.1)
-
-GIT
   remote: https://github.com/technoweenie/acts_as_versioned.git
   revision: 63b1fc8529d028fae632fe80ec0cb25df56cd76b
   specs:
@@ -262,6 +255,8 @@ GEM
     prawn (2.2.2)
       pdf-core (~> 0.7.0)
       ttfunk (~> 1.5)
+    prawn-table (0.2.2)
+      prawn (>= 1.3.0, < 3.0.0)
     protected_attributes (1.1.0)
       activemodel (>= 4.0.1, < 5.0)
     pry (0.10.3)
@@ -517,7 +512,7 @@ DEPENDENCIES
   meta_request
   mysql2
   prawn
-  prawn-table!
+  prawn-table
   protected_attributes (= 1.1.0)
   pry-rescue
   pry-stack_explorer

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,13 @@ GIT
     localize_input (0.1.0)
 
 GIT
+  remote: https://github.com/straydogstudio/prawn-table.git
+  revision: 759a27b6fef2e682c035fc83f2182e53c3270279
+  ref: 759a27b6
+  specs:
+    prawn-table (0.2.1)
+
+GIT
   remote: https://github.com/technoweenie/acts_as_versioned.git
   revision: 63b1fc8529d028fae632fe80ec0cb25df56cd76b
   specs:
@@ -217,7 +224,7 @@ GEM
     libv8 (3.16.14.17)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
-    mail (2.6.6)
+    mail (2.6.4)
       mime-types (>= 1.16, < 4)
     mailcatcher (0.6.4)
       activesupport (~> 4.0)
@@ -237,7 +244,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     mini-smtp-server (0.0.2)
-    mini_portile2 (2.2.0)
+    mini_portile2 (2.1.0)
     minitest (5.10.1)
     mono_logger (1.1.0)
     multi_json (1.12.1)
@@ -246,17 +253,15 @@ GEM
       net-ssh (>= 2.6.5)
     net-ssh (3.1.1)
     netrc (0.11.0)
-    nokogiri (1.8.0)
-      mini_portile2 (~> 2.2.0)
-    pdf-core (0.6.1)
+    nokogiri (1.7.1)
+      mini_portile2 (~> 2.1.0)
+    pdf-core (0.7.0)
     polyamorous (1.3.1)
       activerecord (>= 3.0)
     polyglot (0.3.5)
-    prawn (2.1.0)
-      pdf-core (~> 0.6.1)
-      ttfunk (~> 1.4.0)
-    prawn-table (0.2.2)
-      prawn (>= 1.3.0, < 3.0.0)
+    prawn (2.2.2)
+      pdf-core (~> 0.7.0)
+      ttfunk (~> 1.5)
     protected_attributes (1.1.0)
       activemodel (>= 4.0.1, < 5.0)
     pry (0.10.3)
@@ -437,7 +442,7 @@ GEM
     thread_safe (0.3.6)
     tilt (2.0.7)
     tins (1.13.2)
-    ttfunk (1.4.0)
+    ttfunk (1.5.1)
     twitter-bootstrap-rails (2.2.8)
       actionpack (>= 3.1)
       execjs
@@ -512,7 +517,7 @@ DEPENDENCIES
   meta_request
   mysql2
   prawn
-  prawn-table
+  prawn-table!
   protected_attributes (= 1.1.0)
   pry-rescue
   pry-stack_explorer
@@ -549,4 +554,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   1.11.2
+   1.15.1

--- a/app/documents/order_by_groups.rb
+++ b/app/documents/order_by_groups.rb
@@ -47,7 +47,7 @@ class OrderByGroups < OrderPdf
         # borders
         table.cells.borders = [:bottom]
         table.cells.border_width = 0.02
-        table.cells.border_color = 'dddddd'
+        table.cells.border_color = '000000'
         table.rows(0).border_width = 1
         table.rows(0).border_color = '666666'
         table.rows(0).column(5).font_style = :bold

--- a/app/documents/order_matrix.rb
+++ b/app/documents/order_matrix.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 class OrderMatrix < OrderPdf
 
-  MAX_ARTICLES_PER_PAGE = 22 # How many order_articles shoud written on a page
+  MAX_ARTICLES_PER_PAGE = 21 # How many order_articles shoud written on a page
 
   def filename
     I18n.t('documents.order_matrix.filename', :name => @order.name, :date => @order.ends.to_date) + '.pdf'
@@ -21,7 +21,6 @@ class OrderMatrix < OrderPdf
     move_down 10
 
     order_articles_data = [I18n.t('documents.order_matrix.rows')]
-      
 
     order_articles.each do |a|
       order_articles_data << [a.article.name,
@@ -31,12 +30,11 @@ class OrderMatrix < OrderPdf
                               number_with_precision(article_price(a), precision: 2),
                               a.units]
     end
-    
-    #order_articles_data.sort_by!{|a| a[0].downcase}
 
     table order_articles_data, cell_style: {size: fontsize(8), overflow: :shrink_to_fit} do |table|
       table.cells.border_width = 1
       table.cells.border_color = '666666'
+      table.column(3).text_color = 'aeaeae'
     end
 
     page_number = 0
@@ -59,7 +57,7 @@ class OrderMatrix < OrderPdf
       for header_article in current_order_articles
         name = header_article.article.name.gsub(/[-\/]/, " ").gsub(".", ". ")
         name = name.split.collect { |w| w.truncate(20) }.join(" ")
-        header << name.truncate(35)+' - ('+header_article.article.unit+')'
+        header << "#{name.truncate(35)} - (#{header_article.article.unit})"
    
       end
    
@@ -79,21 +77,17 @@ class OrderMatrix < OrderPdf
       end
 
       # Make table
-      column_widths = [85]
-      (MAX_ARTICLES_PER_PAGE + 1).times { |i| column_widths << 30 unless i == 0 }
-      table groups_data, column_widths: column_widths, cell_style: {size: fontsize(8), overflow: :shrink_to_fit } do |table|
+      column_widths = [55]
+      (MAX_ARTICLES_PER_PAGE + 1).times { |i| column_widths << 32 unless i == 0 }
+      table groups_data, column_widths: column_widths, cell_style: {size: fontsize(5), overflow: :shrink_to_fit } do |table|
    
-      table.rows(0).rotate = 90
-      table.rows(0).padding = 2
-      table.rows(0).height = 90
-      table.rows(0).overflow = :truncate 
-      table.rows(0).align = :left
-      table.rows(0).min_font_size = 6
-     # table.rows(0).valign = :bottom
-        
-      table.cells.border_width = 1
-      table.cells.border_color = '666666'
-      table.row_colors = ['ffffff','ececec']
+        table.rows(0).padding = 2
+        table.rows(0).height = 35
+        table.rows(0).overflow = :truncate 
+        table.rows(0).min_font_size = 8
+        table.cells.border_width = 1
+        table.cells.border_color = '666666'
+        table.row_colors = ['ffffff','ececec']
       end
    
     end

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -732,6 +732,7 @@ de:
       - Artikel
       - Einheit
       - Gebinde
+      - Nettopreis
       - FC-Preis
       - Menge
       title: 'Sortiermatrix der Bestellung: %{name}, beendet am %{date}'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -734,7 +734,7 @@ en:
       - Article
       - Unit
       - Unit quantity
-      - Netto price
+      - Price (net)
       - FC-Price
       - Amount
       title: 'Order sorting matrix: %{name}, closed at %{date}'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -734,6 +734,7 @@ en:
       - Article
       - Unit
       - Unit quantity
+      - Netto price
       - FC-Price
       - Amount
       title: 'Order sorting matrix: %{name}, closed at %{date}'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -732,6 +732,7 @@ fr:
       - Nom du produit
       - Unité
       - Nombre d'unités
+      - Prix HT
       - Prix coop
       - Quantité
       title: 'Tableau de répartition pour la commande: %{name}; clôturée le %{date}'

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -732,6 +732,7 @@ nl:
       - Artikel
       - Eenheid
       - Gr.Eenh.
+      - Netto prijs
       - Foodcoop-prijs
       - Aantal
       title: 'Sorteermatrix van bestelling: %{name}, gesloten op %{date}'


### PR DESCRIPTION
- sort articles by description for easier localization
- rotate header for enhanced readability and longer descriptions
- add net price for easier check with supplier invoice
- add unit to header for quantity-clarification

A bug in the prawn gem forced me to update the gem
https://github.com/prawnpdf/prawn/issues/409
https://github.com/prawnpdf/prawn-table/pull/32

I have uploaded the Gemfile.lock which has changed, but I am not sure if this has to be changed?

