### PR TITLE
Add warning about Windows line-endings issues to docs

### DIFF
--- a/doc/SETUP_DEVELOPMENT.md
+++ b/doc/SETUP_DEVELOPMENT.md
@@ -28,6 +28,8 @@ If instead you just want to run Foodsoft without changing its code, please refer
    This brings up the bleeding-edge development version, which might contain some
    unfinished parts. If you want to be safe, choose the last release:
    `git checkout $(git tag -l | grep ^v | sort -rn | head -n1)`
+   
+   *Note:* When developing on Windows you might run into issues with shell scripts because of Git auto-crlf. Have a look how to avoid that in the [Docker Development Setup](./SETUP_DEVELOPMENT_DOCKER.md#prerequisites-windows-only) instructions. 
 
 1. Install RVM and Ruby 2.4+ (if you have not done so before):
 
@@ -182,3 +184,4 @@ within a docker image. While the default [`Dockerfile`](../Dockerfile) is setup 
 use docker-compose (using [`docker-compose-dev.yml`](../docker-compose-dev.yml)) to
 setup the whole stack at once.
 
+See [Setup Development Docker](./SETUP_DEVELOPMENT_DOCKER.md) for a detailed description.

--- a/doc/SETUP_DEVELOPMENT.md
+++ b/doc/SETUP_DEVELOPMENT.md
@@ -29,7 +29,10 @@ If instead you just want to run Foodsoft without changing its code, please refer
    unfinished parts. If you want to be safe, choose the last release:
    `git checkout $(git tag -l | grep ^v | sort -rn | head -n1)`
    
-   *Note:* When developing on Windows you might run into issues with shell scripts because of Git auto-crlf. Have a look how to avoid that in the [Docker Development Setup](./SETUP_DEVELOPMENT_DOCKER.md#prerequisites-windows-only) instructions. 
+   *Note:* When developing on Windows you might run into issues with shell scripts 
+   because of Git auto-crlf. Have a look how to avoid that in the 
+   [Docker Development Setup](./SETUP_DEVELOPMENT_DOCKER.md#prerequisites-windows-only) 
+   instructions. 
 
 1. Install RVM and Ruby 2.4+ (if you have not done so before):
 

--- a/doc/SETUP_DEVELOPMENT_DOCKER.md
+++ b/doc/SETUP_DEVELOPMENT_DOCKER.md
@@ -15,7 +15,14 @@ If instead you just want to run Foodsoft without changing its code, please refer
 
 For installing instructions see https://docs.docker.com/installation/.
 Docker runs on every modern Linux kernel, but also with a little help on MacOS
-and Windows!
+and Windows!  
+
+## Prerequisites (Windows only)
+To avoid line-ending issues with shell scripts, make sure to configure Git autocrlf to keep linux line endings via
+
+    git config --local core.autocrlf input 
+
+Don't forget to do a clean checkout (delete everything except `.git` directory) afterwards.  
 
 ## Setup
 

--- a/doc/SETUP_DEVELOPMENT_DOCKER.md
+++ b/doc/SETUP_DEVELOPMENT_DOCKER.md
@@ -18,11 +18,13 @@ Docker runs on every modern Linux kernel, but also with a little help on MacOS
 and Windows!  
 
 ## Prerequisites (Windows only)
-To avoid line-ending issues with shell scripts, make sure to configure Git autocrlf to keep linux line endings via
+To avoid line-ending issues with shell scripts, make sure to configure 
+Git autocrlf to keep linux line endings via
 
     git config --local core.autocrlf input 
 
-Don't forget to do a clean checkout (delete everything except `.git` directory) afterwards.  
+Don't forget to do a clean checkout (delete everything except `.git` directory) 
+afterwards.  
 
 ## Setup
 


### PR DESCRIPTION
Hi @paroga,

I've updated the docs with a warning about line-ending issues when using the Docker environment on Windows.

Should we add the section also to the non-docker development setup instructions? I guess it is possible to run the rails server on windows without docker as well?

Thanks, Harald