### PR TITLE
fix SupplierCategory seed from minimal.seeds.rb (#774)

### DIFF
--- a/db/seeds/minimal.seeds.rb
+++ b/db/seeds/minimal.seeds.rb
@@ -1,7 +1,7 @@
 # Create nessecary data to start with a fresh installation
 
 # Create working group with full rights
-administrators = Workgroup.create(
+administrators = Workgroup.create!(
     :name => "Administrators",
     :description => "System administrators.",
     :role_admin => true,
@@ -13,7 +13,7 @@ administrators = Workgroup.create(
 )
 
 # Create admin user
-User.create(
+User.create!(
     :nick => "admin",
     :first_name => "Anton",
     :last_name => "Administrator",
@@ -23,9 +23,9 @@ User.create(
 )
 
 # First entry for financial transaction types
-financial_transaction_class = FinancialTransactionClass.create(:name => "Other")
-FinancialTransactionType.create(:name => "Foodcoop", :financial_transaction_class_id => financial_transaction_class.id)
+financial_transaction_class = FinancialTransactionClass.create!(:name => "Other")
+FinancialTransactionType.create!(:name => "Foodcoop", :financial_transaction_class_id => financial_transaction_class.id)
 
 # First entry for article categories
-SupplierCategory.create(:name => "Other", :financial_transaction_class_id => financial_transaction_class.id)
-ArticleCategory.create(:name => "Other", :description => "other, misc, unknown")
+SupplierCategory.create!(:name => "Other", :financial_transaction_class_id => financial_transaction_class.id)
+ArticleCategory.create!(:name => "Other", :description => "other, misc, unknown")

--- a/db/seeds/minimal.seeds.rb
+++ b/db/seeds/minimal.seeds.rb
@@ -27,5 +27,5 @@ financial_transaction_class = FinancialTransactionClass.create(:name => "Other")
 FinancialTransactionType.create(:name => "Foodcoop", :financial_transaction_class_id => financial_transaction_class.id)
 
 # First entry for article categories
-SupplierCategory.create(:name => "Other")
+SupplierCategory.create(:name => "Other", :financial_transaction_class_id => financial_transaction_class.id)
 ArticleCategory.create(:name => "Other", :description => "other, misc, unknown")

--- a/db/seeds/seed_helper.rb
+++ b/db/seeds/seed_helper.rb
@@ -7,7 +7,7 @@ def seed_group_orders
       # 20% of the order-ordergroup combinations don't order
       next if rand(10) < 2
       # order 3..12 times a random article
-      go = og.group_orders.create!(order: order)
+      go = og.group_orders.create!(order: order, updated_by_user_id: 1)
       (3+rand(10)).times do
         goa = go.group_order_articles.find_or_create_by!(order_article: order.order_articles.offset(rand(noas)).first)
         unit_quantity = goa.order_article.price.unit_quantity
@@ -23,5 +23,6 @@ end
 def seed_order(options={})
   options[:article_ids] ||= (options[:supplier]||Supplier.find(options[:supplier_id])).articles.map(&:id)
   options[:created_by_user_id] ||= 1
+  options[:updated_by_user_id] ||= 1
   Order.create! options
 end

--- a/db/seeds/seed_helper.rb
+++ b/db/seeds/seed_helper.rb
@@ -7,9 +7,9 @@ def seed_group_orders
       # 20% of the order-ordergroup combinations don't order
       next if rand(10) < 2
       # order 3..12 times a random article
-      go = og.group_orders.create(order: order)
+      go = og.group_orders.create!(order: order)
       (3+rand(10)).times do
-        goa = go.group_order_articles.find_or_create_by(order_article: order.order_articles.offset(rand(noas)).first)
+        goa = go.group_order_articles.find_or_create_by!(order_article: order.order_articles.offset(rand(noas)).first)
         unit_quantity = goa.order_article.price.unit_quantity
         goa.update_quantities rand([4, 2*unit_quantity+2].max), rand(unit_quantity)
       end
@@ -23,6 +23,5 @@ end
 def seed_order(options={})
   options[:article_ids] ||= (options[:supplier]||Supplier.find(options[:supplier_id])).articles.map(&:id)
   options[:created_by_user_id] ||= 1
-  Order.create options
+  Order.create! options
 end
-

--- a/db/seeds/small.en.seeds.rb
+++ b/db/seeds/small.en.seeds.rb
@@ -141,13 +141,6 @@ Article.create!(:name => "Chia seeds", :supplier_id => 4, :article_category_id =
 Article.create!(:name => "Coconut grated", :supplier_id => 4, :article_category_id => 13, :unit => "kg", :availability => true, :price => 0.55E0, :tax => 6.0, :deposit => 0.0, :unit_quantity => 1, :order_number => ":b3f65e4")
 
 
-## Orders & OrderArticles
-
-seed_order(supplier_id: 1, starts: 2.days.ago, ends: 5.days.from_now)
-seed_order(supplier_id: 3, starts: 2.days.ago, ends: 5.days.from_now)
-seed_order(supplier_id: 2, starts: 2.days.ago, ends: 4.days.from_now)
-
-
 ## Members & groups
 
 User.create!(:id => 1, :nick => "admin", :password => "secret", :first_name => "Anton", :last_name => "Administrator", :email => "admin@foo.test", :created_on => 'Wed, 15 Jan 2014 16:15:33 UTC +00:00')
@@ -176,6 +169,13 @@ Membership.create!(:group_id => 3, :user_id => 4)
 Membership.create!(:group_id => 7, :user_id => 5)
 Membership.create!(:group_id => 3, :user_id => 5)
 Membership.create!(:group_id => 4, :user_id => 5)
+
+
+## Orders & OrderArticles
+
+seed_order(supplier_id: 1, starts: 2.days.ago, ends: 5.days.from_now)
+seed_order(supplier_id: 3, starts: 2.days.ago, ends: 5.days.from_now)
+seed_order(supplier_id: 2, starts: 2.days.ago, ends: 4.days.from_now)
 
 
 ## GroupOrders & such

--- a/db/seeds/small.nl.seeds.rb
+++ b/db/seeds/small.nl.seeds.rb
@@ -141,13 +141,6 @@ Article.create!(:name => "Chia zaad", :supplier_id => 4, :article_category_id =>
 Article.create!(:name => "Cocos Rasp", :supplier_id => 4, :article_category_id => 13, :unit => "kg", :availability => true, :price => 0.55E0, :tax => 6.0, :deposit => 0.0, :unit_quantity => 1, :order_number => ":b3f65e4")
 
 
-## Orders & OrderArticles
-
-seed_order(supplier_id: 1, starts: 2.days.ago, ends: 5.days.from_now)
-seed_order(supplier_id: 3, starts: 2.days.ago, ends: 5.days.from_now)
-seed_order(supplier_id: 2, starts: 2.days.ago, ends: 4.days.from_now)
-
-
 ## Members & groups
 
 User.create!(:id => 1, :nick => "admin", :password => "secret", :first_name => "Anton", :last_name => "Administrator", :email => "admin@foo.test", :created_on => 'Wed, 15 Jan 2014 16:15:33 UTC +00:00')
@@ -176,6 +169,13 @@ Membership.create!(:group_id => 3, :user_id => 4)
 Membership.create!(:group_id => 7, :user_id => 5)
 Membership.create!(:group_id => 3, :user_id => 5)
 Membership.create!(:group_id => 4, :user_id => 5)
+
+
+## Orders & OrderArticles
+
+seed_order(supplier_id: 1, starts: 2.days.ago, ends: 5.days.from_now)
+seed_order(supplier_id: 3, starts: 2.days.ago, ends: 5.days.from_now)
+seed_order(supplier_id: 2, starts: 2.days.ago, ends: 4.days.from_now)
 
 
 ## GroupOrders & such


### PR DESCRIPTION
This is a minimal fix (no pun intended) for #774.

In addition, I would like to discuss the following options:

1. Should we use exclamation marks in seeds, e.g., `SupplierCategory.create!` instead of `SupplierCategory.create`? I have read somewhere that seeds should ideally be idempotent, but our seeds are not idempotent anyway (repeated seeding fails due to unique-key constraints).
1. Should we use exclamation marks for defaulting required fields such as `@supplier.supplier_category ||= SupplierCategory.first!` instead of `@supplier.supplier_category ||= SupplierCategory.first`?
1. Should we add "global" validation errors to forms?