### PR TITLE
Run select_foodcoop as the first before_action

### DIFF
--- a/app/controllers/concerns/foodcoop_scope.rb
+++ b/app/controllers/concerns/foodcoop_scope.rb
@@ -6,7 +6,7 @@ module Concerns::FoodcoopScope
   extend ActiveSupport::Concern
 
   included do
-    before_action :select_foodcoop
+    prepend_before_action :select_foodcoop
   end
 
   private


### PR DESCRIPTION
When e.g. authenticate is run as before_action, it could use the wrong
database in a multicoop installation, if select_foodcoop is not run first.