### PR TITLE
API-3: financial transactions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -109,4 +109,7 @@ group :test do
   # code coverage
   gem 'simplecov', require: false
   gem 'coveralls', require: false
+  # api
+  gem 'apivore', require: false
+  gem 'hashie', '~> 3.4.6', require: false # https://github.com/westfieldlabs/apivore/issues/114
 end

--- a/Gemfile
+++ b/Gemfile
@@ -72,10 +72,6 @@ group :development do
   gem 'mailcatcher'
   gem 'web-console', '~> 2.0'
 
-  # allow to use `debugger` https://github.com/conradirwin/pry-rescue
-  gem 'pry-rescue'
-  gem 'pry-stack_explorer'
-
   # Better error output
   gem 'better_errors'
   gem 'binding_of_caller'
@@ -92,6 +88,10 @@ end
 
 group :development, :test do
   gem 'ruby-prof', require: false
+
+  # allow to use `debugger` https://github.com/conradirwin/pry-rescue
+  gem 'pry-rescue'
+  gem 'pry-stack_explorer'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,13 @@ GEM
       activerecord (>= 3.0.0)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
+    apivore (1.6.2)
+      actionpack (>= 4, < 6)
+      hashie (~> 3.3)
+      json-schema (~> 2.5)
+      rspec (~> 3)
+      rspec-expectations (~> 3.1)
+      rspec-mocks (~> 3.1)
     arel (6.0.4)
     attribute_normalizer (1.2.0)
     base32 (0.3.2)
@@ -191,6 +198,7 @@ GEM
     has_scope (0.7.2)
       actionpack (>= 4.1)
       activesupport (>= 4.1)
+    hashie (3.4.6)
     html2haml (2.2.0)
       erubis (~> 2.7.0)
       haml (>= 4.0, < 6)
@@ -217,6 +225,8 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (2.1.0)
+    json-schema (2.8.0)
+      addressable (>= 2.4)
     jsonapi-renderer (0.2.0)
     kaminari (1.1.1)
       activesupport (>= 4.1.0)
@@ -499,6 +509,7 @@ DEPENDENCIES
   active_model_serializers (~> 0.10.0)
   acts_as_tree
   acts_as_versioned!
+  apivore
   attribute_normalizer
   better_errors
   binding_of_caller
@@ -523,6 +534,7 @@ DEPENDENCIES
   gaffe
   haml (~> 4.0)
   haml-rails
+  hashie (~> 3.4.6)
   i18n-js (~> 3.0.0.rc8)
   i18n-spec
   ice_cube

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::BaseController < ApplicationController
+  include Concerns::AuthApi
+
   protect_from_forgery with: :null_session
 
   before_action :skip_session
@@ -11,16 +13,6 @@ class Api::V1::BaseController < ApplicationController
 
   private
 
-  def authenticate
-    doorkeeper_authorize!
-    super if current_user
-  end
-
-  # @return [User] Current user, or +nil+ if no valid token.
-  def current_user
-    @current_user ||= User.undeleted.find(doorkeeper_token.resource_owner_id) if doorkeeper_token
-  end
-
   # @return [Ordergroup] Current user's ordergroup, or +nil+ if no valid token or user has no ordergroup.
   def current_ordergroup
     current_user.try(:ordergroup)
@@ -28,7 +20,9 @@ class Api::V1::BaseController < ApplicationController
 
   def require_ordergroup
     authenticate
-    raise Api::Errors::PermissionRequired unless current_user.ordergroup.present?
+    unless current_ordergroup.present?
+      raise Api::Errors::PermissionRequired.new("Forbidden, must be in an ordergroup")
+    end
   end
 
   def skip_session
@@ -42,10 +36,15 @@ class Api::V1::BaseController < ApplicationController
   end
 
   def not_acceptable_handler(e)
-    render status: 422, json: {error: 'not_acceptable', error_description: e.message || 'Data not acceptable' }
+    msg = e.message || 'Data not acceptable'
+    render status: 422, json: {error: 'not_acceptable', error_description: msg }
   end
 
   def doorkeeper_unauthorized_render_options(error:)
+    {json: {error: error.name, error_description: error.description}}
+  end
+
+  def doorkeeper_forbidden_render_options(error:)
     {json: {error: error.name, error_description: error.description}}
   end
 
@@ -58,5 +57,4 @@ class Api::V1::BaseController < ApplicationController
   def show_user(user = current_user, **options)
     user.display
   end
-
 end

--- a/app/controllers/api/v1/configs_controller.rb
+++ b/app/controllers/api/v1/configs_controller.rb
@@ -1,5 +1,7 @@
 class Api::V1::ConfigsController < Api::V1::BaseController
 
+  before_action ->{ doorkeeper_authorize! 'config:user', 'config:read', 'config:write' }
+
   def show
     render json: FoodsoftConfig, serializer: ConfigSerializer, root: 'config'
   end

--- a/app/controllers/api/v1/financial_transactions_controller.rb
+++ b/app/controllers/api/v1/financial_transactions_controller.rb
@@ -1,0 +1,24 @@
+class Api::V1::FinancialTransactionsController < Api::V1::BaseController
+  include Concerns::CollectionScope
+
+  before_action ->{ doorkeeper_authorize! 'finance:read', 'finance:write' }
+
+  def index
+    render_collection search_scope
+  end
+
+  def show
+    render json: scope.find(params.require(:id))
+  end
+
+  private
+
+  def scope
+    FinancialTransaction
+  end
+
+  def ransack_auth_object
+    :finance
+  end
+
+end

--- a/app/controllers/api/v1/financial_transactions_controller.rb
+++ b/app/controllers/api/v1/financial_transactions_controller.rb
@@ -1,0 +1,20 @@
+class Api::V1::FinancialTransactionsController < Api::V1::BaseController
+  include Concerns::CollectionScope
+
+  before_action :require_ordergroup
+
+  def index
+    render_collection search_scope
+  end
+
+  def show
+    render json: scope.find(params.require(:id))
+  end
+
+  private
+
+  def scope
+    current_ordergroup.financial_transactions
+  end
+
+end

--- a/app/controllers/api/v1/user/financial_transactions_controller.rb
+++ b/app/controllers/api/v1/user/financial_transactions_controller.rb
@@ -1,4 +1,4 @@
-class Api::V1::FinancialTransactionsController < Api::V1::BaseController
+class Api::V1::User::FinancialTransactionsController < Api::V1::BaseController
   include Concerns::CollectionScope
 
   before_action :require_ordergroup

--- a/app/controllers/api/v1/user/financial_transactions_controller.rb
+++ b/app/controllers/api/v1/user/financial_transactions_controller.rb
@@ -1,6 +1,7 @@
 class Api::V1::User::FinancialTransactionsController < Api::V1::BaseController
   include Concerns::CollectionScope
 
+  before_action ->{ doorkeeper_authorize! 'finance:user' }
   before_action :require_ordergroup
 
   def index

--- a/app/controllers/api/v1/user/users_controller.rb
+++ b/app/controllers/api/v1/user/users_controller.rb
@@ -1,0 +1,7 @@
+class Api::V1::User::UsersController < Api::V1::BaseController
+
+  def show
+    render json: current_user
+  end
+
+end

--- a/app/controllers/api/v1/user/users_controller.rb
+++ b/app/controllers/api/v1/user/users_controller.rb
@@ -1,5 +1,7 @@
 class Api::V1::User::UsersController < Api::V1::BaseController
 
+  before_action ->{ doorkeeper_authorize! 'user:read', 'user:write' }
+
   def show
     render json: current_user
   end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,7 +1,0 @@
-class Api::V1::UsersController < Api::V1::BaseController
-
-  def show
-    render json: current_user
-  end
-
-end

--- a/app/controllers/concerns/auth_api.rb
+++ b/app/controllers/concerns/auth_api.rb
@@ -1,0 +1,66 @@
+# Controller concern for authentication methods
+#
+# Split off from main +ApplicationController+ to allow e.g.
+# Doorkeeper to use it too.
+module Concerns::AuthApi
+  extend ActiveSupport::Concern
+
+  protected
+
+  def authenticate
+    # authenticate does not look at scopes, we just want to know if there's a valid token
+    # @see https://github.com/doorkeeper-gem/doorkeeper/blob/v5.0.1/lib/doorkeeper/models/access_token_mixin.rb#L218
+    doorkeeper_render_error unless doorkeeper_token && doorkeeper_token.accessible?
+    super if current_user
+  end
+
+  # @return [User] Current user, or +nil+ if no valid token.
+  def current_user
+    @current_user ||= User.undeleted.find(doorkeeper_token.resource_owner_id) if doorkeeper_token
+  end
+
+  def doorkeeper_authorize!(*scopes)
+    super(*scopes)
+    # In addition to Doorkeeper's authorization and scope check, we also verify
+    # that the user has permissions for the scope (through its workgroups).
+    # Unless no scopes were supplied, which means we only want to make sure there
+    # is a valid user.
+    #
+    # If Doorkeeper's +handle_auth_errors+ is set to +:raise+, we don't get here,
+    # but otherwise we need to check whether +super+ rendered an error.
+    doorkeeper_authorize_roles!(*scopes) if scopes.present? && !performed?
+  end
+
+  private
+
+  # Make sure that at least one the given OAuth scopes is valid for the current user's permissions.
+  # @raise Api::Errors::PermissionsRequired
+  def doorkeeper_authorize_roles!(*scopes)
+    unless scopes.any? {|scope| doorkeeper_scope_permitted?(scope) }
+      raise Api::Errors::PermissionRequired.new("Forbidden, no permission")
+    end
+  end
+
+  # Check whether a given OAuth scope is permitted for the current user.
+  # @note This does not validate whether the given scope is a valid scope.
+  # @return [Boolean] Whether the given scope is valid for the current user.
+  # @see https://github.com/foodcoops/foodsoft/issues/582#issuecomment-442513237
+  def doorkeeper_scope_permitted?(scope)
+    scope_parts = scope.split(':')
+    # user sub-scopes like +config:user+ are always permitted
+    if scope_parts.last == 'user'
+      return true
+    end
+
+    case scope_parts.first
+    when 'user'           then true # access to the current user's own profile
+    when 'config'         then current_user.role_admin?
+    when 'users'          then current_user.role_admin?
+    when 'workgroups'     then current_user.role_admin?
+    when 'suppliers'      then current_user.role_suppliers?
+    when 'group_orders'   then current_user.role_orders?
+    when 'finance'        then current_user.role_finance?
+    # please note that offline_access does not belong here, since it is not used for permission checking
+    end
+  end
+end

--- a/app/controllers/concerns/collection_scope.rb
+++ b/app/controllers/concerns/collection_scope.rb
@@ -26,7 +26,7 @@ module Concerns::CollectionScope
 
   def search_scope
     s = scope
-    s = scope.ransack(params[:q], auth_object: ransack_auth_object).result(distinct: true) if params[:q]
+    s = s.ransack(params[:q], auth_object: ransack_auth_object).result(distinct: true) if params[:q]
     s = s.page(params[:page].to_i).per(per_page) if per_page && per_page >= 0
     s
   end

--- a/app/controllers/concerns/collection_scope.rb
+++ b/app/controllers/concerns/collection_scope.rb
@@ -1,0 +1,49 @@
+module Concerns::CollectionScope
+  extend ActiveSupport::Concern
+
+  private
+
+  def scope
+    raise NotImplementedError, 'Please override #scope when you use Concerns::CollectionScope'
+  end
+
+  def default_per_page
+    20
+  end
+
+  def max_per_page
+    250
+  end
+
+  def per_page
+    # allow max_per_page and default_per_page to be nil as well
+    if params[:per_page]
+      [params[:per_page].to_i, max_per_page].compact.min
+    else
+      default_per_page
+    end
+  end
+
+  def search_scope
+    s = scope
+    s = scope.ransack(params[:q]).result(distinct: true) if params[:q]
+    s = s.page(params[:page].to_i).per(per_page) if per_page && per_page >= 0
+    s
+  end
+
+  def render_collection(scope)
+    render json: scope, meta: collection_meta(scope)
+  end
+
+  def collection_meta(scope, extra = {})
+    return unless scope.respond_to?(:total_count) && per_page
+
+    {
+      page: params[:page].to_i,
+      per_page: per_page,
+      total_pages: (scope.total_count / [1, per_page].max).ceil,
+      total_count: scope.total_count
+    }.merge(extra)
+  end
+
+end

--- a/app/controllers/concerns/collection_scope.rb
+++ b/app/controllers/concerns/collection_scope.rb
@@ -26,7 +26,7 @@ module Concerns::CollectionScope
 
   def search_scope
     s = scope
-    s = scope.ransack(params[:q]).result(distinct: true) if params[:q]
+    s = scope.ransack(params[:q], auth_object: ransack_auth_object).result(distinct: true) if params[:q]
     s = s.page(params[:page].to_i).per(per_page) if per_page && per_page >= 0
     s
   end
@@ -44,6 +44,15 @@ module Concerns::CollectionScope
       total_pages: (scope.total_count / [1, per_page].max).ceil,
       total_count: scope.total_count
     }.merge(extra)
+  end
+
+  # By default, there are no special ransack search scope authentications.
+  # Controllers can override this to return something else and customize a model's
+  # +ransackable_attributes+ and +ransackable_associations+ to allow searching on more
+  # parameters in one controller than another (e.g. to protect searches that are scoped
+  # to a user, while still allowing all search parameters for another endpoint).
+  def ransack_auth_object
+    nil
   end
 
 end

--- a/app/models/financial_transaction.rb
+++ b/app/models/financial_transaction.rb
@@ -18,9 +18,25 @@ class FinancialTransaction < ActiveRecord::Base
     initialize_financial_transaction_type
   end
 
+  # @todo remove alias (and rename created_on to created_at below) after #575
+  ransack_alias :created_at, :created_on
+
+  def self.ransackable_attributes(auth_object = nil)
+    %w(id amount note created_on user_id)
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    %w() # none, and certainly not user until we've secured that more
+  end
+
   # Use this save method instead of simple save and after callback
   def add_transaction!
     ordergroup.add_financial_transaction! amount, note, user, financial_transaction_type
+  end
+
+  # @todo rename in model, see #575
+  def created_at
+    created_on
   end
 
   protected

--- a/app/serializers/financial_transaction_serializer.rb
+++ b/app/serializers/financial_transaction_serializer.rb
@@ -1,0 +1,13 @@
+class FinancialTransactionSerializer < ActiveModel::Serializer
+  include ApplicationHelper
+
+  attributes :id, :user_id, :user_name, :amount, :note, :created_at
+
+  def user_name
+    show_user object.user
+  end
+
+  def amount
+    object.amount.to_f
+  end
+end

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -47,8 +47,14 @@ Doorkeeper.configure do
   # Define access token scopes for your provider
   # For more information go to
   # https://github.com/doorkeeper-gem/doorkeeper/wiki/Using-Scopes
-  # default_scopes  :public
-  # optional_scopes :write, :update
+
+  # default is a collection of read-only scopes
+  default_scopes 'config:user', 'finance:user', 'user:read'
+
+  optional_scopes 'config:read', 'config:write',
+                  'finance:read', 'finance:write',
+                  'user:write',
+                  'offline_access'
 
   # Change the way client credentials are retrieved from the request object.
   # By default it retrieves first from the `HTTP_AUTHORIZATION` header, then

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -248,6 +248,7 @@ Foodsoft::Application.routes.draw do
         resource :user, only: [:show]
         resource :config, only: [:show]
         resource :navigation, only: [:show]
+        resources :financial_transactions, only: [:index, :show]
       end
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -247,10 +247,13 @@ Foodsoft::Application.routes.draw do
       namespace :v1 do
         resource :config, only: [:show]
         resource :navigation, only: [:show]
+
         namespace :user do
           root to: 'users#show'
           resources :financial_transactions, only: [:index, :show]
         end
+
+        resources :financial_transactions, only: [:index, :show]
       end
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -245,10 +245,12 @@ Foodsoft::Application.routes.draw do
 
     namespace :api do
       namespace :v1 do
-        resource :user, only: [:show]
         resource :config, only: [:show]
         resource :navigation, only: [:show]
-        resources :financial_transactions, only: [:index, :show]
+        namespace :user do
+          root to: 'users#show'
+          resources :financial_transactions, only: [:index, :show]
+        end
       end
     end
 

--- a/db/migrate/20181013195028_add_confidential_to_applications.rb
+++ b/db/migrate/20181013195028_add_confidential_to_applications.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddConfidentialToApplications < ActiveRecord::Migration
+  def change
+    add_column(
+      :oauth_applications,
+      :confidential,
+      :boolean,
+      null: false,
+      default: true
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171201000000) do
+ActiveRecord::Schema.define(version: 20181013195028) do
 
   create_table "article_categories", force: :cascade do |t|
     t.string "name",        limit: 255, default: "", null: false
@@ -291,13 +291,14 @@ ActiveRecord::Schema.define(version: 20171201000000) do
   add_index "oauth_access_tokens", ["token"], name: "index_oauth_access_tokens_on_token", unique: true, using: :btree
 
   create_table "oauth_applications", force: :cascade do |t|
-    t.string   "name",         limit: 255,                null: false
-    t.string   "uid",          limit: 255,                null: false
-    t.string   "secret",       limit: 255,                null: false
-    t.text     "redirect_uri", limit: 65535,              null: false
-    t.string   "scopes",       limit: 255,   default: "", null: false
+    t.string   "name",         limit: 255,                  null: false
+    t.string   "uid",          limit: 255,                  null: false
+    t.string   "secret",       limit: 255,                  null: false
+    t.text     "redirect_uri", limit: 65535,                null: false
+    t.string   "scopes",       limit: 255,   default: "",   null: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.boolean  "confidential",               default: true, null: false
   end
 
   add_index "oauth_applications", ["uid"], name: "index_oauth_applications_on_uid", unique: true, using: :btree

--- a/doc/API.md
+++ b/doc/API.md
@@ -1,0 +1,94 @@
+# Foodsoft API
+
+Foodsoft currently provides a JSON REST API that gives access to _member_ operations
+like listing open orders, updating the ordergroup's order, and listing financial
+transactions. (Later versions of the API might include admin-related functionality.)
+
+The API is documented using [Open API 2.0](https://github.com/OAI/OpenAPI-Specification)
+/ [Swagger](http://swagger.io/) in [swagger.v1.yml](swagger.v1.yml).
+This provides a machine-readable reference that is used for
+[running tests](https://github.com/westfieldlabs/apivore) and providing documentation.
+
+## API endpoint documentation
+
+&gt;&gt; [View API documentation](https://petstore.swagger.io/?url=https%3A%2F%2Fraw.githubusercontent.com%2Ffoodcoops%2Ffoodsoft%2Fmaster%2Fdoc%2Fswagger.v1.yml) &lt;&lt;
+
+The above documentation can communicate with the API directly on a local development
+installation of Foodsoft at [http://localhost:3000/f](http://localhost:3000/f). You'll need
+to give access to the application by running in the rails console
+
+```ruby
+app = Doorkeeper::Application.new
+app.name = 'Swagger'; app.scopes = 'all'; app.uid = 'your-client-id'; app.redirect_uri = 'https://petstore.swagger.io/o2c.html'
+app.save!
+```
+
+
+## Security
+
+Uses the [Doorkeeper](https://github.com/doorkeeper-gem/doorkeeper) gem,
+which provides an OAuth2 provider.
+
+
+### Authorization code flow
+
+This is the recommended flow for server-side web applications, where
+members login with Foodsoft, then redirected to the app, which then obtains
+an access token using the authorization code supplied at redirection.
+
+Before you can obtain an access token, the client needs to obtain an id and secret.
+(You can currently skip this for the password credentials flow.) This needs to be
+done for each Foodsoft scope by an admin.
+
+1. Click on the _Apps_ button at the right in Foodsoft's configuration screen.
+2. Click on _New application_
+3. Enter any _Name_ and put the website of your app in _Redirect URI_ and _Submit_.
+4. Click on the new applications' name for the app id and secret.
+5. To quickly test, logging into the app, press _Authorize_.
+
+Not that the user doesn't need to confirm that he is giving the app access to his
+Foodsoft account by default, since apps can only be created by admins. If you
+want to change that, see disable `skip_authorization` in `config/initializers/doorkeeper.rb`.
+
+[Read more](https://github.com/doorkeeper-gem/doorkeeper/wiki/Authorization-Code-Flow).
+
+
+### Implicit flow
+
+This is the recommended flow for client-side web applications. It looks a lot
+like the authorization code flow, but when redirecting back to the app, the
+access token is available directly as part of the url _fragment_ (`window.location.hash`).
+
+This flow also needs to be registered in Foodsoft as in the authorization code flow.
+You only need the `client_id` though, not the secret.
+
+**note** please make sure you understand sections
+[4.4.2](http://tools.ietf.org/html/rfc6819#section-4.4.2) and
+[4.4.3](http://tools.ietf.org/html/rfc6819#section-4.4.3) of the OAuth2 Threat
+Model document before using this flow.
+
+You may find Doorkeeper's [implicit_grant_test](https://github.com/doorkeeper-gem/doorkeeper/blob/master/spec/requests/flows/implicit_grant_spec.rb) useful.
+
+
+### Password credentials flow
+
+The API uses OAuth2 based on [Doorkeeper](https://github.com/doorkeeper-gem).
+To obtain a token using a username/password directly, you can do this:
+
+```ruby
+require 'oauth2'
+c = OAuth2::Client.new('client_id', 'secret', site: 'http://localhost:3002/f/', authorize_url: 'oauth/authorize', token_url: 'oauth/token')
+c.password.get_token('admin', 'secret').token
+# => "1234567890abcdef1234567890abcdef1234567890abcdef123456790abcdef1"
+```
+
+Now use this token as value for the `access_token` when accessing the API, like
+http://localhost:3002/f/api/v1/financial_transactions/1?access_token=12345...
+
+[Read more](https://github.com/doorkeeper-gem/doorkeeper/wiki/Client-Credentials-flow).
+
+
+## Logout
+
+When the user logs out of Foodsoft, all access tokens are destroyed, except when
+the token's scope includes `offline_access` (so offline applications are possible).

--- a/doc/swagger.v1.yml
+++ b/doc/swagger.v1.yml
@@ -1,0 +1,90 @@
+swagger: '2.0'
+info:
+  title: Foodsoft API v1
+  version: '1.0.0'
+  description: >
+    [Foodsoft](https://github.com/foodcoops/foodsoft) is web-based software to manage
+    a non-profit food coop (product catalog, ordering, accounting, job scheduling).
+
+
+    This is a description of Foodsoft's API v1, which exposes operations that a member
+    can do (later API versions may include admin functionality). It includes listing
+    open orders, and changing what the member wants to order (in the ordergroup).
+
+
+    Note that each food cooperative typically has their own instance (on a shared
+    server or their own installation), and there are just as many APIs (if the Foodsoft
+    version is recent enough).
+    This API description points to the default development url with the default
+    Foodsoft scope - that would be [http://localhost:3000/f](http://localhost:3000/f).
+
+    You may find the search parameters for index endpoints lacking. They are not
+    documented here, because there are too many combinations. For now, you'll need
+    to resort to [Ransack](https://github.com/activerecord-hackery/ransack) and
+    looking at Foodsoft's `ransackable_*` model class methods.
+externalDocs:
+  description: General Foodsoft API documentation
+  url: https://github.com/foodcoops/foodsoft/blob/master/doc/API.md
+
+# development url with default scope
+host: localhost:3000
+schemes:
+  - 'http'
+basePath: /f/api/v1
+
+produces:
+  - 'application/json'
+
+paths:
+
+definitions:
+  Error:
+    type: object
+    properties:
+      error:
+        type: string
+        description: error code
+      error_description:
+        type: string
+        description: human-readable error message (localized)
+  Error404:
+    type: object
+    properties:
+      error:
+        type: string
+        description: '<tt>not_found</tt>'
+      error_description:
+        $ref: '#/definitions/Error/properties/error_description'
+  Error401:
+    type: object
+    properties:
+      error:
+        type: string
+        description: '<tt>unauthorized</tt>'
+      error_description:
+        $ref: '#/definitions/Error/properties/error_description'
+  Error403:
+    type: object
+    properties:
+      error:
+        type: string
+        description: '<tt>forbidden</tt>'
+      error_description:
+        $ref: '#/definitions/Error/properties/error_description'
+  Error422:
+    type: object
+    properties:
+      error:
+        type: string
+        description: '<tt>not_acceptable</tt>'
+      error_description:
+        $ref: '#/definitions/Error/properties/error_description'
+
+securityDefinitions:
+  foodsoft_auth:
+    type: oauth2
+    flow: implicit
+    authorizationUrl: http://localhost:3000/f/oauth/authorize
+    scopes:
+      all: full access to user functions
+      offline_access: retain access after user has logged out

--- a/doc/swagger.v1.yml
+++ b/doc/swagger.v1.yml
@@ -56,7 +56,7 @@ paths:
       security:
         - foodsoft_auth: ['all']
 
-  /financial_transactions:
+  /user/financial_transactions:
     get:
       summary: financial transactions of the member's ordergroup
       tags:
@@ -82,7 +82,7 @@ paths:
             $ref: '#/definitions/Error403'
       security:
         - foodsoft_auth: ['all']
-  /financial_transactions/{id}:
+  /user/financial_transactions/{id}:
     parameters:
       - $ref: '#/parameters/idInUrl'
     get:

--- a/doc/swagger.v1.yml
+++ b/doc/swagger.v1.yml
@@ -55,6 +55,59 @@ paths:
             $ref: '#/definitions/Error401'
       security:
         - foodsoft_auth: ['all']
+
+  /financial_transactions:
+    get:
+      summary: financial transactions of the member's ordergroup
+      tags:
+        - 6. FinancialTransaction
+      parameters:
+        - $ref: '#/parameters/page'
+        - $ref: '#/parameters/per_page'
+      responses:
+        200:
+          description: success
+          schema:
+            type: object
+            properties:
+              financial_transactions:
+                type: array
+                items:
+                  $ref: '#/definitions/FinancialTransaction'
+              meta:
+                $ref: '#/definitions/Meta'
+        403:
+          description: user has no ordergroup
+          schema:
+            $ref: '#/definitions/Error403'
+      security:
+        - foodsoft_auth: ['all']
+  /financial_transactions/{id}:
+    parameters:
+      - $ref: '#/parameters/idInUrl'
+    get:
+      summary: find financial transaction by id
+      tags:
+        - 6. FinancialTransaction
+      responses:
+        200:
+          description: success
+          schema:
+            type: object
+            properties:
+              financial_transaction:
+                $ref: '#/definitions/FinancialTransaction'
+        403:
+          description: user has no ordergroup
+          schema:
+            $ref: '#/definitions/Error403'
+        404:
+          description: not found
+          schema:
+            $ref: '#/definitions/Error404'
+      security:
+        - foodsoft_auth: ['all']
+
   /config:
     get:
       summary: configuration variables
@@ -88,6 +141,31 @@ paths:
       security:
         - foodsoft_auth: ['all']
 
+parameters:
+  # url parameters
+  idInUrl:
+    name: id
+    type: integer
+    in: path
+    minimum: 1
+    required: true
+
+  # query parameters
+  page:
+    name: page
+    type: integer
+    in: query
+    description: page number
+    minimum: 0
+    default: 0
+  per_page:
+    name: per_page
+    type: integer
+    in: query
+    description: items per page
+    minimum: 0
+    default: 20
+
 definitions:
   # models
   User:
@@ -105,6 +183,47 @@ definitions:
         type: string
         description: language code
     required: ['id', 'name', 'email']
+
+  FinancialTransaction:
+    type: object
+    properties:
+      id:
+        type: integer
+      user_id:
+        type: ['integer', 'null']
+        description: id of user who entered the transaction (may be <tt>null</tt> for deleted users or 0 for a system user)
+      user_name:
+        type: ['string', 'null']
+        description: name of user who entered the transaction (may be <tt>null</tt> or empty string for deleted users or system users)
+      amount:
+        type: number
+        description: amount credited (negative for a debit transaction)
+      note:
+        type: string
+        description: note entered with the transaction
+      created_at:
+        type: string
+        format: date-time
+        description: when the transaction was entered
+    required: ['id', 'user_id', 'user_name', 'amount', 'note', 'created_at']
+
+  # collection meta object in root of a response
+  Meta:
+    type: object
+    properties:
+      page:
+        type: integer
+        description: page number of the returned collection
+      per_page:
+        type: integer
+        description: number of items per page
+      total_pages:
+        type: integer
+        description: total number of pages
+      total_count:
+        type: integer
+        description: total number of items in the collection
+    required: ['page', 'per_page', 'total_pages', 'total_count']
 
   Error:
     type: object

--- a/doc/swagger.v1.yml
+++ b/doc/swagger.v1.yml
@@ -36,8 +36,76 @@ produces:
   - 'application/json'
 
 paths:
+  /user:
+    get:
+      summary: info about the currently logged-in user
+      tags:
+        - 1. User
+      responses:
+        200:
+          description: success
+          schema:
+            type: object
+            properties:
+              user:
+                $ref: '#/definitions/User'
+        401:
+          description: not logged-in
+          schema:
+            $ref: '#/definitions/Error401'
+      security:
+        - foodsoft_auth: ['all']
+  /config:
+    get:
+      summary: configuration variables
+      tags:
+        - 7. General
+      responses:
+        200:
+          description: success
+          schema:
+            type: object
+        401:
+          description: not logged-in
+          schema:
+            $ref: '#/definitions/Error401'
+      security:
+        - foodsoft_auth: ['all']
+  /navigation:
+    get:
+      summary: navigation
+      tags:
+        - 7. General
+      responses:
+        200:
+          description: success
+          schema:
+            type: object
+        401:
+          description: not logged-in
+          schema:
+            $ref: '#/definitions/Error401'
+      security:
+        - foodsoft_auth: ['all']
 
 definitions:
+  # models
+  User:
+    type: object
+    properties:
+      id:
+        type: integer
+      name:
+        type: string
+        description: full name
+      email:
+        type: string
+        description: email address
+      locale:
+        type: string
+        description: language code
+    required: ['id', 'name', 'email']
+
   Error:
     type: object
     properties:

--- a/doc/swagger.v1.yml
+++ b/doc/swagger.v1.yml
@@ -53,12 +53,78 @@ paths:
           description: not logged-in
           schema:
             $ref: '#/definitions/Error401'
+        403:
+          description: missing scope
+          schema:
+            $ref: '#/definitions/Error403'
       security:
-        - foodsoft_auth: ['all']
+        - foodsoft_auth: ['user:read']
 
   /user/financial_transactions:
     get:
       summary: financial transactions of the member's ordergroup
+      tags:
+        - 1. User
+        - 6. FinancialTransaction
+      parameters:
+        - $ref: '#/parameters/page'
+        - $ref: '#/parameters/per_page'
+      responses:
+        200:
+          description: success
+          schema:
+            type: object
+            properties:
+              financial_transactions:
+                type: array
+                items:
+                  $ref: '#/definitions/FinancialTransaction'
+              meta:
+                $ref: '#/definitions/Meta'
+        401:
+          description: not logged-in
+          schema:
+            $ref: '#/definitions/Error401'
+        403:
+          description: user has no ordergroup or missing scope
+          schema:
+            $ref: '#/definitions/Error403'
+      security:
+        - foodsoft_auth: ['finance:user']
+  /user/financial_transactions/{id}:
+    parameters:
+      - $ref: '#/parameters/idInUrl'
+    get:
+      summary: find financial transaction by id
+      tags:
+        - 1. User
+        - 6. FinancialTransaction
+      responses:
+        200:
+          description: success
+          schema:
+            type: object
+            properties:
+              financial_transaction:
+                $ref: '#/definitions/FinancialTransaction'
+        401:
+          description: not logged-in
+          schema:
+            $ref: '#/definitions/Error401'
+        403:
+          description: user has no ordergroup or missing scope
+          schema:
+            $ref: '#/definitions/Error403'
+        404:
+          description: not found
+          schema:
+            $ref: '#/definitions/Error404'
+      security:
+        - foodsoft_auth: ['finance:user']
+
+  /financial_transactions:
+    get:
+      summary: financial transactions
       tags:
         - 6. FinancialTransaction
       parameters:
@@ -76,13 +142,17 @@ paths:
                   $ref: '#/definitions/FinancialTransaction'
               meta:
                 $ref: '#/definitions/Meta'
+        401:
+          description: not logged-in
+          schema:
+            $ref: '#/definitions/Error401'
         403:
-          description: user has no ordergroup
+          description: missing scope or no permission
           schema:
             $ref: '#/definitions/Error403'
       security:
-        - foodsoft_auth: ['all']
-  /user/financial_transactions/{id}:
+        - foodsoft_auth: ['finance:read', 'finance:write']
+  /financial_transactions/{id}:
     parameters:
       - $ref: '#/parameters/idInUrl'
     get:
@@ -97,8 +167,12 @@ paths:
             properties:
               financial_transaction:
                 $ref: '#/definitions/FinancialTransaction'
+        401:
+          description: not logged-in
+          schema:
+            $ref: '#/definitions/Error401'
         403:
-          description: user has no ordergroup
+          description: missing scope or no permission
           schema:
             $ref: '#/definitions/Error403'
         404:
@@ -106,7 +180,7 @@ paths:
           schema:
             $ref: '#/definitions/Error404'
       security:
-        - foodsoft_auth: ['all']
+        - foodsoft_auth: ['finance:read', 'finance:write']
 
   /config:
     get:
@@ -122,8 +196,12 @@ paths:
           description: not logged-in
           schema:
             $ref: '#/definitions/Error401'
+        403:
+          description: missing scope or no permission
+          schema:
+            $ref: '#/definitions/Error403'
       security:
-        - foodsoft_auth: ['all']
+        - foodsoft_auth: ['config:user', 'config:read', 'config:write']
   /navigation:
     get:
       summary: navigation
@@ -139,7 +217,7 @@ paths:
           schema:
             $ref: '#/definitions/Error401'
       security:
-        - foodsoft_auth: ['all']
+        - foodsoft_auth: []
 
 parameters:
   # url parameters
@@ -255,7 +333,7 @@ definitions:
     properties:
       error:
         type: string
-        description: '<tt>forbidden</tt>'
+        description: '<tt>forbidden</tt> or <tt>invalid_scope</tt>'
       error_description:
         $ref: '#/definitions/Error/properties/error_description'
   Error422:
@@ -273,5 +351,12 @@ securityDefinitions:
     flow: implicit
     authorizationUrl: http://localhost:3000/f/oauth/authorize
     scopes:
-      all: full access to user functions
+      config:user: reading Foodsoft configuration for regular users
+      config:read: reading Foodsoft configuration values
+      config:write: reading and updating Foodsoft configuration values
+      finance:user: accessing your own financial transactions
+      finance:read: reading all financial transactions
+      finance:write: reading and creating financial transactions
+      user:read: reading your own user profile
+      user:write: reading and updating your own user profile
       offline_access: retain access after user has logged out

--- a/spec/api/v1/swagger_spec.rb
+++ b/spec/api/v1/swagger_spec.rb
@@ -15,50 +15,79 @@ describe 'API v1', type: :apivore, order: :defined do
 
   context 'has valid paths' do
     context 'user' do
+      let(:api_scopes) { ['user:read'] }
       # create multiple users to make sure we're getting the authenticated user, not just any
       let!(:other_user_1) { create :user }
       let!(:user)         { create :user }
       let!(:other_user_2) { create :user }
 
-      it { is_expected.to validate(:get, '/user', 200, auth) }
+      it { is_expected.to validate(:get, '/user', 200, api_auth) }
       it { is_expected.to validate(:get, '/user', 401) }
 
-      context 'with invalid access token' do
-        let(:access_token) { 'abc' }
-        it { is_expected.to validate(:get, '/user', 401, auth) }
-      end
+      it_handles_invalid_token_and_scope(:get, '/user')
     end
 
     context 'financial_transactions' do
+      let(:api_scopes) { ['finance:user'] }
       let(:other_user) { create :user, :ordergroup }
       let!(:other_ft_1) { create :financial_transaction, ordergroup: other_user.ordergroup }
 
       context 'without ordergroup' do
-        it { is_expected.to validate(:get, '/user/financial_transactions', 403, auth) }
-        it { is_expected.to validate(:get, '/user/financial_transactions/{id}', 403, auth({'id' => other_ft_1.id})) }
+        it { is_expected.to validate(:get, '/user/financial_transactions', 403, api_auth) }
+        it { is_expected.to validate(:get, '/user/financial_transactions/{id}', 403, api_auth({'id' => other_ft_1.id})) }
       end
 
-      context 'in ordergroup' do
+      context 'with ordergroup' do
         let(:user) { create :user, :ordergroup }
         let!(:ft_1) { create :financial_transaction, ordergroup: user.ordergroup }
         let!(:ft_2) { create :financial_transaction, ordergroup: user.ordergroup }
         let!(:ft_3) { create :financial_transaction, ordergroup: user.ordergroup }
 
-        it { is_expected.to validate(:get, '/user/financial_transactions', 200, auth) }
-        it { is_expected.to validate(:get, '/user/financial_transactions/{id}', 200, auth({'id' => ft_2.id})) }
-        it { is_expected.to validate(:get, '/user/financial_transactions/{id}', 404, auth({'id' => other_ft_1.id})) }
-        it { is_expected.to validate(:get, '/user/financial_transactions/{id}', 404, auth({'id' => FinancialTransaction.last.id + 1})) }
+        it { is_expected.to validate(:get, '/user/financial_transactions', 200, api_auth) }
+        it { is_expected.to validate(:get, '/user/financial_transactions/{id}', 200, api_auth({'id' => ft_2.id})) }
+        it { is_expected.to validate(:get, '/user/financial_transactions/{id}', 404, api_auth({'id' => other_ft_1.id})) }
+        it { is_expected.to validate(:get, '/user/financial_transactions/{id}', 404, api_auth({'id' => FinancialTransaction.last.id + 1})) }
+
+        it_handles_invalid_token_and_scope(:get, '/user/financial_transactions')
+        it_handles_invalid_token_and_scope(:get, '/user/financial_transactions/{id}', ->{ api_auth('id' => ft_2.id) })
       end
     end
 
     context 'config' do
-      it { is_expected.to validate(:get, '/config', 200, auth) }
+      let(:api_scopes) { ['config:user'] }
+
+      it { is_expected.to validate(:get, '/config', 200, api_auth) }
       it { is_expected.to validate(:get, '/config', 401) }
+
+      it_handles_invalid_token_and_scope(:get, '/config')
     end
 
     context 'navigation' do
-      it { is_expected.to validate(:get, '/navigation', 200, auth) }
+      it { is_expected.to validate(:get, '/navigation', 200, api_auth) }
       it { is_expected.to validate(:get, '/navigation', 401) }
+
+      it_handles_invalid_token(:get, '/navigation')
+    end
+
+    context 'financial_transactions' do
+      let(:api_scopes) { ['finance:read'] }
+      let(:user) { create(:user, :role_finance) }
+      let(:other_user) { create :user, :ordergroup }
+      let!(:ft_1) { create :financial_transaction, ordergroup: other_user.ordergroup }
+      let!(:ft_2) { create :financial_transaction, ordergroup: other_user.ordergroup }
+
+      it { is_expected.to validate(:get, '/financial_transactions', 200, api_auth) }
+      it { is_expected.to validate(:get, '/financial_transactions/{id}', 200, api_auth({'id' => ft_2.id})) }
+      it { is_expected.to validate(:get, '/financial_transactions/{id}', 404, api_auth({'id' => FinancialTransaction.last.id + 1})) }
+
+      context 'without role_finance' do
+        let(:user) { create(:user) }
+        it { is_expected.to validate(:get, '/financial_transactions', 403, api_auth) }
+        it { is_expected.to validate(:get, '/financial_transactions/{id}', 403, api_auth({'id' => ft_2.id})) }
+      end
+
+      it_handles_invalid_token_and_scope(:get, '/financial_transactions')
+      it_handles_invalid_token_and_scope(:get, '/financial_transactions/{id}', ->{ api_auth({'id' => ft_2.id}) })
     end
   end
 

--- a/spec/api/v1/swagger_spec.rb
+++ b/spec/api/v1/swagger_spec.rb
@@ -13,7 +13,37 @@ describe 'API v1', type: :apivore, order: :defined do
 
   subject { SwaggerCheckerFile.instance_for Rails.root.join('doc', 'swagger.v1.yml') }
 
-  it 'tests all documented routes' do
-    is_expected.to validate_all_paths
+  context 'has valid paths' do
+    context 'user' do
+      # create multiple users to make sure we're getting the authenticated user, not just any
+      let!(:other_user_1) { create :user }
+      let!(:user)         { create :user }
+      let!(:other_user_2) { create :user }
+
+      it { is_expected.to validate(:get, '/user', 200, auth) }
+      it { is_expected.to validate(:get, '/user', 401) }
+
+      context 'with invalid access token' do
+        let(:access_token) { 'abc' }
+        it { is_expected.to validate(:get, '/user', 401, auth) }
+      end
+    end
+
+    context 'config' do
+      it { is_expected.to validate(:get, '/config', 200, auth) }
+      it { is_expected.to validate(:get, '/config', 401) }
+    end
+
+    context 'navigation' do
+      it { is_expected.to validate(:get, '/navigation', 200, auth) }
+      it { is_expected.to validate(:get, '/navigation', 401) }
+    end
+  end
+
+  # needs to be last context so it is always run at the end
+  context 'and finally' do
+    it 'tests all documented routes' do
+      is_expected.to validate_all_paths
+    end
   end
 end

--- a/spec/api/v1/swagger_spec.rb
+++ b/spec/api/v1/swagger_spec.rb
@@ -29,6 +29,28 @@ describe 'API v1', type: :apivore, order: :defined do
       end
     end
 
+  context 'financial_transactions' do
+    let(:other_user) { create :user, :ordergroup }
+    let!(:other_ft_1) { create :financial_transaction, ordergroup: other_user.ordergroup }
+
+    context 'without ordergroup' do
+      it { is_expected.to validate(:get, '/financial_transactions', 403, auth) }
+      it { is_expected.to validate(:get, '/financial_transactions/{id}', 403, auth({'id' => other_ft_1.id})) }
+    end
+
+    context 'in ordergroup' do
+      let(:user) { create :user, :ordergroup }
+      let!(:ft_1) { create :financial_transaction, ordergroup: user.ordergroup }
+      let!(:ft_2) { create :financial_transaction, ordergroup: user.ordergroup }
+      let!(:ft_3) { create :financial_transaction, ordergroup: user.ordergroup }
+
+      it { is_expected.to validate(:get, '/financial_transactions', 200, auth) }
+      it { is_expected.to validate(:get, '/financial_transactions/{id}', 200, auth({'id' => ft_2.id})) }
+      it { is_expected.to validate(:get, '/financial_transactions/{id}', 404, auth({'id' => other_ft_1.id})) }
+      it { is_expected.to validate(:get, '/financial_transactions/{id}', 404, auth({'id' => FinancialTransaction.last.id + 1})) }
+    end
+  end
+
     context 'config' do
       it { is_expected.to validate(:get, '/config', 200, auth) }
       it { is_expected.to validate(:get, '/config', 401) }

--- a/spec/api/v1/swagger_spec.rb
+++ b/spec/api/v1/swagger_spec.rb
@@ -29,27 +29,27 @@ describe 'API v1', type: :apivore, order: :defined do
       end
     end
 
-  context 'financial_transactions' do
-    let(:other_user) { create :user, :ordergroup }
-    let!(:other_ft_1) { create :financial_transaction, ordergroup: other_user.ordergroup }
+    context 'financial_transactions' do
+      let(:other_user) { create :user, :ordergroup }
+      let!(:other_ft_1) { create :financial_transaction, ordergroup: other_user.ordergroup }
 
-    context 'without ordergroup' do
-      it { is_expected.to validate(:get, '/user/financial_transactions', 403, auth) }
-      it { is_expected.to validate(:get, '/user/financial_transactions/{id}', 403, auth({'id' => other_ft_1.id})) }
+      context 'without ordergroup' do
+        it { is_expected.to validate(:get, '/user/financial_transactions', 403, auth) }
+        it { is_expected.to validate(:get, '/user/financial_transactions/{id}', 403, auth({'id' => other_ft_1.id})) }
+      end
+
+      context 'in ordergroup' do
+        let(:user) { create :user, :ordergroup }
+        let!(:ft_1) { create :financial_transaction, ordergroup: user.ordergroup }
+        let!(:ft_2) { create :financial_transaction, ordergroup: user.ordergroup }
+        let!(:ft_3) { create :financial_transaction, ordergroup: user.ordergroup }
+
+        it { is_expected.to validate(:get, '/user/financial_transactions', 200, auth) }
+        it { is_expected.to validate(:get, '/user/financial_transactions/{id}', 200, auth({'id' => ft_2.id})) }
+        it { is_expected.to validate(:get, '/user/financial_transactions/{id}', 404, auth({'id' => other_ft_1.id})) }
+        it { is_expected.to validate(:get, '/user/financial_transactions/{id}', 404, auth({'id' => FinancialTransaction.last.id + 1})) }
+      end
     end
-
-    context 'in ordergroup' do
-      let(:user) { create :user, :ordergroup }
-      let!(:ft_1) { create :financial_transaction, ordergroup: user.ordergroup }
-      let!(:ft_2) { create :financial_transaction, ordergroup: user.ordergroup }
-      let!(:ft_3) { create :financial_transaction, ordergroup: user.ordergroup }
-
-      it { is_expected.to validate(:get, '/user/financial_transactions', 200, auth) }
-      it { is_expected.to validate(:get, '/user/financial_transactions/{id}', 200, auth({'id' => ft_2.id})) }
-      it { is_expected.to validate(:get, '/user/financial_transactions/{id}', 404, auth({'id' => other_ft_1.id})) }
-      it { is_expected.to validate(:get, '/user/financial_transactions/{id}', 404, auth({'id' => FinancialTransaction.last.id + 1})) }
-    end
-  end
 
     context 'config' do
       it { is_expected.to validate(:get, '/config', 200, auth) }

--- a/spec/api/v1/swagger_spec.rb
+++ b/spec/api/v1/swagger_spec.rb
@@ -34,8 +34,8 @@ describe 'API v1', type: :apivore, order: :defined do
     let!(:other_ft_1) { create :financial_transaction, ordergroup: other_user.ordergroup }
 
     context 'without ordergroup' do
-      it { is_expected.to validate(:get, '/financial_transactions', 403, auth) }
-      it { is_expected.to validate(:get, '/financial_transactions/{id}', 403, auth({'id' => other_ft_1.id})) }
+      it { is_expected.to validate(:get, '/user/financial_transactions', 403, auth) }
+      it { is_expected.to validate(:get, '/user/financial_transactions/{id}', 403, auth({'id' => other_ft_1.id})) }
     end
 
     context 'in ordergroup' do
@@ -44,10 +44,10 @@ describe 'API v1', type: :apivore, order: :defined do
       let!(:ft_2) { create :financial_transaction, ordergroup: user.ordergroup }
       let!(:ft_3) { create :financial_transaction, ordergroup: user.ordergroup }
 
-      it { is_expected.to validate(:get, '/financial_transactions', 200, auth) }
-      it { is_expected.to validate(:get, '/financial_transactions/{id}', 200, auth({'id' => ft_2.id})) }
-      it { is_expected.to validate(:get, '/financial_transactions/{id}', 404, auth({'id' => other_ft_1.id})) }
-      it { is_expected.to validate(:get, '/financial_transactions/{id}', 404, auth({'id' => FinancialTransaction.last.id + 1})) }
+      it { is_expected.to validate(:get, '/user/financial_transactions', 200, auth) }
+      it { is_expected.to validate(:get, '/user/financial_transactions/{id}', 200, auth({'id' => ft_2.id})) }
+      it { is_expected.to validate(:get, '/user/financial_transactions/{id}', 404, auth({'id' => other_ft_1.id})) }
+      it { is_expected.to validate(:get, '/user/financial_transactions/{id}', 404, auth({'id' => FinancialTransaction.last.id + 1})) }
     end
   end
 

--- a/spec/api/v1/swagger_spec.rb
+++ b/spec/api/v1/swagger_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+require 'apivore'
+
+# we want to load a local file in YAML-format instead of a served JSON file
+class SwaggerCheckerFile < Apivore::SwaggerChecker
+  def fetch_swagger!
+    YAML.load(File.read(swagger_path))
+  end
+end
+
+describe 'API v1', type: :apivore, order: :defined do
+  include ApiHelper
+
+  subject { SwaggerCheckerFile.instance_for Rails.root.join('doc', 'swagger.v1.yml') }
+
+  it 'tests all documented routes' do
+    is_expected.to validate_all_paths
+  end
+end

--- a/spec/factories/doorkeeper.rb
+++ b/spec/factories/doorkeeper.rb
@@ -1,0 +1,15 @@
+require 'factory_bot'
+require 'doorkeeper'
+
+FactoryBot.define do
+
+  factory :oauth2_application, class: Doorkeeper::Application do
+    name { Faker::App.name }
+    redirect_uri 'https://example.com:1234/app'
+  end
+
+  factory :oauth2_access_token, class: Doorkeeper::AccessToken do
+    application factory: :oauth2_application
+  end
+
+end

--- a/spec/factories/financial_transaction.rb
+++ b/spec/factories/financial_transaction.rb
@@ -1,0 +1,15 @@
+require 'factory_bot'
+
+FactoryBot.define do
+  factory :financial_transaction do
+    user
+    ordergroup
+    amount { rand(-99_999.00..99_999.00) }
+    note { Faker::Lorem.sentence }
+
+    # This builds a new type and class by default, while for normal financial
+    # transactions we'd use the default. This, however, is the easiest way to
+    # get the factory going. If you want equal types, specify it explicitly.
+    financial_transaction_type
+  end
+end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -15,6 +15,12 @@ FactoryBot.define do
         create :workgroup, role_admin: true, user_ids: [user.id]
       end
     end
+
+    trait :ordergroup do
+      after :create do |user, evaluator|
+        create :ordergroup, user_ids: [user.id]
+      end
+    end
   end
 
   factory :group do

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -21,6 +21,14 @@ FactoryBot.define do
         create :ordergroup, user_ids: [user.id]
       end
     end
+
+    [:ordergroup, :finance, :invoices, :article_meta, :suppliers, :pickups, :orders].each do |role|
+      trait "role_#{role}".to_sym do
+        after :create do |user, evaluator|
+          create :workgroup, "role_#{role}" => true, user_ids: [user.id]
+        end
+      end
+    end
   end
 
   factory :group do

--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -2,17 +2,37 @@ module ApiHelper
   extend ActiveSupport::Concern
 
   included do
-    let(:user) { create :user }
-    let(:access_token) { create(:oauth2_access_token, resource_owner_id: user.id).token }
-    let(:authorization) { "Bearer #{token}" }
+    let(:user) { create(:user) }
+    let(:api_scopes) { [] } # empty scopes for stricter testing (in reality this would be default_scopes)
+    let(:api_access_token) { create(:oauth2_access_token, resource_owner_id: user.id, scopes: api_scopes&.join(' ')).token }
+    let(:api_authorization) { "Bearer #{api_access_token}" }
+
+    def self.it_handles_invalid_token(method, path, params_block = ->{ api_auth })
+      context 'with invalid access token' do
+        let(:api_access_token) { 'abc' }
+        it { is_expected.to validate(method, path, 401, instance_exec(&params_block)) }
+      end
+    end
+
+    def self.it_handles_invalid_scope(method, path, params_block = ->{ api_auth })
+      context 'with invalid scope' do
+        let(:api_scopes) { ['none'] }
+        it { is_expected.to validate(method, path, 403, instance_exec(&params_block)) }
+      end
+    end
+
+    def self.it_handles_invalid_token_and_scope(*args)
+      it_handles_invalid_token(*args)
+      it_handles_invalid_scope(*args)
+    end
   end
 
   # Add authentication to parameters for {Swagger::RspecHelpers#validate}
   # @param params [Hash] Query parameters
   # @return Query parameters with authentication header
   # @see Swagger::RspecHelpers#validate
-  def auth(params = {})
-    {'_headers' => {'Authorization' => "Bearer #{access_token}" }}.deep_merge(params)
+  def api_auth(params = {})
+    {'_headers' => {'Authorization' => api_authorization }}.deep_merge(params)
   end
 
 end

--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -1,0 +1,18 @@
+module ApiHelper
+  extend ActiveSupport::Concern
+
+  included do
+    let(:user) { create :user }
+    let(:access_token) { create(:oauth2_access_token, resource_owner_id: user.id).token }
+    let(:authorization) { "Bearer #{token}" }
+  end
+
+  # Add authentication to parameters for {Swagger::RspecHelpers#validate}
+  # @param params [Hash] Query parameters
+  # @return Query parameters with authentication header
+  # @see Swagger::RspecHelpers#validate
+  def auth(params = {})
+    {'_headers' => {'Authorization' => "Bearer #{access_token}" }}.deep_merge(params)
+  end
+
+end


### PR DESCRIPTION
Part three of #429 in chunks, continued from #571:
* A _collection scope_ concern for listing and searching index API endpoints
* `/api/v1/financial_transactions`
* `/api/v1/financial_transactions/:id`
* `/api/v1/user/financial_transactions`
* `/api/v1/user/financial_transactions/:id`
* OAuth scopes (as discussed in https://github.com/foodcoops/foodsoft/issues/582#issuecomment-442513237)

This doesn't include transaction types or classes yet, since I haven't really worked out how to work with them in an application. Will they have separate endpoints, or is relevant data in the financial transactions endpoint enough? To not over-engineer it, I'd like to postpone adding that until the need arises.

See also the [Swagger UI](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/wvengen/foodsoft/feature/api-3-endpoints-basic/doc/swagger.v1.yml).