### PR TITLE
Add default roles for users

### DIFF
--- a/app/controllers/admin/configs_controller.rb
+++ b/app/controllers/admin/configs_controller.rb
@@ -30,7 +30,7 @@ class Admin::ConfigsController < Admin::BaseController
 
   # Set configuration tab names as `@tabs`
   def get_tabs
-    @tabs = %w(foodcoop payment tasks messages layout language others)
+    @tabs = %w(foodcoop payment tasks messages layout language roles others)
     # allow engines to modify this list
     engines = Rails::Engine.subclasses.map(&:instance).select { |e| e.respond_to?(:configuration) }
     engines.each { |e| e.configuration(@tabs, self) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -147,32 +147,32 @@ class User < ApplicationRecord
 
   # Checks the finance role
   def role_finance?
-    groups.detect {|group| group.role_finance?}
+    FoodsoftConfig[:default_role_finance] || groups.detect {|group| group.role_finance?}
   end
 
   # Checks the invoices role
   def role_invoices?
-    groups.detect {|group| group.role_invoices?}
+    FoodsoftConfig[:default_role_invoices] || groups.detect {|group| group.role_invoices?}
   end
 
   # Checks the article_meta role
   def role_article_meta?
-    groups.detect {|group| group.role_article_meta?}
+    FoodsoftConfig[:default_role_article_meta] || groups.detect {|group| group.role_article_meta?}
   end
 
   # Checks the suppliers role
   def role_suppliers?
-    groups.detect {|group| group.role_suppliers?}
+    FoodsoftConfig[:default_role_suppliers] || groups.detect {|group| group.role_suppliers?}
   end
 
   # Checks the invoices role
   def role_pickups?
-    groups.detect {|group| group.role_pickups?}
+    FoodsoftConfig[:default_role_pickups] || groups.detect {|group| group.role_pickups?}
   end
 
   # Checks the orders role
   def role_orders?
-    groups.detect {|group| group.role_orders?}
+    FoodsoftConfig[:default_role_orders] || groups.detect {|group| group.role_orders?}
   end
 
   def ordergroup_name

--- a/app/views/admin/configs/_tab_roles.html.haml
+++ b/app/views/admin/configs/_tab_roles.html.haml
@@ -1,0 +1,8 @@
+%h4= t '.access_to_title'
+= t '.access_to_paragraph'
+= config_input form, :default_role_suppliers, as: :boolean
+= config_input form, :default_role_article_meta, as: :boolean
+= config_input form, :default_role_orders, as: :boolean
+= config_input form, :default_role_pickups, as: :boolean
+= config_input form, :default_role_finance, as: :boolean
+= config_input form, :default_role_invoices, as: :boolean

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -268,6 +268,9 @@ de:
         emails_title: E-Mails versenden
       tab_payment:
         schedule_title: Bestellschema
+      tab_roles:
+        access_to_title: Zugriff auf
+        access_to_paragraph: Jedes Mitglied der Foodcoop hat automatisch Zugriff auf folgende Bereiche.
       tab_tasks:
         periodic_title: Wiederkehrende Aufgaben
       tabs:
@@ -570,6 +573,12 @@ de:
       currency_unit: Währung
       custom_css: Angepasstes CSS
       default_locale: Standardsprache
+      default_role_article_meta: Artikeldatenbank
+      default_role_finance: Finanzen
+      default_role_invoices: Rechnungen
+      default_role_orders: Bestellverwaltung
+      default_role_pickups: Abholtage
+      default_role_suppliers: Lieferanten
       disable_invite: Einladungen deaktivieren
       email_from: Absenderadresse
       email_replyto: Antwortadresse
@@ -607,6 +616,7 @@ de:
       messages: Nachrichten
       others: Sonstiges
       payment: Finanzen
+      roles: Rollen
       tasks: Aufgaben
   deliveries:
     add_stock_change:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -285,6 +285,9 @@ en:
         emails_title: Sending email
       tab_payment:
         schedule_title: Ordering schedule
+      tab_roles:
+        access_to_title: Access to
+        access_to_paragraph: By default every member of the foodcoop has access to the following areas.
       tab_tasks:
         periodic_title: Periodic tasks
       tabs:
@@ -590,6 +593,12 @@ en:
       currency_unit: Currency
       custom_css: Custom CSS
       default_locale: Default language
+      default_role_article_meta: Articles
+      default_role_finance: Finance
+      default_role_invoices: Invoices
+      default_role_orders: Orders
+      default_role_pickups: Pickup days
+      default_role_suppliers: Suppliers
       disable_invite: Disable invites
       email_from: From address
       email_replyto: Reply-to address
@@ -632,6 +641,7 @@ en:
       messages: Messages
       others: Other
       payment: Finances
+      roles: Roles
       tasks: Tasks
   deliveries:
     add_stock_change:


### PR DESCRIPTION
Some foodcoops want to give some roles to every member by default,
without adding every users to a workgroup.