### PR TITLE
fix missing translation

### DIFF
--- a/app/views/finance/balancing/_edit_note.html.haml
+++ b/app/views/finance/balancing/_edit_note.html.haml
@@ -1,9 +1,9 @@
 = simple_form_for @order, url: update_note_finance_order_path(@order), remote: true, method: :put do |f|
   .modal-header
     = close_button :modal
-    %h3 Notiz bearbeiten
+    %h3= t('.title')
   .modal-body
-    = f.input :note, input_html: {class: 'input-xlarge'}
+    = f.input :note, input_html: {class: 'input-xlarge', rows: 10, cols: 80}
   .modal-footer
     = link_to t('ui.close'), '#', class: 'btn', data: {dismiss: 'modal'}
     = f.submit t('ui.save'), class: 'btn btn-primary'

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -905,7 +905,7 @@ de:
         with_extra_charge: 'mit Aufschlag:'
         without_extra_charge: 'ohne Aufschlag:'
       edit_note:
-        title: Bestellschein bearbeiten
+        title: Notitie bewerken
     create:
       notice: Rechnung wurde erstellt.
     financial_links:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -904,6 +904,8 @@ de:
         reload: Zusammenfassung neu laden
         with_extra_charge: 'mit Aufschlag:'
         without_extra_charge: 'ohne Aufschlag:'
+      edit_note:
+        title: Bestellschein bearbeiten
     create:
       notice: Rechnung wurde erstellt.
     financial_links:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -905,7 +905,7 @@ de:
         with_extra_charge: 'mit Aufschlag:'
         without_extra_charge: 'ohne Aufschlag:'
       edit_note:
-        title: Notitie bewerken
+        title: Notiz bearbeiten
     create:
       notice: Rechnung wurde erstellt.
     financial_links:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -847,6 +847,8 @@ en:
         first_paragraph: 'When the order is settled, all group accounts will be updated.<br />The accounts will be charged as follows:'
         or_cancel: or back to accounting
         title: Settle order
+      edit_note:
+        title: Edit order note
       edit_results_by_articles:
         add_article: Add article
         amount: Amount
@@ -882,7 +884,7 @@ en:
         edit_order: Edit order
         groups_overview: Overview of groups
         invoice: Invoice
-        notes_and_journal: Notes/Protocol
+        notes_and_journal: Order Notes
         summary: Summary
         title: Accounting %{name}
         view_options: Viewing options

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -874,6 +874,8 @@ nl:
         reload: Samenvatting verversen
         with_extra_charge: 'inclusief marge:'
         without_extra_charge: 'zonder marge:'
+      edit_note:
+        title: Bewerk ordernotitie
     create:
       notice: Rekening is gemaakt.
     financial_links:


### PR DESCRIPTION
a missing translation on a modal.

a minor relabel got committed here too by accident - i would revert, but i think my change is clearer than the original "Notes/Protocol"

lots of small fiddly stuff in my branch like this.  i will persist in committing it.