### PR TITLE
don't allow changes to settled orders

### DIFF
--- a/app/models/group_order_article.rb
+++ b/app/models/group_order_article.rb
@@ -5,13 +5,13 @@ class GroupOrderArticle < ApplicationRecord
 
   belongs_to :group_order
   belongs_to :order_article
-  has_many :group_order_article_quantities, :dependent => :destroy
+  has_many   :group_order_article_quantities, :dependent => :destroy
 
   validates_presence_of :group_order, :order_article
-  validates_uniqueness_of :order_article_id, :scope => :group_order_id # just once an article per group order
-  validate :check_order_not_closed  #don't allow changes to closed (aka settled) orders
+  validates_uniqueness_of :order_article_id, :scope => :group_order_id    # just once an article per group order
+  validate :check_order_not_closed # don't allow changes to closed (aka settled) orders
 
-  scope :ordered, -> {includes(:group_order => :ordergroup).order('groups.name')}
+  scope :ordered, -> { includes(:group_order => :ordergroup).order('groups.name') }
 
   localize_input_of :result
 
@@ -90,11 +90,11 @@ class GroupOrderArticle < ApplicationRecord
     end
 
     # Remove zero-only items.
-    quantities = quantities.reject {|q| q.quantity == 0 && q.tolerance == 0}
+    quantities = quantities.reject { | q | q.quantity == 0 && q.tolerance == 0}
 
     # Save
     transaction do
-      quantities.each {|i| i.save!}
+      quantities.each { | i | i.save! }
       self.group_order_article_quantities = quantities
       save!
     end

--- a/app/models/group_order_article.rb
+++ b/app/models/group_order_article.rb
@@ -201,7 +201,7 @@ class GroupOrderArticle < ApplicationRecord
 
   def check_order_not_closed
     if order_article.order.closed?
-      errors.add(:order_article, 'order is closed/settled and cannot be modified')
+      errors.add(:order_article, I18n.t('model.group_order_article.order_closed'))
     end
   end
 end

--- a/app/models/group_order_article.rb
+++ b/app/models/group_order_article.rb
@@ -5,12 +5,13 @@ class GroupOrderArticle < ApplicationRecord
 
   belongs_to :group_order
   belongs_to :order_article
-  has_many   :group_order_article_quantities, :dependent => :destroy
+  has_many :group_order_article_quantities, :dependent => :destroy
 
   validates_presence_of :group_order, :order_article
-  validates_uniqueness_of :order_article_id, :scope => :group_order_id    # just once an article per group order
+  validates_uniqueness_of :order_article_id, :scope => :group_order_id # just once an article per group order
+  validate :check_order_not_closed  #don't allow changes to closed (aka settled) orders
 
-  scope :ordered, -> { includes(:group_order => :ordergroup).order('groups.name') }
+  scope :ordered, -> {includes(:group_order => :ordergroup).order('groups.name')}
 
   localize_input_of :result
 
@@ -89,11 +90,11 @@ class GroupOrderArticle < ApplicationRecord
     end
 
     # Remove zero-only items.
-    quantities = quantities.reject { | q | q.quantity == 0 && q.tolerance == 0}
+    quantities = quantities.reject {|q| q.quantity == 0 && q.tolerance == 0}
 
     # Save
     transaction do
-      quantities.each { | i | i.save! }
+      quantities.each {|i| i.save!}
       self.group_order_article_quantities = quantities
       save!
     end
@@ -194,5 +195,13 @@ class GroupOrderArticle < ApplicationRecord
   # Check if the result deviates from the result_computed
   def result_manually_changed?
     result != result_computed unless result.nil?
+  end
+
+  private
+
+  def check_order_not_closed
+    if order_article.order.closed?
+      errors.add(:order_article, 'order is closed/settled and cannot be modified')
+    end
   end
 end

--- a/app/views/finance/balancing/_edit_results_by_articles.html.haml
+++ b/app/views/finance/balancing/_edit_results_by_articles.html.haml
@@ -11,7 +11,7 @@
       %th= heading_helper Article, :deposit
       %th{:colspan => "2"}
         = link_to t('.add_article'), new_order_order_article_path(@order), remote: true,
-          class: 'btn btn-small'
+          class: 'btn btn-small' unless @order.closed?
   %tbody#result_table
     - for order_article in @articles
       = render :partial => "order_article_result", :locals => {:order_article => order_article}

--- a/app/views/finance/balancing/_group_order_articles.html.haml
+++ b/app/views/finance/balancing/_group_order_articles.html.haml
@@ -9,8 +9,9 @@
           %acronym{:title => t('shared.articles.received_desc')}= t 'shared.articles.received'
         %td= t('.total')
         %td{:colspan => "3",:style => "width:14em"}
-          = link_to t('.add_group'), new_group_order_article_path(order_article_id: order_article.id),
-            remote: true, class: 'btn btn-mini' unless order_article.order.closed?
+          - unless order_article.order.closed?
+            = link_to t('.add_group'), new_group_order_article_path(order_article_id: order_article.id),
+              remote: true, class: 'btn btn-mini' 
     %tbody
       - totals = {result: 0}
       - for group_order_article in order_article.group_order_articles.select { |goa| goa.result > 0 }
@@ -21,8 +22,9 @@
           %td.center= group_order_article_edit_result(group_order_article)
           %td.numeric= number_to_currency(group_order_article.order_article.price.fc_price * group_order_article.result)
           %td.actions{:style=>"width:1em"}
-            = link_to t('ui.delete'), group_order_article_path(group_order_article), method: :delete,
-              remote: true, class: 'btn btn-mini btn-danger' unless order_article.order.closed?
+            - unless order_article.order.closed?
+              = link_to t('ui.delete'), group_order_article_path(group_order_article), 
+                method: :delete, remote: true, class: 'btn btn-mini btn-danger'
           %td
         - totals[:result] += group_order_article.result
     %tfoot

--- a/app/views/finance/balancing/_group_order_articles.html.haml
+++ b/app/views/finance/balancing/_group_order_articles.html.haml
@@ -10,7 +10,7 @@
         %td= t('.total')
         %td{:colspan => "3",:style => "width:14em"}
           = link_to t('.add_group'), new_group_order_article_path(order_article_id: order_article.id),
-            remote: true, class: 'btn btn-mini'
+            remote: true, class: 'btn btn-mini' unless order_article.order.closed?
     %tbody
       - totals = {result: 0}
       - for group_order_article in order_article.group_order_articles.select { |goa| goa.result > 0 }
@@ -22,7 +22,7 @@
           %td.numeric= number_to_currency(group_order_article.order_article.price.fc_price * group_order_article.result)
           %td.actions{:style=>"width:1em"}
             = link_to t('ui.delete'), group_order_article_path(group_order_article), method: :delete,
-              remote: true, class: 'btn btn-mini btn-danger'
+              remote: true, class: 'btn btn-mini btn-danger' unless order_article.order.closed?
           %td
         - totals[:result] += group_order_article.result
     %tfoot

--- a/app/views/finance/balancing/_order_article.html.haml
+++ b/app/views/finance/balancing/_order_article.html.haml
@@ -21,7 +21,7 @@
 %td= order_article.price.deposit
 %td
   = link_to t('ui.edit'), edit_order_order_article_path(order_article.order, order_article), remote: true,
-    class: 'btn btn-mini'
+    class: 'btn btn-mini' unless order_article.order.closed?
 %td
   = link_to t('ui.delete'), order_order_article_path(order_article.order, order_article), method: :delete,
-    remote: true, data: {confirm: t('.confirm')}, class: 'btn btn-danger btn-mini'
+    remote: true, data: {confirm: t('.confirm')}, class: 'btn btn-danger btn-mini' unless order_article.order.closed?

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1428,6 +1428,8 @@ de:
       redirect: Weiterleitung auf [[%{title}]]...
     user:
       no_ordergroup: keine Bestellgruppe
+    group_order_article:
+      order_closed: "Bestellung ist geschlossen und kann nicht geändert werden"
   navigation:
     admin:
       config: Einstellungen

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1429,7 +1429,7 @@ de:
     user:
       no_ordergroup: keine Bestellgruppe
     group_order_article:
-      order_closed: "Bestellung ist geschlossen und kann nicht geändert werden"
+      order_closed: Bestellung ist geschlossen und kann nicht geändert werden
   navigation:
     admin:
       config: Einstellungen

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1454,7 +1454,7 @@ en:
     user:
       no_ordergroup: no ordergroup
     group_order_article:
-      order_closed: "order is closed and cannot be modified"
+      order_closed: Order is closed and cannot be modified
   navigation:
     admin:
       config: Configuration

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1453,6 +1453,8 @@ en:
       redirect: Redirect to [[%{title}]]...
     user:
       no_ordergroup: no ordergroup
+    group_order_article:
+      order_closed: "order is closed and cannot be modified"
   navigation:
     admin:
       config: Configuration

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -1397,6 +1397,8 @@ nl:
       redirect: Doorverwijzing naar [[%{title}]]...
     user:
       no_ordergroup: geen huishouden
+    group_order_article:
+      order_closed: "bestelling is gesloten en kan niet worden gewijzigd"
   navigation:
     admin:
       config: Instellingen

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -1398,7 +1398,7 @@ nl:
     user:
       no_ordergroup: geen huishouden
     group_order_article:
-      order_closed: "bestelling is gesloten en kan niet worden gewijzigd"
+      order_closed: Bestelling is gesloten en kan niet worden gewijzigd
   navigation:
     admin:
       config: Instellingen


### PR DESCRIPTION
this adds a few checks on the order accounting page so that you cannot adjust what people received after the order is closed (aka settled).  it would be bad news to adjust what people received after it has been settled.

i also added a model level check to prevent any saving of `GroupOrderArticle` on a settled order - so this will enforce the rule at the model level too.

i have a separate PR for re-opening a settled order (which also reverse the charges).