### PR TITLE
Set the path of the _foodsoft_session cookie to the slug

### DIFF
--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -89,7 +89,7 @@ class Mailer < ActionMailer::Base
 
   # @todo this global stuff gives threading problems when foodcoops have different values! - pass args to `url_for` instead
   def set_foodcoop_scope(foodcoop = FoodsoftConfig.scope)
-    [:protocol, :host, :port].each do |k|
+    [:protocol, :host, :port, :script_name].each do |k|
       ActionMailer::Base.default_url_options[k] = FoodsoftConfig[k] if FoodsoftConfig[k]
     end
     ActionMailer::Base.default_url_options[:foodcoop] = foodcoop

--- a/config/app_config.yml.SAMPLE
+++ b/config/app_config.yml.SAMPLE
@@ -134,6 +134,7 @@ default: &defaults
   #protocol: http
   #host: localhost
   #port: 3000
+  #script_name: "/"
 
   # Access to sharedlists, the external article-database.
   # This allows a foodcoop to subscribe to a selection of a supplier's full assortment,

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,6 +1,25 @@
 # Be sure to restart your server when you modify this file.
 
-Foodsoft::Application.config.session_store :cookie_store, key: '_foodsoft_session'
+module ActionDispatch
+  module Session
+    class SlugCookieStore < CookieStore
+      alias_method :orig_set_cookie, :set_cookie
+
+      def set_cookie(env, session_id, cookie)
+        if script_name = FoodsoftConfig[:script_name]
+          request = ActionDispatch::Request.new env
+          path = request.original_fullpath[script_name.size..-1]
+          slug = path.split('/', 2).first
+          return if slug.blank?
+          cookie[:path] = script_name + slug
+        end
+        orig_set_cookie env, session_id, cookie
+      end
+    end
+  end
+end
+
+Foodsoft::Application.config.session_store :slug_cookie_store, key: '_foodsoft_session'
 
 # Use the database for sessions instead of the cookie-based default,
 # which shouldn't be used to store highly confidential information


### PR DESCRIPTION
This allows the usage of different foodcoops at the same time.