### PR TITLE
Remove deprecated and obsolete quiet_assets gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,9 +83,6 @@ group :development do
 
   # Get infos when not using proper eager loading
   gem 'bullet'
-
-  # Hide assets requests in log
-  gem 'quiet_assets'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -299,8 +299,6 @@ GEM
     public_suffix (4.0.1)
     puma (4.2.1)
       nio4r (~> 2.0)
-    quiet_assets (1.1.0)
-      railties (>= 3.1, < 5.0)
     rack (1.6.11)
     rack-contrib (1.8.0)
       rack (~> 1.4)
@@ -555,7 +553,6 @@ DEPENDENCIES
   pry-rescue
   pry-stack_explorer
   puma
-  quiet_assets
   rack-cors
   rails (~> 4.2)
   rails-assets-listjs (= 0.2.0.beta.4)

--- a/config/environments/development.rb.SAMPLE
+++ b/config/environments/development.rb.SAMPLE
@@ -34,6 +34,9 @@ Foodsoft::Application.configure do
   # number of complex assets.
   config.assets.debug = true
 
+  # Suppress logger output for asset requests.
+  config.assets.quiet = true
+
   # Required for i18n-js
   config.assets.initialize_on_precompile = true
 


### PR DESCRIPTION
As of sprockets-rails version 3.1.0 the same functionality can be
enabled via config.assets.quiet.