### PR TITLE
Add FinacialTransaction create_collection for ordergroup custom fields

### DIFF
--- a/app/controllers/finance/financial_transactions_controller.rb
+++ b/app/controllers/finance/financial_transactions_controller.rb
@@ -58,6 +58,14 @@ class Finance::FinancialTransactionsController < ApplicationController
   end
 
   def new_collection
+    @ordergroups = {}
+    Ordergroup.undeleted.order(:name).map do |ordergroup|
+      obj = { name: ordergroup.name }
+      Ordergroup.custom_fields.each do |field|
+        obj[field[:name]] = ordergroup.settings.custom_fields[field[:name]]
+      end
+      @ordergroups[ordergroup.id] = obj
+    end
   end
 
   def create_collection

--- a/app/views/finance/financial_transactions/new_collection.html.haml
+++ b/app/views/finance/financial_transactions/new_collection.html.haml
@@ -3,6 +3,7 @@
 - content_for :javascript do
   :javascript
     var ordergroup = $($.parseHTML("#{escape_javascript(render('ordergroup'))}"));
+    var ordergroups = #{raw @ordergroups.to_json};
 
     $(function() {
       $(document).on('touchclick', 'a[data-remove-transaction]', function() {
@@ -16,16 +17,27 @@
       });
 
       $(document).on('touchclick', 'a[data-add-all-ordergroups]', function() {
-        var value = prompt("#{escape_javascript(heading_helper(FinancialTransaction, :amount))}:");
-        if (value === null)
-          return false;
+        var customField = $(this).data('custom-field');
+        var value;
+        if (!customField) {
+          value = prompt("#{escape_javascript(heading_helper(FinancialTransaction, :amount))}:");
+          if (value === null) {
+            return false;
+          }
+        }
         $('#ordergroups > tbody > tr').remove();
-        var options = ordergroup.find('td > select > option').each(function() {
+        for (var id in ordergroups) {
+          if (!ordergroups.hasOwnProperty(id)) {
+            continue;
+          }
+          if (customField) {
+            value = ordergroups[id][customField];
+          }
           var row = ordergroup.clone();
           row.find('td > input').val(value);
-          row.find('td > select').val(this.value);
+          row.find('td > select').val(id);
           row.appendTo('#ordergroups');
-        });
+        }
         return false;
       });
     });
@@ -61,6 +73,10 @@
       %label
         = check_box_tag :create_financial_link, true, params[:create_financial_link]
         = t('.create_financial_link')
+  %p
+    - Ordergroup.custom_fields.each do |f|
+      - if f[:financial_transaction_source]
+        = link_to t('.add_all_ordergroups_custom_field', label: f[:label]), '#', 'data-custom-field' => f[:name], 'data-add-all-ordergroups' => true, class: 'btn'
   .form-actions
     = submit_tag t('.save'), class: 'btn btn-primary'
     = link_to t('ui.or_cancel'), finance_ordergroups_path

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -862,6 +862,7 @@ de:
         title: Neue Transaktion
       new_collection:
         add_all_ordergroups: Alle Bestellgruppen hinzufügen
+        add_all_ordergroups_custom_field: Alle Bestellgruppen mit %{label} hinzufügen
         create_financial_link: Erstelle einen gemeinsamen Finanzlink für die neuen Transaktionen.
         new_ordergroup: Weitere Bestellgruppe hinzufügen
         save: Transaktionen speichern

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -887,6 +887,7 @@ en:
         title: New transaction
       new_collection:
         add_all_ordergroups: Add all ordergroups
+        add_all_ordergroups_custom_field: Add all ordergoups with %{label}
         create_financial_link: Create a common financial link for the new transactions.
         new_ordergroup: Add new ordergroup
         save: Save transaction


### PR DESCRIPTION
If we store a different membership fee for every ordergroup in a custom field, we can now populate the financial transactions with these values.