### PR TITLE
Use Base64.strict_encode64 in discourse plugin

### DIFF
--- a/plugins/discourse/app/controllers/discourse_controller.rb
+++ b/plugins/discourse/app/controllers/discourse_controller.rb
@@ -10,7 +10,7 @@ class DiscourseController < ApplicationController
   end
 
   def redirect_to_with_payload(url, payload)
-    base64_payload = Base64.encode64 payload.to_query
+    base64_payload = Base64.strict_encode64 payload.to_query
     sso = CGI::escape base64_payload
     sig = get_hmac_hex_string base64_payload
     redirect_to "#{url}#{url.include?('?') ? '&' : '?'}sso=#{sso}&sig=#{sig}"


### PR DESCRIPTION
Base64.encode64 adds unneded newlines. Discourse can handle the newlines,
so this does not change the behaviour.