### PR TITLE
Fix line endings for Windows docker environment

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+* text=auto
+*.sh text eol=lf
+proc-start text eol=lf
+Rakefile text eol=lf


### PR DESCRIPTION
I was struggling setting up the development environment with docker-compose on Windows. Telling Git to not convert the line endings of shell scripts to Windows Style (CRLF) solved the issues.