### PR TITLE
#49 potential fix

### DIFF
--- a/app/controllers/group_orders_controller.rb
+++ b/app/controllers/group_orders_controller.rb
@@ -61,8 +61,8 @@ class GroupOrdersController < ApplicationController
     @finished_not_closed_orders_including_group_order = Order.map_with_own_group_orders(Order.finished_not_closed, @ordergroup)
     @closed_orders_including_group_order = Order.map_with_own_group_orders(Order.closed, @ordergroup, params[:page], 10)
     respond_to do |format|
-      format.html # archive.html.haml
-      format.js   # archive.js.erb
+      format.html
+      format.js
     end
   end
 

--- a/app/controllers/group_orders_controller.rb
+++ b/app/controllers/group_orders_controller.rb
@@ -9,8 +9,9 @@ class GroupOrdersController < ApplicationController
 
   # Index page.
   def index
-    @finished_not_closed_orders_including_group_order = Order.map_with_own_group_orders(Order.finished_not_closed, @ordergroup)
-    @closed_orders_including_group_order = Order.map_with_own_group_orders(Order.closed, @ordergroup, 5)
+    @finished_not_closed_orders_including_group_order = Order.finished_not_closed.ordergroup_group_orders_map(@ordergroup)
+    @closed_orders_including_group_order = Order.closed.limit(5).ordergroup_group_orders_map(@ordergroup)
+    Order.includes(:group_orders).where({group_orders: {ordergroup_id: @ordergroup.id}})
   end
 
   def new
@@ -58,10 +59,11 @@ class GroupOrdersController < ApplicationController
   def archive
     # get only orders belonging to the ordergroup
     @closed_orders = Order.closed.page(params[:page]).per(10)
-    @finished_not_closed_orders_including_group_order = Order.map_with_own_group_orders(Order.finished_not_closed, @ordergroup)
-    @closed_orders_including_group_order = Order.map_with_own_group_orders(Order.closed, @ordergroup, params[:page], 10)
+    @closed_orders_including_group_order = @closed_orders.ordergroup_group_orders_map(@ordergroup)
     respond_to do |format|
-      format.html
+      format.html do
+        @finished_not_closed_orders_including_group_order = Order.finished_not_closed.ordergroup_group_orders_map(@ordergroup)
+      end
       format.js
     end
   end

--- a/app/controllers/group_orders_controller.rb
+++ b/app/controllers/group_orders_controller.rb
@@ -61,8 +61,8 @@ class GroupOrdersController < ApplicationController
     @finished_not_closed_orders_including_group_order = Order.map_with_own_group_orders(Order.finished_not_closed, @ordergroup)
     @closed_orders_including_group_order = Order.map_with_own_group_orders(Order.closed, @ordergroup, params[:page], 10)
     respond_to do |format|
-      format.html
-      format.js
+      format.html # archive.html.haml
+      format.js   # archive.js.erb
     end
   end
 

--- a/app/controllers/group_orders_controller.rb
+++ b/app/controllers/group_orders_controller.rb
@@ -9,6 +9,8 @@ class GroupOrdersController < ApplicationController
 
   # Index page.
   def index
+    @finished_not_closed_orders_including_group_order = Order.map_with_own_group_orders(Order.finished_not_closed, @ordergroup)
+    @closed_orders_including_group_order = Order.map_with_own_group_orders(Order.closed, @ordergroup, 5)
   end
 
   def new
@@ -56,10 +58,11 @@ class GroupOrdersController < ApplicationController
   def archive
     # get only orders belonging to the ordergroup
     @closed_orders = Order.closed.page(params[:page]).per(10)
-
+    @finished_not_closed_orders_including_group_order = Order.map_with_own_group_orders(Order.finished_not_closed, @ordergroup)
+    @closed_orders_including_group_order = Order.map_with_own_group_orders(Order.closed, @ordergroup, params[:page], 10)
     respond_to do |format|
-      format.html # archive.html.haml
-      format.js   # archive.js.erb
+      format.html
+      format.js
     end
   end
 

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -128,6 +128,8 @@ class Order < ApplicationRecord
     self
   end
 
+  # fetch current Order scope's records and map the current user's GroupOrders in (if any)
+  # (performance enhancement as opposed to fetching each GroupOrder separately from the view)
   def self.ordergroup_group_orders_map(ordergroup)
     orders = includes(:supplier)
     group_orders = GroupOrder.where(ordergroup_id: ordergroup.id, order_id: orders.map(&:id))

--- a/app/views/group_orders/_orders.html.haml
+++ b/app/views/group_orders/_orders.html.haml
@@ -6,9 +6,10 @@
       %th= heading_helper Order, :ends
       %th= heading_helper GroupOrder, :price
   %tbody
-    - for order in orders
-      - group_order = order.group_order(@ordergroup) # Get GroupOrder if possible
-      - order_class = group_order ? "" : "color:grey"
+    - for order_hash in orders
+      - order = order_hash[:order]
+      - group_order = order_hash[:group_order]
+      - order_class = group_order.present? ? "" : "color:grey"
       %tr{:class=> cycle('even', 'odd', :name => 'orders'), :style => order_class}
         %td= group_order.present? ? link_to(order.name, group_order_path(group_order)) : order.name
         %td= format_date(order.pickup)

--- a/app/views/group_orders/_orders.html.haml
+++ b/app/views/group_orders/_orders.html.haml
@@ -6,9 +6,8 @@
       %th= heading_helper Order, :ends
       %th= heading_helper GroupOrder, :price
   %tbody
-    - for order_hash in orders
-      - order = order_hash[:order]
-      - group_order = order_hash[:group_order]
+    - for order in orders
+      - group_order = order.cached_ordergroups_group_order
       - order_class = group_order.present? ? "" : "color:grey"
       %tr{:class=> cycle('even', 'odd', :name => 'orders'), :style => order_class}
         %td= group_order.present? ? link_to(order.name, group_order_path(group_order)) : order.name

--- a/app/views/group_orders/_orders.html.haml
+++ b/app/views/group_orders/_orders.html.haml
@@ -9,7 +9,7 @@
     - for order_hash in orders
       - order = order_hash[:order]
       - group_order = order_hash[:group_order]
-      - order_class = group_order.present? ? "" : "color:grey"
+      - order_class = group_order ? "" : "color:grey"
       %tr{:class=> cycle('even', 'odd', :name => 'orders'), :style => order_class}
         %td= group_order.present? ? link_to(order.name, group_order_path(group_order)) : order.name
         %td= format_date(order.pickup)

--- a/app/views/group_orders/_orders.html.haml
+++ b/app/views/group_orders/_orders.html.haml
@@ -9,7 +9,7 @@
     - for order_hash in orders
       - order = order_hash[:order]
       - group_order = order_hash[:group_order]
-      - order_class = group_order ? "" : "color:grey"
+      - order_class = group_order.present? ? "" : "color:grey"
       %tr{:class=> cycle('even', 'odd', :name => 'orders'), :style => order_class}
         %td= group_order.present? ? link_to(order.name, group_order_path(group_order)) : order.name
         %td= format_date(order.pickup)

--- a/app/views/group_orders/archive.html.haml
+++ b/app/views/group_orders/archive.html.haml
@@ -5,9 +5,9 @@
 .row-fluid
   .span6
     %h2= t '.title_open'
-    = render :partial => "orders", :locals => {:orders => Order.finished_not_closed, :pagination => false}
+    = render :partial => "orders", :locals => {:orders => @finished_not_closed_orders_including_group_order, :pagination => false}
 
   .span6
     %h2= t '.title_closed'
     #closed_orders
-      = render :partial => "orders", :locals => {:orders => @closed_orders, :pagination => true}
+      = render :partial => "orders", :locals => {:orders => @closed_orders_including_group_order, :pagination => true}

--- a/app/views/group_orders/archive.js.haml
+++ b/app/views/group_orders/archive.js.haml
@@ -1,1 +1,1 @@
-$('#closed_orders').html('#{escape_javascript(render("orders", orders: @closed_orders, pagination: true))}');
+$('#closed_orders').html('#{escape_javascript(render("orders", orders: @closed_orders_including_group_order, pagination: true))}');

--- a/app/views/group_orders/index.html.haml
+++ b/app/views/group_orders/index.html.haml
@@ -21,19 +21,19 @@
 = render :partial => "shared/open_orders", :locals => {:ordergroup => @ordergroup}
 
 // finished orders
-- unless Order.finished_not_closed.empty?
+- unless @finished_not_closed_orders_including_group_order.empty?
   %section
     %h2= t '.finished_orders.title'
-    = render :partial => "orders", :locals => {:orders => Order.finished_not_closed, :pagination => false}
+    = render :partial => "orders", :locals => {:orders => @finished_not_closed_orders_including_group_order, :pagination => false}
     - if @ordergroup.value_of_finished_orders > 0
       %p
         = t('.finished_orders.total_sum') + ':'
         %b= number_to_currency(@ordergroup.value_of_finished_orders)
 
 // closed orders
-- unless Order.closed.empty?
+- unless @closed_orders_including_group_order.empty?
   %section
     %h2= t '.closed_orders.title'
-    = render :partial => "orders", :locals => {:orders => Order.closed.limit(5), :pagination => false}
+    = render :partial => "orders", :locals => {:orders => @closed_orders_including_group_order, :pagination => false}
     %br/
     = link_to t('.closed_orders.more'), archive_group_orders_path

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -83,4 +83,19 @@ describe Order do
 
   end
 
+  describe 'mapped to GroupOrders' do
+    let!(:user) { create :user, groups: [create(:ordergroup)] }
+    let!(:order) { create :order }
+    let!(:order2) { create :order }
+    let!(:go) { create :group_order, order: order, ordergroup: user.ordergroup }
+
+    it 'to map a user\'s GroupOrders to a list of Orders' do
+      orders = Order.ordergroup_group_orders_map(user.ordergroup)
+
+      expect(orders.length).to be 2
+      expect(orders[0].cached_ordergroups_group_order).to have_attributes(id: go.id)
+      expect(orders[1].cached_ordergroups_group_order).to be_nil
+    end
+  end
+
 end


### PR DESCRIPTION
This more than halves the load time of `group_orders/index` and `group_orders/archive` for a foodcoop with about 1500 `finished_not_closed` orders.

So far each table row in any of the group_orders table views caused an extra `SELECT` on suppliers and another on group_orders. My approach prefetches both those.

*Note:* It's still not optimal: Immediately fetching thousands of records and loading them into the GUI is never a good idea. However, this only seems to be an issue for foodcoops, which aren't using foodsoft to its full extent: Usually the list of `finished_not_closed` orders should be quite small - Only if the `balancing` feature isn't used will there be such huge lists.