### PR TITLE
Remove `config.mass_assignment_sanitizer from development.rb sample

### DIFF
--- a/config/environments/development.rb.SAMPLE
+++ b/config/environments/development.rb.SAMPLE
@@ -23,9 +23,6 @@ Foodsoft::Application.configure do
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 
-  # Raise exception on mass assignment protection for Active Record models
-  config.active_record.mass_assignment_sanitizer = :strict
-
   # Raise an error on page load if there are pending migrations
   config.active_record.migration_error = :page_load
 


### PR DESCRIPTION
This configuration option has been removed in Rails 4; I've only found
references to it from people running Rails 3.