### PR TITLE
allow override of default limit (<200) on articles on shared suppliers

### DIFF
--- a/app/models/shared_supplier.rb
+++ b/app/models/shared_supplier.rb
@@ -18,7 +18,7 @@ class SharedSupplier < ActiveRecord::Base
   # return list of synchronisation methods available for this supplier
   def shared_sync_methods
     methods = []
-    methods += %w(all_available all_unavailable) if shared_articles.count < 200
+    methods += %w(all_available all_unavailable)  if shared_articles.count < FoodsoftConfig[:shared_supplier_article_limit]
     methods += %w(import) # perhaps, in the future: if shared_articles.count > 20
     methods
   end

--- a/app/models/shared_supplier.rb
+++ b/app/models/shared_supplier.rb
@@ -18,7 +18,7 @@ class SharedSupplier < ActiveRecord::Base
   # return list of synchronisation methods available for this supplier
   def shared_sync_methods
     methods = []
-    methods += %w(all_available all_unavailable)  if shared_articles.count < FoodsoftConfig[:shared_supplier_article_limit]
+    methods += %w(all_available all_unavailable) if shared_articles.count < FoodsoftConfig[:shared_supplier_article_sync_limit]
     methods += %w(import) # perhaps, in the future: if shared_articles.count > 20
     methods
   end

--- a/config/app_config.yml.SAMPLE
+++ b/config/app_config.yml.SAMPLE
@@ -162,8 +162,8 @@ default: &defaults
   # Instead of defining all details here, you can also point to an entry in database.yml.
   #shared_lists: shared_lists
 
-  # default to allow sync only on less than 200 articles
-  #shared_supplier_article_limit: 2000,
+  # default is to allow sync only on less than 200 articles
+  #shared_supplier_article_limit: 200,
 development:
   <<: *defaults
 

--- a/config/app_config.yml.SAMPLE
+++ b/config/app_config.yml.SAMPLE
@@ -162,8 +162,8 @@ default: &defaults
   # Instead of defining all details here, you can also point to an entry in database.yml.
   #shared_lists: shared_lists
 
-  # default is to allow sync only on less than 200 articles
-  #shared_supplier_article_limit: 200,
+  # default to allow sync only on less than 200 articles
+  #shared_supplier_article_sync_limit: 200,
 development:
   <<: *defaults
 

--- a/config/app_config.yml.SAMPLE
+++ b/config/app_config.yml.SAMPLE
@@ -162,6 +162,8 @@ default: &defaults
   # Instead of defining all details here, you can also point to an entry in database.yml.
   #shared_lists: shared_lists
 
+  # default to allow sync only on less than 200 articles
+  #shared_supplier_article_limit: 2000,
 development:
   <<: *defaults
 

--- a/lib/foodsoft_config.rb
+++ b/lib/foodsoft_config.rb
@@ -256,6 +256,7 @@ class FoodsoftConfig
         contact: {}, # avoid errors when undefined
         tasks_period_days: 7,
         tasks_upfront_days: 49,
+        shared_supplier_article_limit: 200,
         # The following keys cannot, by default, be set by foodcoops themselves.
         protected: {
           multi_coop_install: true,

--- a/lib/foodsoft_config.rb
+++ b/lib/foodsoft_config.rb
@@ -256,7 +256,7 @@ class FoodsoftConfig
         contact: {}, # avoid errors when undefined
         tasks_period_days: 7,
         tasks_upfront_days: 49,
-        shared_supplier_article_limit: 200,
+        shared_supplier_article_sync_limit: 200,
         # The following keys cannot, by default, be set by foodcoops themselves.
         protected: {
           multi_coop_install: true,


### PR DESCRIPTION
on my version, i will sync up to 5000 articles.  this allows the restriction to be lifted by a config option.

(some performance enhancements to make sync faster are coming, but not part of this PR)