### PR TITLE
Adopt model to allow FinancialTransaction without an ordergroup

### DIFF
--- a/app/controllers/finance/financial_transactions_controller.rb
+++ b/app/controllers/finance/financial_transactions_controller.rb
@@ -84,6 +84,7 @@ class Finance::FinancialTransactionsController < ApplicationController
 
     ActiveRecord::Base.transaction do
       financial_link = FinancialLink.new if params[:create_financial_link]
+      foodcoop_amount = 0
 
       params[:financial_transactions].each do |trans|
         # ignore empty amount fields ...
@@ -96,7 +97,19 @@ class Finance::FinancialTransactionsController < ApplicationController
             amount -= ordergroup.financial_transaction_class_balance(type.financial_transaction_class)
           end
           ordergroup.add_financial_transaction!(amount, note, @current_user, type, financial_link)
+          foodcoop_amount -= amount
         end
+      end
+
+      if params[:create_foodcoop_transaction]
+        ft = FinancialTransaction.new({
+          financial_transaction_type: type,
+          user: @current_user,
+          amount: foodcoop_amount,
+          note: params[:note],
+          financial_link: financial_link,
+        })
+        ft.save!
       end
 
       financial_link.try(&:save!)

--- a/app/views/finance/financial_transactions/new_collection.html.haml
+++ b/app/views/finance/financial_transactions/new_collection.html.haml
@@ -68,6 +68,11 @@
   %p
     = link_to t('.new_ordergroup'), '#', 'data-add-transaction' => true, class: 'btn'
     = link_to t('.add_all_ordergroups'), '#', 'data-add-all-ordergroups' => true, class: 'btn'
+  - if FinancialTransaction.where(ordergroup: nil).any?
+    %p
+      %label
+        = check_box_tag :create_foodcoop_transaction, true, params[:create_foodcoop_transaction]
+        = t('.create_foodcoop_transaction')
   - if BankAccount.any?
     %p
       %label

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -874,6 +874,7 @@ de:
         add_all_ordergroups: Alle Bestellgruppen hinzufügen
         add_all_ordergroups_custom_field: Alle Bestellgruppen mit %{label} hinzufügen
         create_financial_link: Erstelle einen gemeinsamen Finanzlink für die neuen Transaktionen.
+        create_foodcoop_transaction: Erstelle einen Transaktion mit der der invertieten Summe für die Foodcoop (für den Fall der "doppelte Buchführung")
         new_ordergroup: Weitere Bestellgruppe hinzufügen
         save: Transaktionen speichern
         set_balance: Setze den Kontostand der Bestellgrupppe auf den eingegebenen Betrag.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -897,6 +897,7 @@ en:
         add_all_ordergroups: Add all ordergroups
         add_all_ordergroups_custom_field: Add all ordergoups with %{label}
         create_financial_link: Create a common financial link for the new transactions.
+        create_foodcoop_transaction: Create a transaction with the inverted sum for the foodcoop (in the case of "double-entry accounting")
         new_ordergroup: Add new ordergroup
         save: Save transaction
         set_balance: Set the balance of the ordergroup to the entered amount.


### PR DESCRIPTION
This will allow us to add accounting for the foodcoop itself, to support listing for spendings independent of the order (e.g. rent, electricity) and a kind of "double-entry accounting",

It's split into multiple commits for easier review (and maybe partial submit).

IMHO some of the names are not optimal, but i didn't had better ideas.