### PR TITLE
Fix copy operation for stock orders

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -60,8 +60,15 @@ class OrdersController < ApplicationController
 
   # Page to create a new order.
   def new
-    @order = Order.new(supplier_id: params[:supplier_id]).init_dates
-    @order.article_ids = Order.find(params[:order_id]).article_ids if params[:order_id]
+    if params[:order_id]
+      old_order = Order.find(params[:order_id])
+      @order = Order.new(supplier_id: old_order.supplier_id).init_dates
+      @order.article_ids = old_order.article_ids
+    else
+      @order = Order.new(supplier_id: params[:supplier_id]).init_dates
+    end
+  rescue => error
+    redirect_to orders_url, alert: t('errors.general_msg', msg: error.message)
   end
 
   # Save a new order.

--- a/app/views/orders/_orders.html.haml
+++ b/app/views/orders/_orders.html.haml
@@ -17,5 +17,5 @@
         %td= format_time(order.ends)
         %td= t(order.state, scope: 'orders.state')
         %td
-          = link_to t('ui.copy'), new_order_path(order_id: order, supplier_id: order.supplier), class: 'btn btn-small'
+          = link_to t('ui.copy'), new_order_path(order_id: order), class: 'btn btn-small'
           = link_to t('ui.show'), order, class: 'btn btn-small'

--- a/app/views/orders/index.html.haml
+++ b/app/views/orders/index.html.haml
@@ -60,7 +60,7 @@
                   = receive_button order, class: 'btn-small'
 
               %td
-                = link_to t('ui.copy'), new_order_path(order_id: order, supplier_id: order.supplier), class: 'btn btn-small'
+                = link_to t('ui.copy'), new_order_path(order_id: order), class: 'btn btn-small'
                 = link_to t('ui.show'), order, class: 'btn btn-small'
                 = link_to t('ui.delete'), order, data: {confirm: t('.confirm_delete')}, method: :delete,
                   class: 'btn btn-small btn-danger'


### PR DESCRIPTION
Stock orders have the supplier_id set to zero, which will be ignored
in the url-method by rails. Only use the order_id to fix this.