### PR TITLE
not a very nice fix to invoice_id pointing at deleted invoice

### DIFF
--- a/app/controllers/finance/balancing_controller.rb
+++ b/app/controllers/finance/balancing_controller.rb
@@ -7,6 +7,14 @@ class Finance::BalancingController < Finance::BaseController
 
   def new
     @order = Order.find(params[:order_id])
+
+    # this is unpleasant - and not where this code should belong, but solves the case where
+    # an order points to an invoice that has been deleted
+    if @order.invoice.nil? && !@order.invoice_id.nil?
+      @order.invoice_id = nil
+      @order.save
+    end
+
     flash.now.alert = t('finance.balancing.new.alert') if @order.closed?
     @comments = @order.comments
 


### PR DESCRIPTION
a quick fix for #718 

i'm not particularly happy with this, but it does the job in my use case.  this fix simply checks that when you visit the balancing page for an order, if the order has an invoice_id set but that invoice does not exist, it clears the invoice_id.  i dislike the code for all the reasons i hate logic in controllers.  i like the code because it is contained, predictable, and actually fixed my issue.

a better fix would be to do the cleanup when an invoice is deleted.  why didn't i do that?  well, it seems there are quite a few ways you could do it.  perhaps a callback on https://apidock.com/rails/ActiveRecord/Callbacks/after_destroy which would search for any references to the now-deleted invoice and clear them.

but then i also wondered if this was a deeper issue with how the active record relation was setup in the first place.  an invoice to order is a 1-N relationship, meaning one invoice could cover many orders (in practice for us, we never have this case, it is always 1-1, but that doesn't matter).  so perhaps there is a more elegant bit of sugar that could be added on this line to clean up the id when/if the invoice is deleted.  https://github.com/foodcoops/foodsoft/blob/739914ad430544c1e3126262bd614e3cecd4d599/app/models/order.rb#L14


