### PR TITLE
fixes #634 - set mailer options for non-multi, add missing defaults

### DIFF
--- a/lib/foodsoft_config.rb
+++ b/lib/foodsoft_config.rb
@@ -69,6 +69,8 @@ class FoodsoftConfig
       self.scope = config[:default_scope] or raise "No default_scope is set"
       # Set defaults for backward-compatibility
       set_missing
+      # Set the mailer config when multi coop isn't enabled
+      setup_mailing unless config[:multi_coop_install]
     end
 
     # Set config and database connection for specific foodcoop.
@@ -257,6 +259,9 @@ class FoodsoftConfig
         tasks_period_days: 7,
         tasks_upfront_days: 49,
         shared_supplier_article_sync_limit: 200,
+        host: 'localhost',
+        port: '3000',
+        protocol: 'http',
         # The following keys cannot, by default, be set by foodcoops themselves.
         protected: {
           multi_coop_install: true,


### PR DESCRIPTION
there are many ways i could have fixed this, but i think this is the cleanest one.

instead of setting action mailer defaults in the `config/environment` i'm calling the setup_mailing method.  this helps reduce the code duplication and centralises the configuration.  
