### PR TITLE
Migrations for new `received` order state (s. #779)

### DIFF
--- a/db/migrate/20210205090257_introduce_received_state_in_orders.rb
+++ b/db/migrate/20210205090257_introduce_received_state_in_orders.rb
@@ -1,0 +1,11 @@
+class IntroduceReceivedStateInOrders < ActiveRecord::Migration[5.2]
+  def up
+    Order.where(state: 'finished').each do |order|
+      order.update_attribute(:state, 'received') if order.order_articles.where('units_received IS NOT NULL').any?
+    end
+  end
+
+  def down
+    Order.where(state: 'received').update_all(state: 'finished')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_05_010000) do
+ActiveRecord::Schema.define(version: 2021_02_05_090257) do
 
   create_table "article_categories", force: :cascade do |t|
     t.string "name", default: "", null: false


### PR DESCRIPTION
Added migrations for the new `received` order state:
All orders that have been finished associated to order articles that have `units_received` other than `nil` should have the `received` state.