### PR TITLE
improve usability when ordering

### DIFF
--- a/app/views/group_orders/show.html.haml
+++ b/app/views/group_orders/show.html.haml
@@ -6,27 +6,32 @@
 
 - title t('.title', order: @order.name)
 
-.well
-  // Order summary
-  %dl.dl-horizontal
-    %dt= heading_helper Order, :name
-    %dd= @order.name
-    %dt= heading_helper Order, :note
-    %dd= @order.note
-    %dt= heading_helper Order, :ends
-    %dd= format_time(@order.ends)
-    %dt= heading_helper Order, :pickup
-    %dd= format_date(@order.pickup)
-    %dt= heading_helper GroupOrder, :price
-    %dd
-      - if @group_order
-        = number_to_currency(@group_order.price)
-      - else
-        = t '.not_ordered'
-    - if @order.closed?
-      %dt= heading_helper Order, :closed_by
-      %dd= show_user_link @order.updated_by
-      %p= link_to t('.comment'), "#comments"
+.row-fluid
+  .well.pull-left
+    // Order summary
+    %dl.dl-horizontal
+      %dt= heading_helper Order, :name
+      %dd= @order.name
+      %dt= heading_helper Order, :note
+      %dd= @order.note
+      %dt= heading_helper Order, :ends
+      %dd= format_time(@order.ends)
+      %dt= heading_helper Order, :pickup
+      %dd= format_date(@order.pickup)
+      %dt= heading_helper GroupOrder, :price
+      %dd
+        - if @group_order
+          = number_to_currency(@group_order.price)
+        - else
+          = t '.not_ordered'
+      - if @order.closed?
+        %dt= heading_helper Order, :closed_by
+        %dd= show_user_link @order.updated_by
+        %p= link_to t('.comment'), "#comments"
+
+  .well.pull-right
+    = close_button :alert
+    = render 'switch_order', current_order: @order
 
 // Article box
 %section


### PR DESCRIPTION
also show box with links to currently open orders after the order has
been saved

I'm until now only a use of the great foodsoft, however one annoying thing for me is, that one has to go all the way back through the main menu for placing a new order after the current edited order has been saved.
Since I'm completely new to ruby and rails I just copied the code more or less from the _form.html.haml file. 

This is the result you get with this change:
![image](https://user-images.githubusercontent.com/1112068/39652386-a23e3572-4fed-11e8-9814-96ca0b39ac7d.png)
