### PR TITLE
Add SupplierCategory

### DIFF
--- a/app/controllers/suppliers_controller.rb
+++ b/app/controllers/suppliers_controller.rb
@@ -27,6 +27,7 @@ class SuppliersController < ApplicationController
 
   def create
     @supplier = Supplier.new(supplier_params)
+    @supplier.supplier_category ||= SupplierCategory.first
     if @supplier.save
       flash[:notice] = I18n.t('suppliers.create.notice')
       redirect_to suppliers_path
@@ -70,7 +71,7 @@ class SuppliersController < ApplicationController
     params
       .require(:supplier)
       .permit(:name, :address, :phone, :phone2, :fax, :email, :url, :contact_person, :customer_number,
-              :iban, :custom_fields, :delivery_days, :order_howto, :note,
+              :iban, :custom_fields, :delivery_days, :order_howto, :note, :supplier_category_id,
               :shared_supplier_id, :min_order_quantity, :shared_sync_method)
   end
 

--- a/app/models/financial_transaction_class.rb
+++ b/app/models/financial_transaction_class.rb
@@ -1,5 +1,6 @@
 class FinancialTransactionClass < ApplicationRecord
   has_many :financial_transaction_types, dependent: :destroy
+  has_many :supplier_category, dependent: :restrict_with_exception
 
   validates :name, presence: true
   validates_uniqueness_of :name

--- a/app/models/supplier.rb
+++ b/app/models/supplier.rb
@@ -8,6 +8,7 @@ class Supplier < ApplicationRecord
   has_many :orders
   has_many :deliveries
   has_many :invoices
+  belongs_to :supplier_category
   belongs_to :shared_supplier  # for the sharedLists-App
 
   validates :name, :presence => true, :length => { :in => 4..30 }

--- a/app/models/supplier_category.rb
+++ b/app/models/supplier_category.rb
@@ -1,0 +1,19 @@
+class SupplierCategory < ActiveRecord::Base
+
+  belongs_to :financial_transaction_class
+  has_many :suppliers
+
+  normalize_attributes :name, :description
+
+  validates :name, presence: true, uniqueness: true, length: { minimum: 2 }
+
+  before_destroy :check_for_associated_suppliers
+
+  protected
+
+  # Deny deleting the category when there are associated suppliers.
+  def check_for_associated_suppliers
+    raise I18n.t('activerecord.errors.has_many_left', collection: Supplier.model_name.human) if suppliers.undeleted.any?
+  end
+
+end

--- a/app/views/suppliers/_form.html.haml
+++ b/app/views/suppliers/_form.html.haml
@@ -12,6 +12,9 @@
   = f.input :url
   = f.input :contact_person
   = f.input :customer_number
+  - supplier_categories = SupplierCategory.order(:name)
+  - if supplier_categories.count > 1
+    = f.association :supplier_category, collection: supplier_categories, include_blank: false
   - if FoodsoftConfig[:use_iban]
     = f.input :iban
   = f.input :delivery_days

--- a/app/views/suppliers/show.html.haml
+++ b/app/views/suppliers/show.html.haml
@@ -29,6 +29,9 @@
       %dd= @supplier.contact_person
       %dt= heading_helper(Supplier, :customer_number) + ':'
       %dd= @supplier.customer_number
+      - if SupplierCategory.count > 1
+        %dt= heading_helper(Supplier, :supplier_category) + ':'
+        %dd= @supplier.supplier_category.try(:name)
       - if FoodsoftConfig[:use_iban]
         %dt= heading_helper(Supplier, :iban) + ':'
         %dd= @supplier.iban

--- a/db/migrate/20181201000400_create_supplier_categories.rb
+++ b/db/migrate/20181201000400_create_supplier_categories.rb
@@ -1,0 +1,25 @@
+class CreateSupplierCategories < ActiveRecord::Migration
+  class FinancialTransactionClass < ActiveRecord::Base; end
+  class SupplierCategory < ActiveRecord::Base; end
+  class Supplier < ActiveRecord::Base; end
+
+  def change
+    create_table :supplier_categories do |t|
+      t.string :name, null: false
+      t.string :description
+      t.references :financial_transaction_class, null: false
+    end
+
+    add_reference :suppliers, :supplier_category
+
+    reversible do |dir|
+      dir.up do
+        ftc = FinancialTransactionClass.first
+        sc = SupplierCategory.create name: 'Other', financial_transaction_class_id: ftc.id
+        Supplier.update_all supplier_category_id: sc.id
+      end
+    end
+
+    change_column_null :suppliers, :supplier_category_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -488,24 +488,31 @@ ActiveRecord::Schema.define(version: 20181205010000) do
     t.datetime "created_at"
   end
 
+  create_table "supplier_categories", force: :cascade do |t|
+    t.string  "name",                           limit: 255, null: false
+    t.string  "description",                    limit: 255
+    t.integer "financial_transaction_class_id", limit: 4
+  end
+
   create_table "suppliers", force: :cascade do |t|
-    t.string   "name",               limit: 255, default: "", null: false
-    t.string   "address",            limit: 255, default: "", null: false
-    t.string   "phone",              limit: 255, default: "", null: false
-    t.string   "phone2",             limit: 255
-    t.string   "fax",                limit: 255
-    t.string   "email",              limit: 255
-    t.string   "url",                limit: 255
-    t.string   "contact_person",     limit: 255
-    t.string   "customer_number",    limit: 255
-    t.string   "delivery_days",      limit: 255
-    t.string   "order_howto",        limit: 255
-    t.string   "note",               limit: 255
-    t.integer  "shared_supplier_id", limit: 4
-    t.string   "min_order_quantity", limit: 255
+    t.string   "name",                 limit: 255, default: "", null: false
+    t.string   "address",              limit: 255, default: "", null: false
+    t.string   "phone",                limit: 255, default: "", null: false
+    t.string   "phone2",               limit: 255
+    t.string   "fax",                  limit: 255
+    t.string   "email",                limit: 255
+    t.string   "url",                  limit: 255
+    t.string   "contact_person",       limit: 255
+    t.string   "customer_number",      limit: 255
+    t.string   "delivery_days",        limit: 255
+    t.string   "order_howto",          limit: 255
+    t.string   "note",                 limit: 255
+    t.integer  "shared_supplier_id",   limit: 4
+    t.string   "min_order_quantity",   limit: 255
     t.datetime "deleted_at"
-    t.string   "shared_sync_method", limit: 255
-    t.string   "iban",               limit: 255
+    t.string   "shared_sync_method",   limit: 255
+    t.string   "iban",                 limit: 255
+    t.integer  "supplier_category_id", limit: 4
   end
 
   add_index "suppliers", ["name"], name: "index_suppliers_on_name", unique: true, using: :btree

--- a/db/seeds/minimal.seeds.rb
+++ b/db/seeds/minimal.seeds.rb
@@ -27,4 +27,5 @@ financial_transaction_class = FinancialTransactionClass.create(:name => "Other")
 FinancialTransactionType.create(:name => "Foodcoop", :financial_transaction_class_id => financial_transaction_class.id)
 
 # First entry for article categories
+SupplierCategory.create(:name => "Other")
 ArticleCategory.create(:name => "Other", :description => "other, misc, unknown")

--- a/db/seeds/small.en.seeds.rb
+++ b/db/seeds/small.en.seeds.rb
@@ -2,11 +2,13 @@ require_relative 'seed_helper.rb'
 
 ## Suppliers & articles
 
+SupplierCategory.create(:id => 1, :name => "Other")
+
 Supplier.create([
-  {:id => 1, :name => "Beautiful bakery", :address => "Smallstreet 1, Cookilage", :phone => "0123456789", :email => "info@bbakery.test", :min_order_quantity => "100"},
-  {:id => 2, :name => "Chocolatiers", :address => "Multatuliroad 1, Amsterdam", :phone => "0123456789", :email => "info@chocolatiers.test", :url => "http://www.chocolatiers.test/", :contact_person => "Max Pure", :delivery_days => "Tue, Fr (Amsterdam)"},
-  {:id => 3, :name => "Cheesemaker", :address => "Cheesestreet 5, London", :phone => "0123456789", :url => "http://www.cheesemaker.test/"},
-  {:id => 4, :name => "The Nuthome", :address => "Alexanderplatz, Berlin", :phone => "0123456789", :email => "info@thenuthome.test", :url => "http://www.thenuthome.test/", :note => "delivery in Berlin; €9 delivery costs for orders under €123"}
+  {:id => 1, :name => "Beautiful bakery", :supplier_category_id => 1, :address => "Smallstreet 1, Cookilage", :phone => "0123456789", :email => "info@bbakery.test", :min_order_quantity => "100"},
+  {:id => 2, :name => "Chocolatiers", :supplier_category_id => 1, :address => "Multatuliroad 1, Amsterdam", :phone => "0123456789", :email => "info@chocolatiers.test", :url => "http://www.chocolatiers.test/", :contact_person => "Max Pure", :delivery_days => "Tue, Fr (Amsterdam)"},
+  {:id => 3, :name => "Cheesemaker", :supplier_category_id => 1, :address => "Cheesestreet 5, London", :phone => "0123456789", :url => "http://www.cheesemaker.test/"},
+  {:id => 4, :name => "The Nuthome", :supplier_category_id => 1, :address => "Alexanderplatz, Berlin", :phone => "0123456789", :email => "info@thenuthome.test", :url => "http://www.thenuthome.test/", :note => "delivery in Berlin; €9 delivery costs for orders under €123"}
 ])
 
 ArticleCategory.create(:id => 1, :name => "Other", :description => "other, misc, unknown")

--- a/db/seeds/small.nl.seeds.rb
+++ b/db/seeds/small.nl.seeds.rb
@@ -2,11 +2,13 @@ require_relative 'seed_helper.rb'
 
 ## Suppliers & articles
 
+SupplierCategory.create(:id => 1, :name => "Other")
+
 Supplier.create([
-  {:id => 1, :name => "Koekenbakker", :address => "Dorpsstraat 1, Koekange", :phone => "012 3456789", :email => "info@dekoekenbakker.test", :min_order_quantity => "100"},
-  {:id => 2, :name => "Chocolademakkers", :address => "Multatuliweg 1, Amsterdam", :phone => "012 3456789", :email => "info@chocolademakkers.test", :url => "http://www.chocolademakkers.test/", :contact_person => "Max Puur", :delivery_days => "di, vr (Amsterdam)"},
-  {:id => 3, :name => "Kaasmaker", :address => "Waagplein, Alkmaar", :phone => "012 3456789", :url => "http://www.kaaskamer.test/"},
-  {:id => 4, :name => "Notenhuis", :address => "Damrak 1, Amsterdam", :phone => "012 3456789", :email => "info@notenhuis.test", :url => "http://www.notenhuis.test/", :note => "leveren in Amsterdam; €9 leverkosten bij bestellingen onder €123"}
+  {:id => 1, :name => "Koekenbakker", :supplier_category_id => 1, :address => "Dorpsstraat 1, Koekange", :phone => "012 3456789", :email => "info@dekoekenbakker.test", :min_order_quantity => "100"},
+  {:id => 2, :name => "Chocolademakkers", :supplier_category_id => 1, :address => "Multatuliweg 1, Amsterdam", :phone => "012 3456789", :email => "info@chocolademakkers.test", :url => "http://www.chocolademakkers.test/", :contact_person => "Max Puur", :delivery_days => "di, vr (Amsterdam)"},
+  {:id => 3, :name => "Kaasmaker", :supplier_category_id => 1, :address => "Waagplein, Alkmaar", :phone => "012 3456789", :url => "http://www.kaaskamer.test/"},
+  {:id => 4, :name => "Notenhuis", :supplier_category_id => 1, :address => "Damrak 1, Amsterdam", :phone => "012 3456789", :email => "info@notenhuis.test", :url => "http://www.notenhuis.test/", :note => "leveren in Amsterdam; €9 leverkosten bij bestellingen onder €123"}
 ])
 
 ArticleCategory.create(:id => 1, :name => "Other", :description => "overig, anders, onbekend")


### PR DESCRIPTION
This allows the categorization of suppliers. For a better reporting
it is necessary to split the expenses of the invoices.
E.g. we want to be able to generate independent sums of general cost
like the rent or electricity and the cost of the bought articles.