### PR TITLE
Increase choices size for polls

### DIFF
--- a/db/migrate/20181120000000_increase_choices_size.foodsoft_polls_engine.rb
+++ b/db/migrate/20181120000000_increase_choices_size.foodsoft_polls_engine.rb
@@ -1,0 +1,5 @@
+class IncreaseChoicesSize < ActiveRecord::Migration
+  def up
+    change_column :polls, :choices, :text, limit: 65535
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -428,7 +428,7 @@ ActiveRecord::Schema.define(version: 20181205010000) do
     t.text     "required_ordergroup_custom_fields", limit: 65535
     t.text     "required_user_custom_fields",       limit: 65535
     t.integer  "voting_method",                     limit: 4,                     null: false
-    t.string   "choices",                           limit: 255,                   null: false
+    t.text     "choices",                           limit: 65535,                 null: false
     t.integer  "final_choice",                      limit: 4
     t.integer  "multi_select_count",                limit: 4,     default: 0,     null: false
     t.integer  "min_points",                        limit: 4

--- a/plugins/polls/db/migrate/20181120000000_increase_choices_size.rb
+++ b/plugins/polls/db/migrate/20181120000000_increase_choices_size.rb
@@ -1,0 +1,5 @@
+class IncreaseChoicesSize < ActiveRecord::Migration
+  def up
+    change_column :polls, :choices, :text, limit: 65535
+  end
+end


### PR DESCRIPTION
MariaDB/MySQL stores the array as serialized string, so the current
limit of 255 is too small to store all choices.