### PR TITLE
use a sensible default if no redis.

### DIFF
--- a/config/initializers/resque.rb
+++ b/config/initializers/resque.rb
@@ -1,2 +1,7 @@
 # Initializer to configure resque daemon
-Resque.redis = ENV['REDIS_URL'] if ENV['REDIS_URL']
+if ENV['REDIS_URL']
+  Resque.redis = ENV['REDIS_URL']
+else
+  puts 'WARNING: redis is not installed, so Resque is using inline method.  (not recommended for production)'
+  Resque.inline = true
+end


### PR DESCRIPTION
since parts of the site require `Resque` to work, it seems like developer pain to not initialise it to a sensible default (with a warning message).  otherwise, it will cause confusion when things like messages are not working.