### PR TITLE
allow 1 char unit, eg L or g

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -56,7 +56,7 @@ class Article < ApplicationRecord
   # Validations
   validates_presence_of :name, :unit, :price, :tax, :deposit, :unit_quantity, :supplier_id, :article_category
   validates_length_of :name, :in => 4..60
-  validates_length_of :unit, :in => 2..15
+  validates_length_of :unit, :in => 1..15
   validates_numericality_of :price, :greater_than_or_equal_to => 0
   validates_numericality_of :unit_quantity, :greater_than => 0
   validates_numericality_of :deposit, :tax


### PR DESCRIPTION
our articles sometimes have L and G - so i'd like to remove this over-strict validation