### PR TITLE
Set the common ActionMailer default_url_options only once

### DIFF
--- a/config/initializers/01_load_app_config.rb
+++ b/config/initializers/01_load_app_config.rb
@@ -3,3 +3,4 @@
 # Load Config, start by selecting defaults via current environment
 require 'foodsoft_config'
 FoodsoftConfig.init
+FoodsoftConfig.init_mailing

--- a/lib/foodsoft_config.rb
+++ b/lib/foodsoft_config.rb
@@ -71,6 +71,12 @@ class FoodsoftConfig
       set_missing
     end
 
+    def init_mailing
+      [:protocol, :host, :port, :script_name].each do |k|
+        ActionMailer::Base.default_url_options[k] = self[k] if self[k]
+      end
+    end
+
     # Set config and database connection for specific foodcoop.
     #
     # Only needed in multi coop mode.
@@ -225,9 +231,6 @@ class FoodsoftConfig
     end
 
     def setup_mailing
-      [:protocol, :host, :port, :script_name].each do |k|
-        ActionMailer::Base.default_url_options[k] = self[k] if self[k]
-      end
       ActionMailer::Base.default_url_options[:foodcoop] = scope
     end
 

--- a/spec/app_config.yml
+++ b/spec/app_config.yml
@@ -19,6 +19,8 @@ default: &defaults
   tax_default: 6.0
   email_sender: noreply@minimal.test
 
+  host: localhost
+
 
 development:
   <<: *defaults

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,6 +32,7 @@ RSpec.configure do |config|
   # without messing up tests run after that
   config.before(:each) do
     FoodsoftConfig.init
+    FoodsoftConfig.init_mailing
   end
 
   # If true, the base class of anonymous controllers will be inferred


### PR DESCRIPTION
There is no need to set options other than the foodcoop during every
change of the scope. This also makes sure that the correct options will
be loaded during testing to fix problems with newer rails versions.