### PR TITLE
API-4: ordering

### DIFF
--- a/app/controllers/api/v1/article_categories_controller.rb
+++ b/app/controllers/api/v1/article_categories_controller.rb
@@ -1,0 +1,26 @@
+class Api::V1::ArticleCategoriesController < Api::V1::BaseController
+  include Concerns::CollectionScope
+
+  def index
+    render json: search_scope
+  end
+
+  def show
+    render json: scope.find(params.require(:id))
+  end
+
+  private
+
+  def max_per_page
+    nil
+  end
+
+  def default_per_page
+    nil
+  end
+
+  def scope
+    ArticleCategory.all
+  end
+
+end

--- a/app/controllers/api/v1/order_articles_controller.rb
+++ b/app/controllers/api/v1/order_articles_controller.rb
@@ -1,0 +1,38 @@
+class Api::V1::OrderArticlesController < Api::V1::BaseController
+  include Concerns::CollectionScope
+
+  before_action ->{ doorkeeper_authorize! 'orders:read', 'orders:write' }
+
+  def index
+    render_collection search_scope
+  end
+
+  def show
+    render json: scope.find(params.require(:id))
+  end
+
+  private
+
+  def scope
+    OrderArticle.includes(:article_price, article: :supplier)
+  end
+
+  def search_scope
+    merge_ordered_scope(super, params.fetch(:q, {})[:ordered])
+  end
+
+  def merge_ordered_scope(scope, ordered)
+    if ordered.blank?
+      scope
+    elsif ordered == 'member' && current_ordergroup
+      scope.joins(:group_order_articles).merge(current_ordergroup.group_order_articles)
+    elsif ordered == 'all'
+      table = scope.arel_table
+      scope.where(table[:quantity].gt(0).or(table[:tolerance].gt(0)))
+    elsif ordered == 'supplier'
+      scope.ordered
+    else
+      scope.none # as a hint that it's an invalid value
+    end
+  end
+end

--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -1,0 +1,19 @@
+class Api::V1::OrdersController < Api::V1::BaseController
+  include Concerns::CollectionScope
+
+  before_action ->{ doorkeeper_authorize! 'orders:read', 'orders:write' }
+
+  def index
+    render_collection search_scope
+  end
+
+  def show
+    render json: scope.find(params.require(:id))
+  end
+
+  private
+
+  def scope
+    Order.includes(:supplier)
+  end
+end

--- a/app/controllers/api/v1/user/group_order_articles_controller.rb
+++ b/app/controllers/api/v1/user/group_order_articles_controller.rb
@@ -1,0 +1,108 @@
+class Api::V1::User::GroupOrderArticlesController < Api::V1::BaseController
+  include Concerns::CollectionScope
+
+  before_action ->{ doorkeeper_authorize! 'group_orders:user' }
+
+  before_action :require_ordergroup
+  before_action :require_minimum_balance, only: [:create, :update] # destroy is ok
+  before_action :require_enough_apples, only: [:create, :update] # destroy is ok
+  # @todo allow decreasing amounts when minimum balance isn't met
+
+  def index
+    render_collection search_scope
+  end
+
+  def show
+    goa = scope.find(params.require(:id))
+    render_goa_with_oa(goa)
+  end
+
+  def create
+    goa = nil
+    GroupOrderArticle.transaction do
+      oa = order_articles_scope_for_create.find(create_params.require(:order_article_id))
+      go = current_ordergroup.group_orders.find_or_create_by!(order_id: oa.order_id)
+      goa = go.group_order_articles.create!(order_article: oa)
+      goa.update_quantities((create_params[:quantity] || 0).to_i, (create_params[:tolerance] || 0).to_i)
+      oa.update_results!
+      go.update_price!
+      go.update_attributes! updated_by: current_user
+    end
+    render_goa_with_oa(goa)
+  end
+
+  def update
+    goa = nil
+    GroupOrderArticle.transaction do
+      goa = scope_for_update.includes(:group_order_article_quantities).find(params.require(:id))
+      goa.update_quantities((update_params[:quantity] || goa.quantity).to_i, (update_params[:tolerance] || goa.tolerance).to_i)
+      goa.order_article.update_results!
+      goa.group_order.update_price!
+      goa.group_order.update_attributes! updated_by: current_user
+    end
+    render_goa_with_oa(goa)
+  end
+
+  def destroy
+    goa = nil
+    GroupOrderArticle.transaction do
+      goa = scope_for_update.find(params.require(:id))
+      goa.destroy!
+      goa.order_article.update_results!
+      goa.group_order.update_price!
+      goa.group_order.update_attributes! updated_by: current_user
+    end
+    render_goa_with_oa(nil, goa.order_article)
+  end
+
+  private
+
+  def max_per_page
+    nil
+  end
+
+  def scope
+    GroupOrderArticle.
+      joins(:group_order).
+      includes(order_article: :article, group_order: :order).
+      where(group_orders: { ordergroup_id: current_ordergroup.id })
+  end
+
+  def scope_for_update
+    scope.references(order_article: { group_order: :order }).merge(Order.open)
+  end
+
+  def order_articles_scope_for_create
+    OrderArticle.joins(:order).merge(Order.open)
+  end
+
+  def create_params
+    params.require(:group_order_article).permit(:order_article_id, :quantity, :tolerance)
+  end
+
+  def update_params
+    params.require(:group_order_article).permit(:quantity, :tolerance)
+  end
+
+  def require_minimum_balance
+    minimum_balance = FoodsoftConfig[:minimum_balance] or return
+    if current_ordergroup.account_balance < minimum_balance
+      raise Api::Errors::PermissionRequired.new(t('application.controller.error_minimum_balance', min: minimum_balance))
+    end
+  end
+
+  def require_enough_apples
+    if current_ordergroup.not_enough_apples?
+      s = t('group_orders.messages.not_enough_apples', apples: current_ordergroup.apples, stop_ordering_under: FoodsoftConfig[:stop_ordering_under])
+      raise Api::Errors::PermissionRequired.new(s)
+    end
+  end
+
+  def render_goa_with_oa(goa, oa = goa.order_article)
+    data = {}
+    data[:group_order_article] = GroupOrderArticleSerializer.new(goa) if goa
+    data[:order_article] = OrderArticleSerializer.new(oa) if oa
+
+    render json: data, root: nil
+  end
+end

--- a/app/controllers/concerns/auth_api.rb
+++ b/app/controllers/concerns/auth_api.rb
@@ -53,14 +53,19 @@ module Concerns::AuthApi
     end
 
     case scope_parts.first
-    when 'user'           then true # access to the current user's own profile
-    when 'config'         then current_user.role_admin?
-    when 'users'          then current_user.role_admin?
-    when 'workgroups'     then current_user.role_admin?
-    when 'suppliers'      then current_user.role_suppliers?
-    when 'group_orders'   then current_user.role_orders?
-    when 'finance'        then current_user.role_finance?
+    when 'user'           then return true # access to the current user's own profile
+    when 'config'         then return current_user.role_admin?
+    when 'users'          then return current_user.role_admin?
+    when 'workgroups'     then return current_user.role_admin?
+    when 'suppliers'      then return current_user.role_suppliers?
+    when 'group_orders'   then return current_user.role_orders?
+    when 'finance'        then return current_user.role_finance?
     # please note that offline_access does not belong here, since it is not used for permission checking
+    end
+
+    case scope
+    when 'orders:read'    then return true
+    when 'orders:write'   then return current_user.role_orders?
     end
   end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -43,6 +43,12 @@ class Article < ApplicationRecord
   # @!attribute article_prices
   #   @return [Array<ArticlePrice>] Price history (current price first).
   has_many :article_prices, -> { order("created_at DESC") }
+  # @!attribute order_articles
+  #   @return [Array<OrderArticle>] Order articles for this article.
+  has_many :order_articles
+  # @!attribute order
+  #   @return [Array<Order>] Orders this article appears in.
+  has_many :orders, through: :order_articles
 
   # Replace numeric seperator with database format
   localize_input_of :price, :tax, :deposit
@@ -67,6 +73,14 @@ class Article < ApplicationRecord
   # Callbacks
   before_save :update_price_history
   before_destroy :check_article_in_use
+
+  def self.ransackable_attributes(auth_object = nil)
+    %w(id name supplier_id article_category_id unit note manufacturer origin unit_quantity order_number)
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    %w(article_category supplier order_articles orders)
+  end
 
   # Returns true if article has been updated at least 2 days ago
   def recently_updated

--- a/app/models/article_category.rb
+++ b/app/models/article_category.rb
@@ -9,12 +9,26 @@ class ArticleCategory < ApplicationRecord
   # @!attribute articles
   #   @return [Array<Article>] Articles with this category.
   has_many :articles
+  # @!attribute order_articles
+  #   @return [Array<OrderArticle>] Order articles with this category.
+  has_many :order_articles, through: :articles
+  # @!attribute orders
+  #   @return [Array<Order>] Orders with articles in this category.
+  has_many :orders, through: :order_articles
 
   normalize_attributes :name, :description
 
   validates :name, :presence => true, :uniqueness => true, :length => { :minimum => 2 }
 
   before_destroy :check_for_associated_articles
+
+  def self.ransackable_attributes(auth_object = nil)
+    %w(id name)
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    %w(articles order_articles orders)
+  end
 
   # Find a category that matches a category name; may return nil.
   # TODO more intelligence like remembering earlier associations (global and/or per-supplier)

--- a/app/models/group_order.rb
+++ b/app/models/group_order.rb
@@ -21,6 +21,14 @@ class GroupOrder < ApplicationRecord
 
   scope :ordered, -> { includes(:ordergroup).order('groups.name') }
 
+  def self.ransackable_attributes(auth_object = nil)
+    %w(id price)
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    %w(order group_order_articles)
+  end
+
   # Generate some data for the javascript methods in ordering view
   def load_data
     data = {}

--- a/app/models/group_order_article.rb
+++ b/app/models/group_order_article.rb
@@ -5,15 +5,24 @@ class GroupOrderArticle < ApplicationRecord
 
   belongs_to :group_order
   belongs_to :order_article
-  has_many   :group_order_article_quantities, :dependent => :destroy
+  has_many   :group_order_article_quantities, dependent: :destroy
 
   validates_presence_of :group_order, :order_article
   validates_uniqueness_of :order_article_id, :scope => :group_order_id    # just once an article per group order
   validate :check_order_not_closed # don't allow changes to closed (aka settled) orders
+  validates :quantity, :tolerance, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
 
   scope :ordered, -> { includes(:group_order => :ordergroup).order('groups.name') }
 
   localize_input_of :result
+
+  def self.ransackable_attributes(auth_object = nil)
+    %w(id quantity tolerance result)
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    %w(order_article group_order)
+  end
 
   # Setter used in group_order_article#new
   # We have to create an group_order, if the ordergroup wasn't involved in the order yet
@@ -86,7 +95,7 @@ class GroupOrderArticle < ApplicationRecord
 
     # Check if something went terribly wrong and quantites have not been adjusted as desired.
     if (self.quantity != quantity || self.tolerance != tolerance)
-      raise 'Invalid state: unable to update GroupOrderArticle/-Quantities to desired quantities!'
+      raise ActiveRecord::RecordNotSaved.new('Unable to update GroupOrderArticle/-Quantities to desired quantities!', self)
     end
 
     # Remove zero-only items.

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -30,9 +30,9 @@ class Order < ApplicationRecord
 
   # Finders
   scope :started, -> { where('starts <= ?', Time.now) }
-  scope :closed, -> { where(state: 'closed').order('ends DESC') }
-  scope :stockit, -> { where(supplier_id: nil).order('ends DESC') }
-  scope :recent, -> { order('starts DESC').limit(10) }
+  scope :closed, -> { where(state: 'closed').order(ends: :desc) }
+  scope :stockit, -> { where(supplier_id: nil).order(ends: :desc) }
+  scope :recent, -> { order(starts: :desc).limit(10) }
   scope :stock_group_order, -> { group_orders.where(ordergroup_id: nil).first }
   scope :with_invoice, -> { where.not(invoice: nil) }
 
@@ -42,9 +42,9 @@ class Order < ApplicationRecord
   # So orders can
   # 1. ...only transition in one direction (e.g. an order that has been `finished` currently cannot be reopened)
   # 2. ...be set to `closed` when having the `finished` state. (`received` is optional)
-  scope :open, -> { where(state: 'open').order('ends DESC') }
-  scope :finished, -> { where(state: %w[finished received closed]).order('ends DESC') }
-  scope :finished_not_closed, -> { where(state: %w[finished received]).order('ends DESC') }
+  scope :open, -> { where(state: 'open').order(ends: :desc) }
+  scope :finished, -> { where(state: %w[finished received closed]).order(ends: :desc) }
+  scope :finished_not_closed, -> { where(state: %w[finished received]).order(ends: :desc) }
 
   # Allow separate inputs for date and time
   #   with workaround for https://github.com/einzige/date_time_attribute/issues/14

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -51,6 +51,14 @@ class Order < ApplicationRecord
   include DateTimeAttributeValidate
   date_time_attribute :starts, :boxfill, :ends
 
+  def self.ransackable_attributes(auth_object = nil)
+    %w(id state supplier_id starts boxfill ends pickup)
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    %w(supplier articles order_articles)
+  end
+
   def stockit?
     supplier_id.nil?
   end
@@ -111,11 +119,11 @@ class Order < ApplicationRecord
   end
 
   def boxfill?
-    FoodsoftConfig[:use_boxfill] && open? && boxfill.present? && boxfill < Time.now
+    !!FoodsoftConfig[:use_boxfill] && open? && boxfill.present? && boxfill < Time.now
   end
 
   def is_boxfill_useful?
-    FoodsoftConfig[:use_boxfill] && supplier.try(:has_tolerance?)
+    !!FoodsoftConfig[:use_boxfill] && !!supplier.try(:has_tolerance?)
   end
 
   def expired?

--- a/app/models/order_article.rb
+++ b/app/models/order_article.rb
@@ -20,6 +20,14 @@ class OrderArticle < ApplicationRecord
   before_create :init_from_balancing
   after_destroy :update_ordergroup_prices
 
+  def self.ransackable_attributes(auth_object = nil)
+    %w(id order_id article_id quantity tolerance units_to_order)
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    %w(order article)
+  end
+
   # This method returns either the ArticlePrice or the Article
   # The first will be set, when the the order is finished
   def price

--- a/app/models/ordergroup.rb
+++ b/app/models/ordergroup.rb
@@ -13,7 +13,8 @@ class Ordergroup < Group
 
   has_many :financial_transactions
   has_many :group_orders
-  has_many :orders, :through => :group_orders
+  has_many :orders, through: :group_orders
+  has_many :group_order_articles, through: :group_orders
 
   validates_numericality_of :account_balance, :message => I18n.t('ordergroups.model.invalid_balance')
   validate :uniqueness_of_name, :uniqueness_of_members

--- a/app/models/stock_article.rb
+++ b/app/models/stock_article.rb
@@ -9,6 +9,16 @@ class StockArticle < Article
 
   before_destroy :check_quantity
 
+  ransack_alias :quantity_available, :quantity # in-line with {StockArticleSerializer}
+
+  def self.ransackable_attributes(auth_object = nil)
+    super(auth_object) - %w(supplier_id) + %w(quantity)
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    super(auth_object) - %w(supplier)
+  end
+
   # Update the quantity of items in stock
   def update_quantity!
     update_attribute :quantity, stock_changes.collect(&:quantity).sum

--- a/app/models/supplier.rb
+++ b/app/models/supplier.rb
@@ -23,6 +23,14 @@ class Supplier < ApplicationRecord
   scope :undeleted, -> { where(deleted_at: nil) }
   scope :having_articles, -> { where(id: Article.undeleted.select(:supplier_id).distinct) }
 
+  def self.ransackable_attributes(auth_object = nil)
+    %w(id name)
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    %w(articles stock_articles orders)
+  end
+
   # sync all articles with the external database
   # returns an array with articles(and prices), which should be updated (to use in a form)
   # also returns an array with outlisted_articles, which should be deleted

--- a/app/serializers/article_category_serializer.rb
+++ b/app/serializers/article_category_serializer.rb
@@ -1,0 +1,3 @@
+class ArticleCategorySerializer < ActiveModel::Serializer
+  attributes :id, :name
+end

--- a/app/serializers/article_serializer.rb
+++ b/app/serializers/article_serializer.rb
@@ -1,0 +1,9 @@
+class ArticleSerializer < ActiveModel::Serializer
+  attributes :id, :name
+  attributes :supplier_id, :supplier_name
+  attributes :unit, :unit_quantity, :note, :manufacturer, :origin, :article_category_id
+
+  def supplier_name
+    object.supplier.try(:name)
+  end
+end

--- a/app/serializers/group_order_article_serializer.rb
+++ b/app/serializers/group_order_article_serializer.rb
@@ -1,0 +1,8 @@
+class GroupOrderArticleSerializer < ActiveModel::Serializer
+  attributes :id, :order_article_id
+  attributes :quantity, :tolerance, :result, :total_price
+
+  def total_price
+    object.total_price.to_f
+  end
+end

--- a/app/serializers/order_article_serializer.rb
+++ b/app/serializers/order_article_serializer.rb
@@ -1,0 +1,10 @@
+class OrderArticleSerializer < ActiveModel::Serializer
+  attributes :id, :order_id, :price
+  attributes :quantity, :tolerance, :units_to_order
+
+  has_one :article
+
+  def price
+    object.price.fc_price.to_f
+  end
+end

--- a/app/serializers/order_serializer.rb
+++ b/app/serializers/order_serializer.rb
@@ -1,0 +1,11 @@
+class OrderSerializer < ActiveModel::Serializer
+  attributes :id, :name, :starts, :ends, :boxfill, :pickup, :is_open, :is_boxfill
+
+  def is_open
+    object.open?
+  end
+
+  def is_boxfill
+    object.boxfill?
+  end
+end

--- a/app/serializers/stock_article_serializer.rb
+++ b/app/serializers/stock_article_serializer.rb
@@ -1,0 +1,7 @@
+class StockArticleSerializer < ArticleSerializer
+  attribute :quantity_available
+
+  def quantity_available
+    object.quantity
+  end
+end

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -49,7 +49,7 @@ Doorkeeper.configure do
   # https://github.com/doorkeeper-gem/doorkeeper/wiki/Using-Scopes
 
   # default is a collection of read-only scopes
-  default_scopes 'config:user', 'finance:user', 'user:read', 'orders:read'
+  default_scopes 'config:user', 'finance:user', 'user:read', 'orders:read', 'group_orders:user'
 
   optional_scopes 'config:read', 'config:write',
                   'finance:read', 'finance:write',

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -49,10 +49,11 @@ Doorkeeper.configure do
   # https://github.com/doorkeeper-gem/doorkeeper/wiki/Using-Scopes
 
   # default is a collection of read-only scopes
-  default_scopes 'config:user', 'finance:user', 'user:read'
+  default_scopes 'config:user', 'finance:user', 'user:read', 'orders:read'
 
   optional_scopes 'config:read', 'config:write',
                   'finance:read', 'finance:write',
+                  'orders:write',
                   'user:write',
                   'offline_access'
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -418,6 +418,7 @@ en:
       error_denied_sign_in: sign in as another user
       error_feature_disabled: This feature is currently disabled.
       error_members_only: This action is only available to members of the group!
+      error_minimum_balance: Sorry, your account balance is below the minimum of %{min}.
       error_token: Access denied (invalid token)!
   article_categories:
     create:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -272,6 +272,7 @@ Rails.application.routes.draw do
         resources :financial_transaction_types, only: [:index, :show]
         resources :financial_transactions, only: [:index, :show]
         resources :orders, only: [:index, :show]
+        resources :order_articles, only: [:index, :show]
       end
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -266,6 +266,7 @@ Rails.application.routes.draw do
         namespace :user do
           root to: 'users#show'
           resources :financial_transactions, only: [:index, :show]
+          resources :group_order_articles
         end
 
         resources :financial_transaction_classes, only: [:index, :show]
@@ -273,6 +274,7 @@ Rails.application.routes.draw do
         resources :financial_transactions, only: [:index, :show]
         resources :orders, only: [:index, :show]
         resources :order_articles, only: [:index, :show]
+        resources :group_order_articles
       end
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -271,6 +271,7 @@ Rails.application.routes.draw do
         resources :financial_transaction_classes, only: [:index, :show]
         resources :financial_transaction_types, only: [:index, :show]
         resources :financial_transactions, only: [:index, :show]
+        resources :orders, only: [:index, :show]
       end
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -275,6 +275,7 @@ Rails.application.routes.draw do
         resources :orders, only: [:index, :show]
         resources :order_articles, only: [:index, :show]
         resources :group_order_articles
+        resources :article_categories, only: [:index, :show]
       end
     end
 

--- a/doc/swagger.v1.yml
+++ b/doc/swagger.v1.yml
@@ -469,6 +469,58 @@ paths:
             $ref: '#/definitions/Error404'
       security:
         - foodsoft_auth: ['orders:read', 'orders:write']
+  /article_categories:
+    get:
+      summary: article categories
+      tags:
+        - 2. Category
+      parameters:
+        - $ref: '#/parameters/page'
+        - $ref: '#/parameters/per_page'
+      responses:
+        200:
+          description: success
+          schema:
+            type: object
+            properties:
+              article_categories:
+                type: array
+                items:
+                  $ref: '#/definitions/ArticleCategory'
+              meta:
+                $ref: '#/definitions/Meta'
+        401:
+          description: not logged-in
+          schema:
+            $ref: '#/definitions/Error401'
+
+      security:
+        - foodsoft_auth: ['all']
+  /article_categories/{id}:
+    parameters:
+      - $ref: '#/parameters/idInUrl'
+    get:
+      summary: find article category by id
+      tags:
+        - 2. Category
+      responses:
+        200:
+          description: success
+          schema:
+            type: object
+            properties:
+              article_category:
+                $ref: '#/definitions/ArticleCategory'
+        401:
+          description: not logged-in
+          schema:
+            $ref: '#/definitions/Error401'
+        404:
+          description: not found
+          schema:
+            $ref: '#/definitions/Error404'
+      security:
+        - foodsoft_auth: ['all']
 
   /financial_transaction_classes:
     get:
@@ -733,6 +785,15 @@ definitions:
         type: string
         description: name of the class of the transaction
     required: ['id', 'name', 'financial_transaction_class_id', 'financial_transaction_class_name']
+
+  ArticleCategory:
+    type: object
+    properties:
+      id:
+        type: integer
+      name:
+        type: string
+    required: ['id', 'name']
 
   Order:
     type: object

--- a/doc/swagger.v1.yml
+++ b/doc/swagger.v1.yml
@@ -179,6 +179,65 @@ paths:
             $ref: '#/definitions/Error404'
       security:
         - foodsoft_auth: ['finance:read', 'finance:write']
+  /orders:
+    get:
+      summary: orders
+      tags:
+        - 2. Orders
+      parameters:
+        - $ref: '#/parameters/page'
+        - $ref: '#/parameters/per_page'
+      responses:
+        200:
+          description: success
+          schema:
+            type: object
+            properties:
+              orders:
+                type: array
+                items:
+                  $ref: '#/definitions/Order'
+              meta:
+                $ref: '#/definitions/Meta'
+        401:
+          description: not logged-in
+          schema:
+            $ref: '#/definitions/Error401'
+        403:
+          description: missing scope or no permission
+          schema:
+            $ref: '#/definitions/Error403'
+      security:
+        - foodsoft_auth: ['orders:read', 'orders:write']
+  /orders/{id}:
+    parameters:
+      - $ref: '#/parameters/idInUrl'
+    get:
+      summary: find order by id
+      tags:
+        - 2. Order
+      responses:
+        200:
+          description: success
+          schema:
+            type: object
+            properties:
+              order:
+                $ref: '#/definitions/Order'
+        401:
+          description: not logged-in
+          schema:
+            $ref: '#/definitions/Error401'
+        403:
+          description: missing scope or no permission
+          schema:
+            $ref: '#/definitions/Error403'
+        404:
+          description: not found
+          schema:
+            $ref: '#/definitions/Error404'
+      security:
+        - foodsoft_auth: ['orders:read', 'orders:write']
 
   /financial_transaction_classes:
     get:
@@ -435,6 +494,37 @@ definitions:
         type: string
         description: name of the class of the transaction
     required: ['id', 'name', 'financial_transaction_class_id', 'financial_transaction_class_name']
+
+  Order:
+    type: object
+    properties:
+      id:
+        type: integer
+      name:
+        type: string
+        description: name of the order's supplier (or stock)
+      starts:
+        type: string
+        format: date-time
+        description: when the order was opened
+      ends:
+        type: ['string', 'null']
+        format: date-time
+        description: when the order will close or was closed
+      boxfill:
+        type: ['string', 'null']
+        format: date-time
+        description: when the order will enter or entered the boxfill phase
+      pickup:
+        type: ['string', 'null']
+        format: date
+        description: pickup date
+      is_open:
+        type: boolean
+        description: if the order is currently open or not
+      is_boxfill:
+        type: boolean
+        description: if the order is currently in the boxfill phase or not
 
   Navigation:
     type: array

--- a/doc/swagger.v1.yml
+++ b/doc/swagger.v1.yml
@@ -238,6 +238,66 @@ paths:
             $ref: '#/definitions/Error404'
       security:
         - foodsoft_auth: ['orders:read', 'orders:write']
+  /order_articles:
+    get:
+      summary: order articles
+      tags:
+        - 2. Order
+      parameters:
+        - $ref: '#/parameters/page'
+        - $ref: '#/parameters/per_page'
+        - $ref: '#/parameters/q_ordered'
+      responses:
+        200:
+          description: success
+          schema:
+            type: object
+            properties:
+              order_articles:
+                type: array
+                items:
+                  $ref: '#/definitions/OrderArticle'
+              meta:
+                $ref: '#/definitions/Meta'
+        401:
+          description: not logged-in
+          schema:
+            $ref: '#/definitions/Error401'
+        403:
+          description: missing scope or no permission
+          schema:
+            $ref: '#/definitions/Error403'
+      security:
+        - foodsoft_auth: ['group_orders:user']
+  /order_articles/{id}:
+    parameters:
+      - $ref: '#/parameters/idInUrl'
+    get:
+      summary: find order article by id
+      tags:
+        - 2. Order
+      responses:
+        200:
+          description: success
+          schema:
+            type: object
+            properties:
+              order_article:
+                $ref: '#/definitions/OrderArticle'
+        401:
+          description: not logged-in
+          schema:
+            $ref: '#/definitions/Error401'
+        403:
+          description: missing scope or no permission
+          schema:
+            $ref: '#/definitions/Error403'
+        404:
+          description: not found
+          schema:
+            $ref: '#/definitions/Error404'
+      security:
+        - foodsoft_auth: ['orders:read', 'orders:write']
 
   /financial_transaction_classes:
     get:
@@ -410,6 +470,14 @@ parameters:
     minimum: 0
     default: 20
 
+  # non-ransack query parameters
+  q_ordered:
+    name: q[ordered]
+    type: string
+    in: query
+    description: "'member' show articles ordered by the user's ordergroup, 'all' by all members, and 'supplier' ordered at the supplier"
+    enum: ['member', 'all', 'supplier']
+
 definitions:
   # models
   User:
@@ -525,6 +593,66 @@ definitions:
       is_boxfill:
         type: boolean
         description: if the order is currently in the boxfill phase or not
+
+  Article:
+    type: object
+    properties:
+      id:
+        type: integer
+      name:
+        type: string
+      supplier_id:
+        type: integer
+        description: id of supplier, or 0 for stock articles
+      supplier_name:
+        type: ['string', 'null']
+        description: name of the supplier, or null for stock articles
+      unit:
+        type: string
+        description: amount of each unit, e.g. "100 g" or "kg"
+      unit_quantity:
+        type: integer
+        description: units can only be ordered from the supplier in multiples of unit_quantity
+      note:
+        type: ['string', 'null']
+        description: generic note
+      manufacturer:
+        type: ['string', 'null']
+        description: manufacturer
+      origin:
+        type: ['string', 'null']
+        description: origin, preferably (starting with a) 2-letter ISO country code
+      article_category_id:
+        type: integer
+        description: id of article category
+      quantity_available:
+        type: integer
+        description: number of units available (only present on stock articles)
+    required: ['id', 'name', 'supplier_id', 'supplier_name', 'unit', 'unit_quantity', 'note', 'manufacturer', 'origin', 'article_category_id']
+
+  OrderArticle:
+    type: object
+    properties:
+      id:
+        type: integer
+      order_id:
+        type: integer
+        description: id of order this order article belongs to
+      price:
+        type: number
+        format: float
+        description: foodcoop price
+      quantity:
+        type: integer
+        description: number of units ordered by members
+      tolerance:
+        type: integer
+        description: number of extra units that members are willing to buy to fill a box
+      units_to_order:
+        type: integer
+        description: number of units to order from the supplier
+      article:
+        $ref: '#/definitions/Article'
 
   Navigation:
     type: array

--- a/doc/swagger.v1.yml
+++ b/doc/swagger.v1.yml
@@ -120,6 +120,177 @@ paths:
       security:
         - foodsoft_auth: ['finance:user']
 
+  /user/group_order_articles:
+    get:
+      summary: group order articles
+      tags:
+        - 1. User
+        - 2. Order
+      parameters:
+        - $ref: '#/parameters/page'
+        - $ref: '#/parameters/per_page'
+        - $ref: '#/parameters/q_ordered'
+      responses:
+        200:
+          description: success
+          schema:
+            type: object
+            properties:
+              group_order_articles:
+                type: array
+                items:
+                  $ref: '#/definitions/GroupOrderArticle'
+              meta:
+                $ref: '#/definitions/Meta'
+        401:
+          description: not logged-in
+          schema:
+            $ref: '#/definitions/Error401'
+        403:
+          description: user has no ordergroup or missing scope
+          schema:
+            $ref: '#/definitions/Error403'
+      security:
+        - foodsoft_auth: ['group_orders:user']
+    post:
+      summary: create new group order article
+      tags:
+        - 1. User
+        - 2. Order
+      parameters:
+        - in: body
+          name: body
+          description: group order article to create
+          required: true
+          schema:
+            $ref: '#/definitions/GroupOrderArticleForCreate'
+      responses:
+        200:
+          description: success
+          schema:
+            type: object
+            properties:
+              group_order_article:
+                $ref: '#/definitions/GroupOrderArticle'
+              order_article:
+                $ref: '#/definitions/OrderArticle'
+        401:
+          description: not logged-in
+          schema:
+            $ref: '#/definitions/Error401'
+        403:
+          description: user has no ordergroup, order not open, is below minimum balance, has not enough apple points, or missing scope
+          schema:
+            $ref: '#/definitions/Error403'
+        404:
+          description: order article not found in open orders
+          schema:
+            $ref: '#/definitions/Error404'
+        422:
+          description: invalid parameter value or group order article already exists
+          schema:
+            $ref: '#/definitions/Error422'
+  /user/group_order_articles/{id}:
+    parameters:
+      - $ref: '#/parameters/idInUrl'
+    get:
+      summary: find group order article by id
+      tags:
+        - 1. User
+        - 2. Order
+      responses:
+        200:
+          description: success
+          schema:
+            type: object
+            properties:
+              group_order_article:
+                $ref: '#/definitions/GroupOrderArticle'
+              order_article:
+                $ref: '#/definitions/OrderArticle'
+        401:
+          description: not logged-in
+          schema:
+            $ref: '#/definitions/Error401'
+        403:
+          description: user has no ordergroup or missing scope
+          schema:
+            $ref: '#/definitions/Error403'
+        404:
+          description: not found
+          schema:
+            $ref: '#/definitions/Error404'
+      security:
+        - foodsoft_auth: ['group_orders:user']
+    patch:
+      summary: update a group order article (but delete if quantity and tolerance are zero)
+      tags:
+        - 1. User
+        - 2. Order
+      parameters:
+        - $ref: '#/parameters/idInUrl'
+        - in: body
+          name: body
+          description: group order article update
+          required: true
+          schema:
+            $ref: '#/definitions/GroupOrderArticleForUpdate'
+      responses:
+        200:
+          description: success
+          schema:
+            type: object
+            properties:
+              group_order_article:
+                $ref: '#/definitions/GroupOrderArticle'
+              order_article:
+                $ref: '#/definitions/OrderArticle'
+        401:
+          description: not logged-in
+          schema:
+            $ref: '#/definitions/Error401'
+        403:
+          description: user has no ordergroup, order not open, is below minimum balance, has not enough apple points, or missing scope
+          schema:
+            $ref: '#/definitions/Error403'
+        404:
+          description: order article not found in open orders
+          schema:
+            $ref: '#/definitions/Error404'
+        422:
+          description: invalid parameter value
+          schema:
+            $ref: '#/definitions/Error422'
+    delete:
+      summary: remove group order article
+      tags:
+        - 1. User
+        - 2. Order
+      parameters:
+        - $ref: '#/parameters/idInUrl'
+      responses:
+        200:
+          description: success
+          schema:
+            type: object
+            properties:
+              group_order_article:
+                $ref: '#/definitions/GroupOrderArticle'
+              order_article:
+                $ref: '#/definitions/OrderArticle'
+        401:
+          description: not logged-in
+          schema:
+            $ref: '#/definitions/Error401'
+        403:
+          description: user has no ordergroup, order not open, is below minimum balance, has not enough apple points, or missing scope
+          schema:
+            $ref: '#/definitions/Error403'
+        404:
+          description: order article not found in open orders
+          schema:
+            $ref: '#/definitions/Error404'
+
   /financial_transactions:
     get:
       summary: financial transactions
@@ -654,6 +825,39 @@ definitions:
       article:
         $ref: '#/definitions/Article'
 
+  GroupOrderArticleForUpdate:
+    type: object
+    properties:
+      quantity:
+        type: integer
+        description: number of units ordered by the user's ordergroup
+      tolerance:
+        type: integer
+        description: number of extra units the user's ordergroup is willing to buy for filling a box
+  GroupOrderArticleForCreate:
+    allOf:
+      - $ref: '#/definitions/GroupOrderArticleForUpdate'
+      - type: object
+        properties:
+          order_article_id:
+            type: integer
+            description: id of order article
+  GroupOrderArticle:
+    allOf:
+      - $ref: '#/definitions/GroupOrderArticleForCreate'
+      - type: object
+        properties:
+          id:
+            type: integer
+          result:
+            type: number
+            format: float
+            description: number of units the user's ordergroup will receive or has received
+          total_price:
+            type: number
+            format: float
+            description: total price of this group order article
+
   Navigation:
     type: array
     items:
@@ -721,6 +925,15 @@ definitions:
         description: '<tt>forbidden</tt> or <tt>invalid_scope</tt>'
       error_description:
         $ref: '#/definitions/Error/properties/error_description'
+  Error422:
+    type: object
+    properties:
+      error:
+        type: string
+        description: unprocessable entity
+      error_description:
+        $ref: '#/definitions/Error/properties/error_description'
+
 
 securityDefinitions:
   foodsoft_auth:

--- a/spec/api/v1/order_articles_spec.rb
+++ b/spec/api/v1/order_articles_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+# Most routes are tested in the swagger_spec, this tests (non-ransack) parameters.
+describe Api::V1::OrderArticlesController, type: :controller do
+  include ApiOAuth
+  let(:api_scopes) { ['orders:read'] }
+
+  let(:json_order_articles) { json_response['order_articles'] }
+  let(:json_order_article_ids) { json_order_articles.map {|joa| joa["id"] } }
+
+  describe "GET :index" do
+    context "with param q[ordered]" do
+      let(:order) { create(:order, article_count: 4) }
+      let(:order_articles) { order.order_articles }
+      before do
+        order_articles[0].update_attributes! quantity: 0, tolerance: 0, units_to_order: 0
+        order_articles[1].update_attributes! quantity: 1, tolerance: 0, units_to_order: 0
+        order_articles[2].update_attributes! quantity: 0, tolerance: 1, units_to_order: 0
+        order_articles[3].update_attributes! quantity: 0, tolerance: 0, units_to_order: 1
+      end
+
+      it "(unset)" do
+        get :index, params: { foodcoop: 'f' }
+        expect(json_order_articles.count).to eq 4
+      end
+
+      it "all" do
+        get :index, params: { foodcoop: 'f', q: { ordered: 'all' } }
+        expect(json_order_article_ids).to match_array order_articles[1..2].map(&:id)
+      end
+
+      it "supplier" do
+        get :index, params: { foodcoop: 'f', q: { ordered: 'supplier' } }
+        expect(json_order_article_ids).to match_array [order_articles[3].id]
+      end
+
+      it "member" do
+        get :index, params: { foodcoop: 'f', q: { ordered: 'member' } }
+        expect(json_order_articles.count).to eq 0
+      end
+
+      context "when ordered by user" do
+        let(:user) { create(:user, :ordergroup) }
+        let(:go) { create(:group_order, order: order, ordergroup: user.ordergroup) }
+        before do
+          create(:group_order_article, group_order: go, order_article: order_articles[1], quantity: 1)
+          create(:group_order_article, group_order: go, order_article: order_articles[2], tolerance: 0)
+        end
+
+        it "member" do
+          get :index, params: { foodcoop: 'f', q: { ordered: 'member' } }
+          expect(json_order_article_ids).to match_array order_articles[1..2].map(&:id)
+        end
+      end
+    end
+  end
+end

--- a/spec/api/v1/swagger_spec.rb
+++ b/spec/api/v1/swagger_spec.rb
@@ -216,6 +216,18 @@ describe 'API v1', type: :apivore, order: :defined do
       it_handles_invalid_token_and_scope(:get, '/order_articles')
       it_handles_invalid_token_and_scope(:get, '/order_articles/{id}', ->{ api_auth({'id' => order_article.id}) })
     end
+
+    context 'article_categories' do
+      let!(:cat_1) { create :article_category }
+      let!(:cat_2) { create :article_category }
+
+      it { is_expected.to validate(:get, '/article_categories', 200, api_auth) }
+      it { is_expected.to validate(:get, '/article_categories/{id}', 200, api_auth({'id' => cat_2.id})) }
+      it { is_expected.to validate(:get, '/article_categories/{id}', 404, api_auth({'id' => cat_2.id + 1})) }
+
+      it_handles_invalid_token(:get, '/article_categories')
+      it_handles_invalid_token(:get, '/article_categories/{id}', ->{ api_auth({'id' => cat_1.id }) })
+    end
   end
 
   # needs to be last context so it is always run at the end

--- a/spec/api/v1/swagger_spec.rb
+++ b/spec/api/v1/swagger_spec.rb
@@ -113,6 +113,18 @@ describe 'API v1', type: :apivore, order: :defined do
       it_handles_invalid_token(:get, '/financial_transaction_types')
       it_handles_invalid_token(:get, '/financial_transaction_types/{id}', ->{ api_auth({'id' => tpy_1.id }) })
     end
+
+    context 'orders' do
+      let(:api_scopes) { ['orders:read'] }
+      let!(:order) { create :order }
+
+      it { is_expected.to validate(:get, '/orders', 200, api_auth) }
+      it { is_expected.to validate(:get, '/orders/{id}', 200, api_auth({'id' => order.id})) }
+      it { is_expected.to validate(:get, '/orders/{id}', 404, api_auth({'id' => Order.last.id + 1})) }
+
+      it_handles_invalid_token_and_scope(:get, '/orders')
+      it_handles_invalid_token_and_scope(:get, '/orders/{id}', ->{ api_auth({'id' => order.id}) })
+    end
   end
 
   # needs to be last context so it is always run at the end

--- a/spec/api/v1/swagger_spec.rb
+++ b/spec/api/v1/swagger_spec.rb
@@ -125,6 +125,21 @@ describe 'API v1', type: :apivore, order: :defined do
       it_handles_invalid_token_and_scope(:get, '/orders')
       it_handles_invalid_token_and_scope(:get, '/orders/{id}', ->{ api_auth({'id' => order.id}) })
     end
+
+    context 'order_articles' do
+      let(:api_scopes) { ['orders:read'] }
+      let!(:order_article) { create(:order, article_count: 1).order_articles.first }
+      let!(:stock_article) { create(:stock_article) }
+      let!(:stock_order_article) { create(:stock_order, article_ids: [stock_article.id]).order_articles.first }
+
+      it { is_expected.to validate(:get, '/order_articles', 200, api_auth) }
+      it { is_expected.to validate(:get, '/order_articles/{id}', 200, api_auth({'id' => order_article.id})) }
+      it { is_expected.to validate(:get, '/order_articles/{id}', 200, api_auth({'id' => stock_order_article.id})) }
+      it { is_expected.to validate(:get, '/order_articles/{id}', 404, api_auth({'id' => Article.last.id + 1})) }
+
+      it_handles_invalid_token_and_scope(:get, '/order_articles')
+      it_handles_invalid_token_and_scope(:get, '/order_articles/{id}', ->{ api_auth({'id' => order_article.id}) })
+    end
   end
 
   # needs to be last context so it is always run at the end

--- a/spec/api/v1/user/group_order_articles_spec.rb
+++ b/spec/api/v1/user/group_order_articles_spec.rb
@@ -1,0 +1,211 @@
+require 'spec_helper'
+
+# Most routes are tested in the swagger_spec, this tests endpoints that change data.
+describe Api::V1::User::GroupOrderArticlesController, type: :controller do
+  include ApiOAuth
+  let(:user) { create(:user, :ordergroup) }
+  let(:api_scopes) { ['group_orders:user'] }
+
+  let(:order) { create(:order, article_count: 1) }
+  let(:oa_1) { order.order_articles.first }
+
+  let(:other_quantity) { rand(1..10) }
+  let(:other_tolerance) { rand(1..10) }
+  let(:user_other) { create(:user, :ordergroup) }
+  let!(:go_other) { create(:group_order, order: order, ordergroup: user_other.ordergroup ) }
+  let!(:goa_other) { create(:group_order_article, group_order: go_other, order_article: oa_1, quantity: other_quantity, tolerance: other_tolerance) }
+  before { go_other.update_price!; user_other.ordergroup.update_stats! }
+
+  let(:json_goa) { json_response['group_order_article'] }
+  let(:json_oa) { json_response['order_article'] }
+
+
+  shared_examples "group_order_articles endpoint success" do
+    before { request }
+
+    it "returns status 200" do
+      expect(response.status).to eq 200
+    end
+
+    it "returns the order_article" do
+      expect(json_oa['id']).to eq oa_1.id
+      expect(json_oa['quantity']).to eq new_quantity + other_quantity
+      expect(json_oa['tolerance']).to eq new_tolerance + other_tolerance
+    end
+
+    it "updates the group_order" do
+      go = nil
+      expect {
+        request
+        go = user.ordergroup.group_orders.where(order: order).last
+       }.to change { go&.updated_by }.to(user)
+        .and change { go&.price }
+    end
+  end
+
+  shared_examples "group_order_articles create/update success" do
+    include_examples "group_order_articles endpoint success"
+
+    it "returns the group_order_article" do
+      expect(json_goa['id']).to be_present
+      expect(json_goa['order_article_id']).to eq oa_1.id
+      expect(json_goa['quantity']).to eq new_quantity
+      expect(json_goa['tolerance']).to eq new_tolerance
+    end
+
+    it "updates the group_order_article" do
+      resulting_goa = GroupOrderArticle.where(id: json_goa['id']).first
+      expect(resulting_goa).to be_present
+      expect(resulting_goa.quantity).to eq new_quantity
+      expect(resulting_goa.tolerance).to eq new_tolerance
+    end
+  end
+
+
+  shared_examples "group_order_articles endpoint failure" do |status|
+    it "returns status #{status}" do
+      request
+      expect(response.status).to eq status
+    end
+
+    it "does not change the group_order" do
+      expect { request }.to_not change {
+        go = user.ordergroup.group_orders.where(order: order).last
+        go&.attributes
+      }
+    end
+
+    it "does not change the group_order_article" do
+      expect { request }.to_not change {
+        goa = GroupOrderArticle.joins(:group_order)
+          .where(order_article_id: oa_1.id, group_orders: { ordergroup: user.ordergroup }).last
+        goa&.attributes
+      }
+    end
+  end
+
+
+  describe "POST :create" do
+    let(:new_quantity) { rand(1..10) }
+    let(:new_tolerance) { rand(1..10) }
+
+    let(:goa_params) { { order_article_id: oa_1.id, quantity: new_quantity, tolerance: new_tolerance } }
+    let(:request) { post :create, params: { group_order_article: goa_params, foodcoop: 'f' } }
+
+    context "with no existing group_order" do
+      include_examples "group_order_articles create/update success"
+    end
+
+    context "with an existing group_order" do
+      let!(:go) { create(:group_order, order: order, ordergroup: user.ordergroup) }
+      include_examples "group_order_articles create/update success"
+    end
+
+    context "with an existing group_order_article" do
+      let!(:go) { create(:group_order, order: order, ordergroup: user.ordergroup) }
+      let!(:goa) { create(:group_order_article, group_order: go, order_article: oa_1, quantity: 0, tolerance: 1) }
+      before { go.update_price!; user.ordergroup.update_stats! }
+      include_examples "group_order_articles endpoint failure", 422
+    end
+
+    context "with invalid parameter values" do
+      let(:goa_params) { { order_article_id: oa_1.id, quantity: -1, tolerance: new_tolerance} }
+      include_examples "group_order_articles endpoint failure", 422
+    end
+
+    context 'with a closed order' do
+      let(:order) { create(:order, article_count: 1, state: :finished) }
+      include_examples "group_order_articles endpoint failure", 404
+    end
+
+    context 'without enough balance' do
+      before { FoodsoftConfig[:minimum_balance] = 1000 }
+      include_examples "group_order_articles endpoint failure", 403
+    end
+
+    context 'without enough apple points' do
+      before { allow_any_instance_of(Ordergroup).to receive(:not_enough_apples?).and_return(true)  }
+      include_examples "group_order_articles endpoint failure", 403
+    end
+  end
+
+  describe "PATCH :update" do
+    let(:new_quantity) { rand(2..10) }
+    let(:new_tolerance) { rand(2..10) }
+
+    let!(:go) { create(:group_order, order: order, ordergroup: user.ordergroup) }
+    let!(:goa) { create(:group_order_article, group_order: go, order_article: oa_1, quantity: 1, tolerance: 0) }
+    before { go.update_price!; user.ordergroup.update_stats! }
+
+    let(:goa_params) { { quantity: new_quantity, tolerance: new_tolerance } }
+    let(:request) { patch :update, params: { id: goa.id, group_order_article: goa_params, foodcoop: 'f' } }
+
+    context "happy flow" do
+      include_examples "group_order_articles create/update success"
+    end
+
+    context "with invalid parameter values" do
+      let(:goa_params) { { order_article_id: oa_1.id, quantity: -1, tolerance: new_tolerance} }
+      include_examples "group_order_articles endpoint failure", 422
+    end
+
+    context 'with a closed order' do
+      let(:order) { create(:order, article_count: 1, state: :finished) }
+      include_examples "group_order_articles endpoint failure", 404
+    end
+
+    context 'without enough balance' do
+      before { FoodsoftConfig[:minimum_balance] = 1000 }
+      include_examples "group_order_articles endpoint failure", 403
+    end
+
+    context 'without enough apple points' do
+      before { allow_any_instance_of(Ordergroup).to receive(:not_enough_apples?).and_return(true)  }
+      include_examples "group_order_articles endpoint failure", 403
+    end
+  end
+
+  describe "DELETE :destroy" do
+    let(:new_quantity) { 0 }
+    let(:new_tolerance) { 0 }
+
+    let!(:go) { create(:group_order, order: order, ordergroup: user.ordergroup) }
+    let!(:goa) { create(:group_order_article, group_order: go, order_article: oa_1) }
+    before { go.update_price!; user.ordergroup.update_stats! }
+
+    let(:request) { delete :destroy, params: { id: goa.id, foodcoop: 'f' } }
+
+
+    shared_examples "group_order_articles destroy success" do
+      include_examples "group_order_articles endpoint success"
+
+      it "does not return the group_order_article" do
+        expect(json_goa).to be_nil
+      end
+
+      it "deletes the group_order_article" do
+        expect(GroupOrderArticle.where(id: goa.id)).to be_empty
+      end
+    end
+
+
+    context "happy flow" do
+      include_examples "group_order_articles destroy success"
+    end
+
+    context 'with a closed order' do
+      let(:order) { create(:order, article_count: 1, state: :finished) }
+      include_examples "group_order_articles endpoint failure", 404
+    end
+
+    context 'without enough balance' do
+      before { FoodsoftConfig[:minimum_balance] = 1000 }
+      include_examples "group_order_articles destroy success"
+    end
+
+    context 'without enough apple points' do
+      before { allow_any_instance_of(Ordergroup).to receive(:not_enough_apples?).and_return(true)  }
+      include_examples "group_order_articles destroy success"
+    end
+  end
+end

--- a/spec/factories/article.rb
+++ b/spec/factories/article.rb
@@ -11,14 +11,21 @@ FactoryBot.define do
 
     factory :article do
       sequence(:name) { |n| Faker::Lorem.words(number: rand(2..4)).join(' ') + " ##{n}" }
-      supplier { create :supplier }
-      article_category { create :article_category }
+      supplier
+      article_category
     end
 
     factory :shared_article, class: SharedArticle do
       sequence(:name) { |n| Faker::Lorem.words(number: rand(2..4)).join(' ') + " s##{n}" }
       order_number { Faker::Lorem.characters(number: rand(1..12)) }
-      supplier { create :shared_supplier }
+      shared_supplier
+    end
+
+    factory :stock_article, class: StockArticle do
+      sequence(:name) { |n| Faker::Lorem.words(number: rand(2..4)).join(' ') + " ##{n}" }
+      unit_quantity { 1 }
+      supplier
+      article_category
     end
   end
 

--- a/spec/support/api_oauth.rb
+++ b/spec/support/api_oauth.rb
@@ -1,0 +1,14 @@
+# Dummy OAuth implementation with +current_user+ and scopes
+module ApiOAuth
+  extend ActiveSupport::Concern
+
+  included do
+    let(:user) { build(:user) }
+    let(:api_scopes) { [] } # empty scopes for stricter testing (in reality this would be default_scopes)
+    let(:api_access_token) { double(:acceptable? => true, :accessible? => true, scopes: api_scopes) }
+    before { allow(controller).to receive(:doorkeeper_token) { api_access_token } }
+    before { allow(controller).to receive(:current_user) { user } }
+
+    let(:json_response) { JSON.parse(response.body) }
+  end
+end


### PR DESCRIPTION
Part four of #429 in chunks, continued from #572:
* `/api/v1/orders(/:id)`
* `/api/v1/order_articles(/:id)`
* `/api/v1/group_order_articles(/:id)` with CRUD
* `/api/v1/article_categories(/:id)`

Updating single `GroupOrderArticle`s is something (I believe) we don't really do elsewhere. I've looked into this years ago in the foodcoop-adam fork, and used something similar here.

- [x] add docs and specs for endpoints (rebase on updated #572)
- [x] see if update logic can be moved to model
- [x] specs for updating endpoints
- [x] add description to swagger fields
- [x] test group_order_article serializer `total_price` (first check if Apivore might test that)
- [x] rebase