### PR TITLE
Add set_balance to FinancialTransactions#new_collection (fixes #438)

### DIFF
--- a/app/controllers/finance/financial_transactions_controller.rb
+++ b/app/controllers/finance/financial_transactions_controller.rb
@@ -59,12 +59,20 @@ class Finance::FinancialTransactionsController < ApplicationController
     params[:financial_transactions].each do |trans|
       # ignore empty amount fields ...
       unless trans[:amount].blank?
-        Ordergroup.find(trans[:ordergroup_id]).add_financial_transaction!(trans[:amount], params[:note], @current_user, type)
+        amount = trans[:amount].to_f
+        note = params[:note]
+        ordergroup = Ordergroup.find(trans[:ordergroup_id])
+        if params[:set_balance]
+          note += " (#{amount})"
+          amount -= ordergroup.financial_transaction_class_balance(type.financial_transaction_class)
+        end
+        ordergroup.add_financial_transaction!(amount, note, @current_user, type)
       end
     end
     redirect_to finance_ordergroups_url, notice: I18n.t('finance.financial_transactions.controller.create_collection.notice')
   rescue => error
-    redirect_to finance_new_transaction_collection_url, alert: I18n.t('finance.financial_transactions.controller.create_collection.alert', error: error.to_s)
+    flash.now[:alert] = error.message
+    render action: :new_collection
   end
 
   protected

--- a/app/models/ordergroup.rb
+++ b/app/models/ordergroup.rb
@@ -65,6 +65,13 @@ class Ordergroup < Group
     account_balance - value_of_open_orders(exclude) - value_of_finished_orders(exclude)
   end
 
+  def financial_transaction_class_balance(klass)
+    financial_transactions
+      .joins(:financial_transaction_type)
+      .where(financial_transaction_types: {financial_transaction_class_id: klass})
+      .sum(:amount)
+  end
+
   # Creates a new FinancialTransaction for this Ordergroup and updates the account_balance accordingly.
   # Throws an exception if it fails.
   def add_financial_transaction!(amount, note, user, transaction_type, link = nil)

--- a/app/views/finance/financial_transactions/new_collection.html.haml
+++ b/app/views/finance/financial_transactions/new_collection.html.haml
@@ -37,10 +37,14 @@
   - if FinancialTransactionType.has_multiple_types
     %p
       %b= heading_helper FinancialTransaction, :financial_transaction_type
-      = select_tag :type, options_for_select(FinancialTransactionType.order(:name).map { |t| [ t.name, t.id ] })
+      = select_tag :type, options_for_select(FinancialTransactionType.order(:name).map { |t| [ t.name, t.id ] }, params[:type])
   %p
     %b= heading_helper FinancialTransaction, :note
     = text_field_tag :note, params[:note], class: 'input-xlarge', required: 'required'
+  %p
+    %label
+      = check_box_tag :set_balance, true, params[:set_balance]
+      = t('.set_balance')
   %p
     %table#ordergroups{:style => "width:20em"}
       %thead

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -930,6 +930,7 @@ de:
         add_all_ordergroups: Alle Bestellgruppen hinzufügen
         new_ordergroup: Weitere Bestellgruppe hinzufügen
         save: Transaktionen speichern
+        set_balance: Setze den Kontostand der Bestellgrupppe auf den eingegebenen Betrag.
         sidebar: Hier kannst Du mehrere Konten gleichzeitig aktualsieren. Z.B. alle Überweisungen der Bestellgruppen aus einem Kontoauszug.
         title: Mehrere Konten aktualisieren
       ordergroup:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -947,6 +947,7 @@ en:
         add_all_ordergroups: Add all ordergroups
         new_ordergroup: Add new ordergroup
         save: Save transaction
+        set_balance: Set the balance of the ordergroup to the entered amount.
         sidebar: Here you can update more accounts at the same time. For example all transfers of the ordergroup from one account statement.
         title: Updating more accounts
       ordergroup:


### PR DESCRIPTION
A new checkbox will allow user to set the balance to a given ABSOLUTE value
in addition to changing it by a RELATIVE value. This can be used if the
balance is tracked outside of foodsoft and should be syncroniced or for
setting the balance to zero for multiple ordergroups.