### PR TITLE
Fix Gemfile.lock write permission for Docker dev build

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -29,7 +29,7 @@ WORKDIR /home/app/src
 COPY Gemfile Gemfile.lock ./
 COPY plugins ./plugins
 RUN bundle config build.nokogiri "--use-system-libraries" && \
-    bundle install -j 4
+    bundle install --frozen -j 4
 
 # Copy the application code
 COPY . ./


### PR DESCRIPTION
The Docker dev build does not work with Docker for Windows, leading to the following error:

```
There was an error while trying to write to `/home/app/src/Gemfile.lock`. It is
likely that you need to grant write permissions for that path.
ERROR: Service 'foodsoft' failed to build: The command '/bin/sh -c bundle config build.nokogiri "--use-system-libraries" &&     bundle install -j 4' returned a non-zero code: 23
```

I guess bundler wants to update dependencies in the lock file. Not sure if this is only occurring on Windows? 

Changing the owner in the `COPY` instruction to the `app` user fixes the issue:
`COPY --chown=app:app Gemfile Gemfile.lock ./`

An alternative solution would be to use `bundle install --frozen` instead.