### PR TITLE
Add option to create a financial_link when creating financial_transaction

### DIFF
--- a/app/views/finance/financial_transactions/new_collection.html.haml
+++ b/app/views/finance/financial_transactions/new_collection.html.haml
@@ -56,6 +56,11 @@
   %p
     = link_to t('.new_ordergroup'), '#', 'data-add-transaction' => true, class: 'btn'
     = link_to t('.add_all_ordergroups'), '#', 'data-add-all-ordergroups' => true, class: 'btn'
+  - if BankAccount.any?
+    %p
+      %label
+        = check_box_tag :create_financial_link, true, params[:create_financial_link]
+        = t('.create_financial_link')
   .form-actions
     = submit_tag t('.save'), class: 'btn btn-primary'
     = link_to t('ui.or_cancel'), finance_ordergroups_path

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -838,6 +838,7 @@ de:
         title: Neue Transaktion
       new_collection:
         add_all_ordergroups: Alle Bestellgruppen hinzufügen
+        create_financial_link: Erstelle einen gemeinsamen Finanzlink für die neuen Transaktionen.
         new_ordergroup: Weitere Bestellgruppe hinzufügen
         save: Transaktionen speichern
         set_balance: Setze den Kontostand der Bestellgrupppe auf den eingegebenen Betrag.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -863,6 +863,7 @@ en:
         title: New transaction
       new_collection:
         add_all_ordergroups: Add all ordergroups
+        create_financial_link: Create a common financial link for the new transactions.
         new_ordergroup: Add new ordergroup
         save: Save transaction
         set_balance: Set the balance of the ordergroup to the entered amount.


### PR DESCRIPTION
If multiple financial transaction belong to a bank transaction, it
is sometimes easier to create them as a collection and add the bank
transaction instead of adding all financial transaction to a link
created via a bank transaction.