### PR TITLE
sort by name as default

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -122,7 +122,7 @@ class OrdersController < ApplicationController
   def receive
     @order = Order.find(params[:id])
     unless request.post?
-      @order_articles = @order.order_articles.ordered_or_member.includes(:article).order('articles.order_number, articles.name')
+      @order_articles = @order.order_articles.ordered_or_member.includes(:article)
     else
       s = update_order_amounts
       flash[:notice] = (s ? I18n.t('orders.receive.notice', :msg => s) : I18n.t('orders.receive.notice_none'))

--- a/app/models/group_order_article.rb
+++ b/app/models/group_order_article.rb
@@ -11,6 +11,8 @@ class GroupOrderArticle < ApplicationRecord
   validates_uniqueness_of :order_article_id, :scope => :group_order_id    # just once an article per group order
 
   scope :ordered, -> { includes(:group_order => :ordergroup).order('groups.name') }
+  default_scope { joins(:order_article => :article).order('articles.name') }
+
 
   localize_input_of :result
 

--- a/app/models/order_article.rb
+++ b/app/models/order_article.rb
@@ -16,6 +16,7 @@ class OrderArticle < ApplicationRecord
   _ordered_sql = "order_articles.units_to_order > 0 OR order_articles.units_billed > 0 OR order_articles.units_received > 0"
   scope :ordered, -> { where(_ordered_sql) }
   scope :ordered_or_member, -> { includes(:group_order_articles).where("#{_ordered_sql} OR order_articles.quantity > 0 OR group_order_articles.result > 0") }
+  default_scope { includes(:article).order('articles.name') }
 
   before_create :init_from_balancing
   after_destroy :update_ordergroup_prices

--- a/app/models/ordergroup.rb
+++ b/app/models/ordergroup.rb
@@ -15,6 +15,8 @@ class Ordergroup < Group
   has_many :group_orders
   has_many :orders, :through => :group_orders
 
+  default_scope { order('name') }
+
   validates_numericality_of :account_balance, :message => I18n.t('ordergroups.model.invalid_balance')
   validate :uniqueness_of_name, :uniqueness_of_members
 

--- a/app/views/finance/balancing/_group_order_articles.html.haml
+++ b/app/views/finance/balancing/_group_order_articles.html.haml
@@ -1,3 +1,4 @@
+
 %td{:colspan => "7"}
   %table.table.table-striped
     %thead
@@ -13,7 +14,8 @@
             remote: true, class: 'btn btn-mini'
     %tbody
       - totals = {result: 0}
-      - for group_order_article in order_article.group_order_articles.select { |goa| goa.result > 0 }
+      - group_order_articles = order_article.group_order_articles.select { |goa| goa.result > 0 }
+      - for group_order_article in group_order_articles.sort_by { | goa | goa.group_order.ordergroup_name  }
         %tr[group_order_article]
           %td
           %td{:style=>"width:50%"}


### PR DESCRIPTION
there are many screens that show either articles or member's names in somewhat random orders.  this PR sorts several such cases by name, which i would argue, is far easier for most humans to work with.  

perhaps there will be some complaint about removing the default sort by order number on one page, however, i feel even this is not a good default as i have not seen any invoices from suppliers that are sorted like that.  i would argue that if anything but name is required, then those pages should have the ability to sort by any field shown. (it would be nice if all screens showing table data had this feature)

for now though, i hope you see the sense in this PR to improve usability.  
