### PR TITLE
Raise a RoutingError for unknown foodcoop in multi_coop_installs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -177,19 +177,16 @@ class ApplicationController < ActionController::Base
   # It uses the subdomain to select the appropriate section in the config files
   # Use this method as a before filter (first filter!) in ApplicationController
   def select_foodcoop
-    if FoodsoftConfig[:multi_coop_install]
-      if params[:foodcoop].present?
-        begin
-          # Set Config and database connection
-          FoodsoftConfig.select_foodcoop params[:foodcoop]
-        rescue => error
-          FoodsoftConfig.select_default_foodcoop
-          redirect_to root_url, alert: error.message
-        end
-      else
-        FoodsoftConfig.select_default_foodcoop
-        redirect_to root_url
-      end
+    return unless FoodsoftConfig[:multi_coop_install]
+
+    foodcoop = params[:foodcoop]
+    if foodcoop.blank?
+      FoodsoftConfig.select_default_foodcoop
+      redirect_to root_url
+    elsif FoodsoftConfig.allowed_foodcoop? foodcoop
+      FoodsoftConfig.select_foodcoop foodcoop
+    else
+      raise ActionController::RoutingError.new 'Foodcoop Not Found'
     end
   end
 

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -11,9 +11,16 @@ class ErrorsController < ApplicationController
 
   private
 
+  def select_foodcoop
+    foodcoop = params[:foodcoop]
+    if FoodsoftConfig.allowed_foodcoop? foodcoop
+      FoodsoftConfig.select_foodcoop foodcoop
+    else
+      FoodsoftConfig.select_default_foodcoop
+    end
+  end
+
   def current_layout
-    # Need foodcoop for `current_user`, even though it may not be retrieved from the url.
-    params[:foodcoop] ||= session[:scope]
     current_user ? 'application' : 'login'
   end
 

--- a/lib/foodsoft_config.rb
+++ b/lib/foodsoft_config.rb
@@ -159,6 +159,10 @@ class FoodsoftConfig
       end
     end
 
+    def allowed_foodcoop?(foodcoop)
+      foodcoops.include? foodcoop
+    end
+
     # @return [Boolean] Whether this key may be set in the database
     def allowed_key?(key)
       # fast check for keys without nesting


### PR DESCRIPTION
This gives the correct error code for request to files in the root
folder (e.g. /apple-touch-icon.png), which do not exist.