### PR TITLE
Avoid ActionView::MissingTemplate occurred in sessions#new

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,8 +2,11 @@ class SessionsController < ApplicationController
 
   skip_before_filter :authenticate
   layout 'login'
-  
+
   def new
+    respond_to do |format|
+      format.html
+    end
   end
 
   def create


### PR DESCRIPTION
Some browser request /:foodcoop/login with the HTTP-Accept-Header set
to "image/webp,image/*;q=0.8", which leads to an internal server error
due to a not existing template. Call respond_to to allow only html and
respond with the correct "406 Not Acceptable" HTTP status code.