### PR TITLE
localize without errors applying to non-string values

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem 'haml-rails'
 gem 'kaminari'
 gem 'simple_form'
 gem 'inherited_resources'
-gem 'localize_input', git: "https://github.com/bennibu/localize_input.git"
+gem 'localize_input', git: 'https://github.com/carchrae/localize_input.git'
 gem 'daemons'
 gem 'doorkeeper'
 gem 'doorkeeper-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
-  remote: https://github.com/bennibu/localize_input.git
-  revision: 5eb188d2525a073d09e142cf8b0b04e6ace6e7b0
+  remote: https://github.com/carchrae/localize_input.git
+  revision: 597e33bb42a3b0fd58c3ea7d4f5a208c2911b43d
   specs:
     localize_input (0.1.0)
 


### PR DESCRIPTION
i fixed this a few years ago.  just submitting it here.  https://github.com/bennibu/localize_input/pull/2

IMHO, the localise gem is kind of questionable.  if using something like this i'd opt for either something more supported/widely used, or just pull the code into foodsoft.

