### PR TITLE
Fix docker on development

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -11,7 +11,7 @@ Xvfb $DISPLAY -nolisten tcp &
 XVFB_PID=$!
 
 # Start tests
-rspec $@
+bundle exec rspec $@
 
 # Cleanup
 kill $XVFB_PID

--- a/config/environments/development.rb.SAMPLE
+++ b/config/environments/development.rb.SAMPLE
@@ -43,7 +43,7 @@ Foodsoft::Application.configure do
   # Mailcatcher config, start mailcatcher from console with 'mailcatcher'
   # Mailcatcher can be installed by gem install mailcatcher
   config.action_mailer.delivery_method = :smtp
-  config.action_mailer.smtp_settings = { address: ENV.fetch('MAILCATCHER_PORT_1025_TCP_ADDR', 'localhost'), port: ENV.fetch('MAILCATCHER_PORT_1025_TCP_PORT', 1025) }
+  config.action_mailer.smtp_settings = { address: ENV.fetch("MAILCATCHER_PORT_25_TCP_ADDR", "localhost"), port: ENV.fetch("MAILCATCHER_PORT_25_TCP_PORT", 1025) }
 
   # Run resque tasks as part of the main app (not recommended for production)
   Resque.inline = true unless ENV['REDIS_URL']

--- a/doc/SETUP_DEVELOPMENT_DOCKER.md
+++ b/doc/SETUP_DEVELOPMENT_DOCKER.md
@@ -22,9 +22,16 @@ and Windows!
 Then setup foodsoft development (this will take some time, containers needs
 to be pulled from docker registry and a lot dependencies needs to be installed)
 
-    docker-compose -f docker-compose-dev.yml run foodsoft rake foodsoft:setup_development
+    docker-compose -f docker-compose-dev.yml run --rm foodsoft \
+      bundle exec rake foodsoft:setup_development
 
 Do not enable mailcatcher, because this is already included as a docker image.
+
+Then create an initial database (here seeded with `small.en`) by running
+
+    docker-compose -f docker-compose-dev.yml up -d mariadb && sleep 15
+    docker-compose -f docker-compose-dev.yml run --rm foodsoft \
+      bundle exec rake db:create db:schema:load db:seed:small.en
 
 To avoid having to pass the `-f` argument all the time, it is recommended to setup
 an alias, e.g. by adding the following line to your ~/.bashrc
@@ -42,15 +49,15 @@ Start containers (in foreground, stop them with `Ctrl-C`)
 
 Run a rails/rake command
 
-    docker-compose-dev run --rm foodsoft rake db:migrate
+    docker-compose-dev run --rm foodsoft bundle exec rake db:migrate
 
 Open a rails console
 
-    docker-compose-dev run --rm foodsoft rails c
+    docker-compose-dev run --rm foodsoft bundle exec rails c
 
 Setup the test database
 
-    docker-compose-dev run --rm foodsoft rake db:setup RAILS_ENV=test DATABASE_URL=mysql2://root:secret@mariadb/test
+    docker-compose-dev run --rm foodsoft bundle exec rake db:setup RAILS_ENV=test DATABASE_URL=mysql2://root:secret@mariadb/test
 
 Run the tests
 
@@ -71,7 +78,7 @@ Go to [http://localhost:1080](http://localhost:1080)
 
 As the gem bundle is stored in a volume, you can run
 
-    docker-compose-dev run foodsoft bundle install
+    docker-compose-dev run --rm foodsoft bundle install
     docker-compose-dev restart foodsoft foodsoft_worker
 
 Do this each time you update your `Gemfile`.

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -22,9 +22,9 @@ services:
       - TEST_DATABASE_URL=mysql2://root:secret@mariadb/test?encoding=utf8
 
   mailcatcher:
-    image: aboutsource/mailcatcher
+    image: tophfr/mailcatcher
     ports:
-      - "1080:1080"
+      - "1080:80"
 
   mariadb:
     image: mariadb:10.1


### PR DESCRIPTION
Fixes #585.

We might still consider moving the files to `.docker`, but this should fix the setup.