### PR TITLE
Show article infos and order button on smaller screens

### DIFF
--- a/app/assets/stylesheets/bootstrap_and_overrides.css.less
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css.less
@@ -235,11 +235,25 @@ table {
   }
 }
 
-/* Hide the orders article info for small screens
+/* Restrict orders article info width for small screens
    to prevent the "save order" button to disappear */
 @media only screen and (max-width: 950px) {
   tr.order-article:hover .article-info {
-    display: none;
+    max-width: 25em;
+    overflow-y: scroll;
+    height: 9em;
+  }
+  
+  form.edit_group_order .table {
+    margin-bottom: 6em;
+  }
+
+  div#order-footer {
+    height: 10em;
+  }
+
+  div#total-sum {
+    max-width: 15em;
   }
 }
 

--- a/app/assets/stylesheets/bootstrap_and_overrides.css.less
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css.less
@@ -241,7 +241,7 @@ table {
   tr.order-article:hover .article-info {
     max-width: 25em;
     overflow-y: scroll;
-    height: 9em;
+    height: 10em;
   }
   
   form.edit_group_order .table {


### PR DESCRIPTION
The solution from PR #665 still displays `article-info` when I click a row or when I add/remove a product. Unfortunately, it also overlays the `total-sum` node with the order button (you can only spot the blue text link ending with `..n` in the right bottom):

![image](https://user-images.githubusercontent.com/1405446/63695344-c6b48380-c818-11e9-9bce-c75a4c1a188c.png)

May I suggest a solution that would display both `article-info` and `total-sum` besides each other?

![image](https://user-images.githubusercontent.com/1405446/63697221-c7e7af80-c81c-11e9-952a-df56a7bd1cc5.png)
