### PR TITLE
 Add view to sort orders by pickup day

### DIFF
--- a/app/controllers/pickups_controller.rb
+++ b/app/controllers/pickups_controller.rb
@@ -1,0 +1,26 @@
+class PickupsController < ApplicationController
+
+  def index
+    @orders = Order.order('pickup DESC').group_by { |o| o.pickup }
+  end
+
+  def document
+    return redirect_to pickups_path, alert: t('.empty_selection') unless params[:orders]
+
+    order_ids = params[:orders].map(&:to_i)
+
+    if params[:articles_pdf]
+      klass = OrderByArticles
+    elsif params[:groups_pdf]
+      klass = OrderByGroups
+    elsif params[:matrix_pdf]
+      klass = OrderMatrix
+    end
+
+    return redirect_to pickups_path, alert: t('.invalid_document') unless klass
+
+    pdf = klass.new(order_ids, title: t('.title'), show_supplier: true)
+
+    send_data pdf.to_pdf, type: 'application/pdf', disposition: :inline
+  end
+end

--- a/app/views/orders/show.html.haml
+++ b/app/views/orders/show.html.haml
@@ -65,19 +65,7 @@
       = update_articles_link @order, t('.sort_article'), :articles, class: 'btn'
 
     - unless @order.open?
-      .btn-group
-        = link_to '#', class: 'btn dropdown-toggle', data: {toggle: 'dropdown'} do
-          = t '.download.title'
-          %span.caret
-        %ul.dropdown-menu
-          %li= order_pdf(@order, :groups, t('.download.group_pdf'))
-          %li= order_pdf(@order, :articles, t('.download.article_pdf'))
-          %li= order_pdf(@order, :matrix, t('.download.matrix_pdf'))
-          %li= order_pdf(@order, :fax, t('.download.fax_pdf'))
-          - unless @order.stockit?
-            %li= link_to t('.download.fax_txt'), order_path(@order, format: :txt), {title: t('.download.download_file')}
-          %li= link_to t('.download.fax_csv'), order_path(@order, format: :csv), {title: t('.download.download_file')}
-
+      = render 'shared/order_download_button', order: @order, klass: ''
     - if @order.open?
       = link_to t('.action_end'), finish_order_path(@order), method: :post, class: 'btn btn-success',
         data: {confirm: t('.confirm_end', order: @order.name)}

--- a/app/views/pickups/index.html.haml
+++ b/app/views/pickups/index.html.haml
@@ -1,0 +1,33 @@
+- title t('.title')
+
+- @orders.each do |pickup, orders|
+  = form_tag document_pickups_path do
+    %h2
+      - if pickup
+        = l pickup, format: :long
+      - else
+        = t '.without_pickup'
+      %span{style:'float:right'}
+        = submit_tag t('.article_pdf'), name: 'articles_pdf', class: 'btn'
+        = submit_tag t('.group_pdf'), name: 'groups_pdf', class: 'btn'
+        = submit_tag t('.matrix_pdf'), name: 'matrix_pdf', class: 'btn'
+
+    %table.table.table-striped
+      %thead
+        %tr
+          %th{style:'width:50%'}= heading_helper Order, :name
+          %th{style:'width:50%'}= heading_helper Order, :note
+          %th{style:'width:1px'}= t 'ui.actions'
+      %tbody
+        - for order in orders
+          %tr
+            %td
+              = check_box_tag "orders[]", order.id, true #, style: 'float:left'
+              - if current_user.role_orders?
+                = link_to order.name, order_path(order)
+              - else
+                = order.name
+            %td= truncate order.note
+            %td{style:'white-space:nowrap'}
+              = render 'shared/order_download_button', order: order, klass: 'btn-small'
+              = receive_button order, class: 'btn-small'

--- a/app/views/shared/_order_download_button.html.haml
+++ b/app/views/shared/_order_download_button.html.haml
@@ -1,0 +1,12 @@
+.btn-group
+  = link_to '#', class: "btn #{klass} dropdown-toggle", data: {toggle: 'dropdown'} do
+    = t '.title'
+    %span.caret
+  %ul.dropdown-menu
+    %li= order_pdf(order, :groups, t('.group_pdf'))
+    %li= order_pdf(order, :articles, t('.article_pdf'))
+    %li= order_pdf(order, :matrix, t('.matrix_pdf'))
+    %li= order_pdf(order, :fax, t('.fax_pdf'))
+    - unless order.stockit?
+      %li= link_to t('.fax_txt'), order_path(order, format: :txt), {title: t('.download_file')}
+    %li= link_to t('.fax_csv'), order_path(order, format: :csv), {title: t('.download_file')}

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1451,6 +1451,7 @@ de:
       archive: Meine Bestellungen
       manage: Bestellverwaltung
       ordering: Bestellen!
+      pickups: Abholtage
       title: Bestellungen
     tasks: Aufgaben
     wiki:
@@ -1672,6 +1673,15 @@ de:
       title: "%{title} - Version %{version}"
       title_version: Version
       view_current: Aktuelle Version sehen
+  pickups:
+    document:
+      empty_selection: Es muss zumindest eine Bestellung ausgewählt sein.
+      invalid_document: Ungültiger Dokumententyp
+    index:
+      article_pdf: Artikel PDF
+      group_pdf: Gruppen PDF
+      matrix_pdf: Matrix PDF
+      title: Abholtage
   sessions:
     logged_in: Angemeldet!
     logged_out: Abgemeldet!

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1563,15 +1563,6 @@ de:
         starts: läuft von %{starts}
         starts_ends: läuft von %{starts} bis %{ends}
       description2: "%{ordergroups} haben %{article_count} Artikel mit einem Gesamtwert von %{net_sum} / %{gross_sum} (netto / brutto) bestellt."
-      download:
-        article_pdf: Artikel PDF
-        download_file: Download file
-        fax_csv: Fax CSV
-        fax_pdf: Fax PDF
-        fax_txt: Fax Text
-        group_pdf: Gruppen PDF
-        matrix_pdf: Matrix PDF
-        title: Download
       group_orders: 'Gruppenbestellungen:'
       search_placeholder:
         articles: Suche nach Artikeln ...
@@ -1717,6 +1708,15 @@ de:
       title: Laufende Bestellungen
       total_sum: Gesamtsumme
       who_ordered: Wer hat bestellt?
+    order_download_button:
+      article_pdf: Artikel PDF
+      download_file: Download file
+      fax_csv: Fax CSV
+      fax_pdf: Fax PDF
+      fax_txt: Fax Text
+      group_pdf: Gruppen PDF
+      matrix_pdf: Matrix PDF
+      title: Download
     task_list:
       accept_task: Aufgabe übernehmen
       done: Erledigt

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1461,6 +1461,7 @@ en:
       archive: My Orders
       manage: Manage orders
       ordering: Place order!
+      pickups: Pickup days
       title: Orders
     tasks: Tasks
     wiki:
@@ -1682,6 +1683,15 @@ en:
       title: "%{title} - version %{version}"
       title_version: Version
       view_current: See current version
+  pickups:
+    document:
+      empty_selection: At least one order must be selected.
+      invalid_document: Invalid document type
+    index:
+      article_pdf: Article PDF
+      group_pdf: Group PDF
+      matrix_pdf: Matrix PDF
+      title: Pickup days
   sessions:
     logged_in: Logged in!
     logged_out: Logged out!

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1573,15 +1573,6 @@ en:
         starts: open from %{starts}
         starts_ends: open from %{starts} until %{ends}
       description2: "%{ordergroups} ordered %{article_count} articles, with a total value of %{net_sum} / %{gross_sum} (net / gross)."
-      download:
-        article_pdf: Article PDF
-        download_file: Download file
-        fax_csv: Fax CSV
-        fax_pdf: Fax PDF
-        fax_txt: Fax text
-        group_pdf: Group PDF
-        matrix_pdf: Matrix PDF
-        title: Download
       group_orders: 'Group orders:'
       search_placeholder:
         articles: Search for articles...
@@ -1727,6 +1718,15 @@ en:
       title: Current orders
       total_sum: Total sum
       who_ordered: Who ordered?
+    order_download_button:
+      article_pdf: Article PDF
+      download_file: Download file
+      fax_csv: Fax CSV
+      fax_pdf: Fax PDF
+      fax_txt: Fax text
+      group_pdf: Group PDF
+      matrix_pdf: Matrix PDF
+      title: Download
     task_list:
       accept_task: Accept task
       done: Done

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1539,15 +1539,6 @@ es:
         starts: abierto desde %{starts}
         starts_ends: abierto desde %{starts} hasta %{ends}
       description2: "%{ordergroups} ha pedido %{article_count} artículos, con un valor total de %{net_sum} / %{gross_sum} (neto / bruto)."
-      download:
-        article_pdf: Artículos PDF
-        download_file: Descargar archivo
-        fax_csv: Fax CSV
-        fax_pdf: Fax PDF
-        fax_txt: Fax text
-        group_pdf: Group PDF
-        matrix_pdf: Matrix PDF
-        title: Descargar
       group_orders: 'Pedidos del grupo:'
       search_placeholder:
         articles: Busca artículos...
@@ -1695,6 +1686,15 @@ es:
       title: Pedidos activos
       total_sum: Suma total
       who_ordered: "¿Quién ha pedido?"
+    order_download_button:
+      article_pdf: Artículos PDF
+      download_file: Descargar archivo
+      fax_csv: Fax CSV
+      fax_pdf: Fax PDF
+      fax_txt: Fax text
+      group_pdf: Group PDF
+      matrix_pdf: Matrix PDF
+      title: Descargar
     task_list:
       accept_task: Acepta la tarea
       done: Hecho

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1536,15 +1536,6 @@ fr:
         starts: ouverte du %{starts}
         starts_ends: ouverte du %{starts} au %{ends}
       description2: "%{ordergroups} ont commandé %{article_count} articles, pour un montant total de %{net_sum} (net)/ %{gross_sum} (brut)"
-      download:
-        article_pdf: Liste des articles en PDF
-        download_file: Télécharger
-        fax_csv: Fax CSV
-        fax_pdf: Fax au format PDF
-        fax_txt: Fax au format texte
-        group_pdf: Liste des cellules en PDF
-        matrix_pdf: Matrice de répartition en PDF
-        title: Télécharger
       group_orders: 'Commandes des cellules:'
       search_placeholder:
         articles: Rechercher des articles...
@@ -1690,6 +1681,15 @@ fr:
       title: Commandes en cours
       total_sum: Total
       who_ordered: Qui a commandé?
+    order_download_button:
+      article_pdf: Liste des articles en PDF
+      download_file: Télécharger
+      fax_csv: Fax CSV
+      fax_pdf: Fax au format PDF
+      fax_txt: Fax au format texte
+      group_pdf: Liste des cellules en PDF
+      matrix_pdf: Matrice de répartition en PDF
+      title: Télécharger
     task_list:
       accept_task: Te charger de ce boulot
       done: Effectué

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -1540,15 +1540,6 @@ nl:
         starts: open van %{starts}
         starts_ends: open van %{starts} tot %{ends}
       description2: "%{ordergroups} hebben %{article_count} artikelen besteld met een totale waarde van %{net_sum} / %{gross_sum} (netto / bruto)."
-      download:
-        article_pdf: Artikelen PDF
-        download_file: Bestand downloaden
-        fax_csv: Fax CSV
-        fax_pdf: Fax PDF
-        fax_txt: Fax text
-        group_pdf: Huishoudens PDF
-        matrix_pdf: Matrix PDF
-        title: Downloaden
       group_orders: 'Ledenbestellingen:'
       search_placeholder:
         articles: Artikelen zoeken...
@@ -1694,6 +1685,15 @@ nl:
       title: Lopende bestellingen
       total_sum: Totaalsom
       who_ordered: Wie heeft besteld?
+    order_download_button:
+      article_pdf: Artikelen PDF
+      download_file: Bestand downloaden
+      fax_csv: Fax CSV
+      fax_pdf: Fax PDF
+      fax_txt: Fax text
+      group_pdf: Huishoudens PDF
+      matrix_pdf: Matrix PDF
+      title: Downloaden
     task_list:
       accept_task: Taak accepteren
       done: Gedaan

--- a/config/navigation.rb
+++ b/config/navigation.rb
@@ -24,6 +24,7 @@ SimpleNavigation::Configuration.run do |navigation|
       subnav.item :ordering, I18n.t('navigation.orders.ordering'), group_orders_path
       subnav.item :ordering_archive, I18n.t('navigation.orders.archive'), archive_group_orders_path
       subnav.item :orders, I18n.t('navigation.orders.manage'), orders_path, if: Proc.new { current_user.role_orders? }
+      subnav.item :pickups, I18n.t('navigation.orders.pickups'), pickups_path, if: Proc.new { current_user.role_orders? }
     end
 
     primary.item :articles, I18n.t('navigation.articles.title'), '#',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,10 @@ Foodsoft::Application.routes.draw do
       resources :order_articles
     end
 
+    resources :pickups, only: [:index] do
+      post :document, on: :collection
+    end
+
     resources :group_orders do
       get :archive, on: :collection
     end

--- a/lib/render_pdf.rb
+++ b/lib/render_pdf.rb
@@ -85,7 +85,7 @@ class RenderPDF < Prawn::Document
       }
     )
 
-    header = title
+    header = options[:title] || title
     footer = I18n.l(Time.now, format: :long)
 
     header_size = 0


### PR DESCRIPTION
This provides an interface to generate PDFs which include multiple orders.

It reuses the `MultipleOrdersBy*` classes from the `current_orders` plugin for now. A next step is to merge `MultipleOrdersBy*` into the other `OrderPdf` classes and clean them up.