### PR TITLE
Lock SQLite3 to < 1.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,7 @@ gem 'foodsoft_discourse', path: 'plugins/discourse'
 
 
 group :development do
-  gem 'sqlite3'
+  gem 'sqlite3', '~> 1.3.6'
   gem 'mailcatcher'
   gem 'web-console', '~> 2.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -446,7 +446,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.4.1)
+    sqlite3 (1.3.13)
     sqlite3-ruby (1.3.3)
       sqlite3 (>= 1.3.3)
     term-ansicolor (1.2.2)
@@ -574,7 +574,7 @@ DEPENDENCIES
   simple_form
   simplecov
   spreadsheet
-  sqlite3
+  sqlite3 (~> 1.3.6)
   therubyracer
   thin
   twitter-bootstrap-rails (~> 2.2.8)
@@ -583,4 +583,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   1.16.1
+   1.17.1


### PR DESCRIPTION
On my system, I couldn't get `rake db:create` to run on `master`, as the
version of SQLite3 in the Gemfile.lock would result in the following
error. It's likely this didn't cause issues before as CI runs on MySQL and the upgrade to 1.4.1 happened only 2 weeks ago.

https://stackoverflow.com/questions/54527277/cant-activate-sqlite3-1-3-6-already-activated-sqlite3-1-4-0

(Ok, not my question, it was 1.4.1 on my machine, but same thing).

Locking SQLite3 to '~> 1.3.6` did fix the issue. It'll probably a great
candidate to upgrade once we're on Rails 5.