### PR TITLE
Add financial transaction class to supplier

### DIFF
--- a/app/controllers/suppliers_controller.rb
+++ b/app/controllers/suppliers_controller.rb
@@ -70,7 +70,7 @@ class SuppliersController < ApplicationController
     params
       .require(:supplier)
       .permit(:name, :address, :phone, :phone2, :fax, :email, :url, :contact_person, :customer_number,
-              :iban, :custom_fields, :delivery_days, :order_howto, :note,
+              :iban, :custom_fields, :delivery_days, :order_howto, :note, :financial_transaction_class_id,
               :shared_supplier_id, :min_order_quantity, :shared_sync_method)
   end
 

--- a/app/models/financial_transaction_class.rb
+++ b/app/models/financial_transaction_class.rb
@@ -1,5 +1,6 @@
 class FinancialTransactionClass < ApplicationRecord
   has_many :financial_transaction_types, dependent: :destroy
+  has_many :suppliers
 
   validates :name, presence: true
   validates_uniqueness_of :name

--- a/app/models/supplier.rb
+++ b/app/models/supplier.rb
@@ -8,6 +8,7 @@ class Supplier < ApplicationRecord
   has_many :orders
   has_many :deliveries
   has_many :invoices
+  belongs_to :financial_transaction_class
   belongs_to :shared_supplier  # for the sharedLists-App
 
   validates :name, :presence => true, :length => { :in => 4..30 }

--- a/app/views/suppliers/_form.html.haml
+++ b/app/views/suppliers/_form.html.haml
@@ -12,6 +12,8 @@
   = f.input :url
   = f.input :contact_person
   = f.input :customer_number
+  - if FinancialTransactionType.has_multiple_types
+    = f.association :financial_transaction_class, collection: FinancialTransactionClass.order(:name), hint: false
   - if FoodsoftConfig[:use_iban]
     = f.input :iban
   = f.input :delivery_days

--- a/app/views/suppliers/show.html.haml
+++ b/app/views/suppliers/show.html.haml
@@ -29,6 +29,9 @@
       %dd= @supplier.contact_person
       %dt= heading_helper(Supplier, :customer_number) + ':'
       %dd= @supplier.customer_number
+      - if FinancialTransactionType.has_multiple_types
+        %dt= heading_helper(Supplier, :financial_transaction_class) + ':'
+        %dd= @supplier.financial_transaction_class.name
       - if FoodsoftConfig[:use_iban]
         %dt= heading_helper(Supplier, :iban) + ':'
         %dd= @supplier.iban

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -158,6 +158,7 @@ de:
         customer_number_short: Kundennr.
         delivery_days: Liefertage
         email: E-Mail
+        financial_transaction_class: Kontotransaktionsklasse
         is_subscribed: abonniert?
         min_order_quantity: Mindestbestellmenge
         min_order_quantity_short: Menge (mind.)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -167,6 +167,7 @@ en:
         delivery_days: Delivery days
         email: Email
         fax: Fax
+        financial_transaction_class: Financial transaction class
         iban: IBAN
         is_subscribed: subscribed?
         min_order_quantity: Minimum order quantity

--- a/db/migrate/20181201000400_add_finance_transaction_class_to_supplier.rb
+++ b/db/migrate/20181201000400_add_finance_transaction_class_to_supplier.rb
@@ -1,0 +1,5 @@
+class AddFinanceTransactionClassToSupplier < ActiveRecord::Migration
+  def change
+    add_reference :suppliers, :financial_transaction_class
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181201000200) do
+ActiveRecord::Schema.define(version: 20181201000400) do
 
   create_table "article_categories", force: :cascade do |t|
     t.string "name",        limit: 255, default: "", null: false
@@ -439,23 +439,24 @@ ActiveRecord::Schema.define(version: 20181201000200) do
   end
 
   create_table "suppliers", force: :cascade do |t|
-    t.string   "name",               limit: 255, default: "", null: false
-    t.string   "address",            limit: 255, default: "", null: false
-    t.string   "phone",              limit: 255, default: "", null: false
-    t.string   "phone2",             limit: 255
-    t.string   "fax",                limit: 255
-    t.string   "email",              limit: 255
-    t.string   "url",                limit: 255
-    t.string   "contact_person",     limit: 255
-    t.string   "customer_number",    limit: 255
-    t.string   "delivery_days",      limit: 255
-    t.string   "order_howto",        limit: 255
-    t.string   "note",               limit: 255
-    t.integer  "shared_supplier_id", limit: 4
-    t.string   "min_order_quantity", limit: 255
+    t.string   "name",                           limit: 255, default: "", null: false
+    t.string   "address",                        limit: 255, default: "", null: false
+    t.string   "phone",                          limit: 255, default: "", null: false
+    t.string   "phone2",                         limit: 255
+    t.string   "fax",                            limit: 255
+    t.string   "email",                          limit: 255
+    t.string   "url",                            limit: 255
+    t.string   "contact_person",                 limit: 255
+    t.string   "customer_number",                limit: 255
+    t.string   "delivery_days",                  limit: 255
+    t.string   "order_howto",                    limit: 255
+    t.string   "note",                           limit: 255
+    t.integer  "shared_supplier_id",             limit: 4
+    t.string   "min_order_quantity",             limit: 255
     t.datetime "deleted_at"
-    t.string   "shared_sync_method", limit: 255
+    t.string   "shared_sync_method",             limit: 255
     t.string   "iban"
+    t.integer  "financial_transaction_class_id"
   end
 
   add_index "suppliers", ["name"], name: "index_suppliers_on_name", unique: true, using: :btree


### PR DESCRIPTION
This allows the categorization of suppliers. For a better reporting
it is necessary to split the expenses of the invoices.
E.g. we want to be able to generate independent sums of general cost
like the rent or electricity and the cost of the bought articles.