### PR TITLE
Remove protected_attributes gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,6 @@ gem 'rails-settings-cached', '= 0.4.3' # caching breaks tests until Rails 5 http
 gem 'resque'
 gem 'thin'
 gem 'whenever', require: false # For defining cronjobs, see config/schedule.rb
-gem 'protected_attributes', '= 1.1.0' # 1.1.0 until tests work work with higher versions
 gem 'ruby-units'
 gem 'attribute_normalizer'
 gem 'ice_cube'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -285,8 +285,6 @@ GEM
       ttfunk (~> 1.5)
     prawn-table (0.2.2)
       prawn (>= 1.3.0, < 3.0.0)
-    protected_attributes (1.1.0)
-      activemodel (>= 4.0.1, < 5.0)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -549,7 +547,6 @@ DEPENDENCIES
   mysql2 (~> 0.4.0)
   prawn
   prawn-table
-  protected_attributes (= 1.1.0)
   pry-rescue
   pry-stack_explorer
   puma

--- a/app/controllers/suppliers_controller.rb
+++ b/app/controllers/suppliers_controller.rb
@@ -25,23 +25,23 @@ class SuppliersController < ApplicationController
     end
   end
 
-  def create    
-    @supplier = Supplier.new(params[:supplier])
+  def create
+    @supplier = Supplier.new(supplier_params)
     if @supplier.save
       flash[:notice] = I18n.t('suppliers.create.notice')
       redirect_to suppliers_path
     else
       render :action => 'new'
-    end 
+    end
   end
 
-  def edit    
+  def edit
     @supplier = Supplier.find(params[:id])
   end
-  
+
   def update
     @supplier = Supplier.find(params[:id])
-    if @supplier.update_attributes(params[:supplier])
+    if @supplier.update_attributes(supplier_params)
       flash[:notice] = I18n.t('suppliers.update.notice')
       redirect_to @supplier
     else
@@ -57,11 +57,21 @@ class SuppliersController < ApplicationController
     rescue => e
       flash[:error] = I18n.t('errors.general_msg', :msg => e.message)
       redirect_to @supplier
-  end  
-  
+  end
+
   # gives a list with all available shared_suppliers
   def shared_suppliers
     @shared_suppliers = SharedSupplier.all
   end
-  
+
+  private
+
+  def supplier_params
+    params
+      .require(:supplier)
+      .permit(:name, :address, :phone, :phone2, :fax, :email, :url, :contact_person, :customer_number,
+              :iban, :custom_fields, :delivery_days, :order_howto, :note,
+              :shared_supplier_id, :min_order_quantity, :shared_sync_method)
+  end
+
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -17,7 +17,7 @@ class TasksController < ApplicationController
   end
 
   def create
-    @task = Task.new(params[:task])
+    @task = Task.new(task_params, current_user_id: current_user.id)
     if params[:periodic]
       @task.periodic_task_group = PeriodicTaskGroup.new
     end
@@ -44,6 +44,7 @@ class TasksController < ApplicationController
     task_group = @task.periodic_task_group
     was_periodic = @task.periodic?
     prev_due_date = @task.due_date
+    @task.current_user_id = current_user.id
     @task.attributes=(params[:task])
     if @task.errors.empty? && @task.save
       task_group.update_tasks_including(@task, prev_due_date) if params[:periodic]
@@ -111,4 +112,13 @@ class TasksController < ApplicationController
       redirect_to tasks_url, :alert => I18n.t('tasks.error_not_found')
     end
   end
+
+  private
+
+  def task_params
+    params
+      .require(:task)
+      .permit(:name, :description, :duration, :user_list, :required_users, :workgroup, :due_date, :done)
+  end
+
 end

--- a/app/models/supplier.rb
+++ b/app/models/supplier.rb
@@ -10,10 +10,6 @@ class Supplier < ApplicationRecord
   has_many :invoices
   belongs_to :shared_supplier  # for the sharedLists-App
 
-  include ActiveModel::MassAssignmentSecurity
-  attr_accessible :name, :address, :phone, :phone2, :fax, :email, :url, :contact_person, :customer_number, :iban, :custom_fields,
-                  :delivery_days, :order_howto, :note, :shared_supplier_id, :min_order_quantity, :shared_sync_method
-
   validates :name, :presence => true, :length => { :in => 4..30 }
   validates :phone, :presence => true, :length => { :in => 8..25 }
   validates :address, :presence => true, :length => { :in => 8..50 }

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -11,10 +11,6 @@ class Task < ApplicationRecord
 
   attr_accessor :current_user_id
 
-  # form will send user in string. responsibilities will added later
-  include ActiveModel::MassAssignmentSecurity
-  attr_protected :users
-
   validates :name, :presence => true, :length => { :minimum => 3 }
   validates :required_users, :presence => true
   validates_numericality_of :duration, :required_users, :only_integer => true, :greater_than => 0

--- a/app/views/tasks/_form.html.haml
+++ b/app/views/tasks/_form.html.haml
@@ -1,4 +1,3 @@
-= form.hidden_field :current_user_id
 = form.input :name
 = form.input :description, as: :text, input_html: {rows: 10}
 = form.input :duration, :as => :select, :collection => 1..3

--- a/config/application.rb
+++ b/config/application.rb
@@ -42,12 +42,8 @@ module Foodsoft
     # like if you have constraints or database-specific column types
     # config.active_record.schema_format = :sql
 
-    # Enforce whitelist mode for mass assignment.
-    # This will create an empty whitelist of attributes available for mass-assignment for all models
-    # in your app. As such, your models will need to explicitly whitelist or blacklist accessible
-    # parameters by using an attr_accessible or attr_protected declaration.
-    # TODO Re-activate this. Uncommenting this line will currently cause rspec to fail.
-    config.active_record.whitelist_attributes = false
+    # TODO Disable this. Uncommenting this line will currently cause rspec to fail.
+    config.action_controller.permit_all_parameters = true
 
     # Enable the asset pipeline
     config.assets.enabled = true


### PR DESCRIPTION
We do not enforce the rules, so removing it and switching the existing
annotations to strong_parameters does not make our situation worse.

This will help with the upgrade to Rails 5.