### PR TITLE
On #805: Turn bigint IDs back into normal integers

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,13 +12,13 @@
 
 ActiveRecord::Schema.define(version: 2021_02_05_090257) do
 
-  create_table "article_categories", force: :cascade do |t|
+  create_table "article_categories", id: :integer, force: :cascade do |t|
     t.string "name", default: "", null: false
     t.string "description"
     t.index ["name"], name: "index_article_categories_on_name", unique: true
   end
 
-  create_table "article_prices", force: :cascade do |t|
+  create_table "article_prices", id: :integer, force: :cascade do |t|
     t.integer "article_id", null: false
     t.decimal "price", precision: 8, scale: 2, default: "0.0", null: false
     t.decimal "tax", precision: 8, scale: 2, default: "0.0", null: false
@@ -28,7 +28,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["article_id"], name: "index_article_prices_on_article_id"
   end
 
-  create_table "articles", force: :cascade do |t|
+  create_table "articles", id: :integer, force: :cascade do |t|
     t.string "name", default: "", null: false
     t.integer "supplier_id", default: 0, null: false
     t.integer "article_category_id", default: 0, null: false
@@ -54,14 +54,14 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["type"], name: "index_articles_on_type"
   end
 
-  create_table "assignments", force: :cascade do |t|
+  create_table "assignments", id: :integer, force: :cascade do |t|
     t.integer "user_id", default: 0, null: false
     t.integer "task_id", default: 0, null: false
     t.boolean "accepted", default: false
     t.index ["user_id", "task_id"], name: "index_assignments_on_user_id_and_task_id", unique: true
   end
 
-  create_table "bank_accounts", force: :cascade do |t|
+  create_table "bank_accounts", id: :integer, force: :cascade do |t|
     t.string "name", null: false
     t.string "iban"
     t.string "description"
@@ -70,7 +70,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.string "import_continuation_point"
   end
 
-  create_table "bank_transactions", force: :cascade do |t|
+  create_table "bank_transactions", id: :integer, force: :cascade do |t|
     t.integer "bank_account_id", null: false
     t.string "external_id"
     t.date "date"
@@ -84,7 +84,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["financial_link_id"], name: "index_bank_transactions_on_financial_link_id"
   end
 
-  create_table "documents", force: :cascade do |t|
+  create_table "documents", id: :integer, force: :cascade do |t|
     t.string "name"
     t.string "mime"
     t.binary "data", limit: 4294967295
@@ -95,15 +95,15 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["parent_id"], name: "index_documents_on_parent_id"
   end
 
-  create_table "financial_links", force: :cascade do |t|
+  create_table "financial_links", id: :integer, force: :cascade do |t|
     t.text "note"
   end
 
-  create_table "financial_transaction_classes", force: :cascade do |t|
+  create_table "financial_transaction_classes", id: :integer, force: :cascade do |t|
     t.string "name", null: false
   end
 
-  create_table "financial_transaction_types", force: :cascade do |t|
+  create_table "financial_transaction_types", id: :integer, force: :cascade do |t|
     t.string "name", null: false
     t.integer "financial_transaction_class_id", null: false
     t.string "name_short"
@@ -111,7 +111,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["name_short"], name: "index_financial_transaction_types_on_name_short"
   end
 
-  create_table "financial_transactions", force: :cascade do |t|
+  create_table "financial_transactions", id: :integer, force: :cascade do |t|
     t.integer "ordergroup_id"
     t.decimal "amount", precision: 8, scale: 2, default: "0.0", null: false
     t.text "note", null: false
@@ -125,7 +125,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["reverts_id"], name: "index_financial_transactions_on_reverts_id", unique: true
   end
 
-  create_table "group_order_article_quantities", force: :cascade do |t|
+  create_table "group_order_article_quantities", id: :integer, force: :cascade do |t|
     t.integer "group_order_article_id", default: 0, null: false
     t.integer "quantity", default: 0
     t.integer "tolerance", default: 0
@@ -133,7 +133,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["group_order_article_id"], name: "index_group_order_article_quantities_on_group_order_article_id"
   end
 
-  create_table "group_order_articles", force: :cascade do |t|
+  create_table "group_order_articles", id: :integer, force: :cascade do |t|
     t.integer "group_order_id", default: 0, null: false
     t.integer "order_article_id", default: 0, null: false
     t.integer "quantity", default: 0, null: false
@@ -146,7 +146,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["order_article_id"], name: "index_group_order_articles_on_order_article_id"
   end
 
-  create_table "group_orders", force: :cascade do |t|
+  create_table "group_orders", id: :integer, force: :cascade do |t|
     t.integer "ordergroup_id"
     t.integer "order_id", default: 0, null: false
     t.decimal "price", precision: 8, scale: 2, default: "0.0", null: false
@@ -159,7 +159,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["ordergroup_id"], name: "index_group_orders_on_ordergroup_id"
   end
 
-  create_table "groups", force: :cascade do |t|
+  create_table "groups", id: :integer, force: :cascade do |t|
     t.string "type", default: "", null: false
     t.string "name", default: "", null: false
     t.string "description"
@@ -184,7 +184,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["name"], name: "index_groups_on_name", unique: true
   end
 
-  create_table "invites", force: :cascade do |t|
+  create_table "invites", id: :integer, force: :cascade do |t|
     t.string "token", default: "", null: false
     t.datetime "expires_at", null: false
     t.integer "group_id", default: 0, null: false
@@ -193,7 +193,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["token"], name: "index_invites_on_token"
   end
 
-  create_table "invoices", force: :cascade do |t|
+  create_table "invoices", id: :integer, force: :cascade do |t|
     t.integer "supplier_id"
     t.string "number"
     t.date "date"
@@ -211,7 +211,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["supplier_id"], name: "index_invoices_on_supplier_id"
   end
 
-  create_table "links", force: :cascade do |t|
+  create_table "links", id: :integer, force: :cascade do |t|
     t.string "name", null: false
     t.string "url", null: false
     t.integer "workgroup_id"
@@ -219,7 +219,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.string "authorization"
   end
 
-  create_table "mail_delivery_status", force: :cascade do |t|
+  create_table "mail_delivery_status", id: :integer, force: :cascade do |t|
     t.datetime "created_at"
     t.string "email", null: false
     t.string "message", null: false
@@ -228,13 +228,13 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["email"], name: "index_mail_delivery_status_on_email"
   end
 
-  create_table "memberships", force: :cascade do |t|
+  create_table "memberships", id: :integer, force: :cascade do |t|
     t.integer "group_id", default: 0, null: false
     t.integer "user_id", default: 0, null: false
     t.index ["user_id", "group_id"], name: "index_memberships_on_user_id_and_group_id", unique: true
   end
 
-  create_table "message_recipients", force: :cascade do |t|
+  create_table "message_recipients", id: :integer, force: :cascade do |t|
     t.integer "message_id", null: false
     t.integer "user_id", null: false
     t.integer "email_state", default: 0, null: false
@@ -243,7 +243,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["user_id", "read_at"], name: "index_message_recipients_on_user_id_and_read_at"
   end
 
-  create_table "messages", force: :cascade do |t|
+  create_table "messages", id: :integer, force: :cascade do |t|
     t.integer "sender_id"
     t.string "subject", null: false
     t.text "body"
@@ -255,7 +255,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.binary "received_email", limit: 16777215
   end
 
-  create_table "oauth_access_grants", force: :cascade do |t|
+  create_table "oauth_access_grants", id: :integer, force: :cascade do |t|
     t.integer "resource_owner_id", null: false
     t.integer "application_id", null: false
     t.string "token", null: false
@@ -267,7 +267,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["token"], name: "index_oauth_access_grants_on_token", unique: true
   end
 
-  create_table "oauth_access_tokens", force: :cascade do |t|
+  create_table "oauth_access_tokens", id: :integer, force: :cascade do |t|
     t.integer "resource_owner_id"
     t.integer "application_id"
     t.string "token", null: false
@@ -281,7 +281,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["token"], name: "index_oauth_access_tokens_on_token", unique: true
   end
 
-  create_table "oauth_applications", force: :cascade do |t|
+  create_table "oauth_applications", id: :integer, force: :cascade do |t|
     t.string "name", null: false
     t.string "uid", null: false
     t.string "secret", null: false
@@ -293,7 +293,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
   end
 
-  create_table "order_articles", force: :cascade do |t|
+  create_table "order_articles", id: :integer, force: :cascade do |t|
     t.integer "order_id", default: 0, null: false
     t.integer "article_id", default: 0, null: false
     t.integer "quantity", default: 0, null: false
@@ -307,7 +307,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["order_id"], name: "index_order_articles_on_order_id"
   end
 
-  create_table "order_comments", force: :cascade do |t|
+  create_table "order_comments", id: :integer, force: :cascade do |t|
     t.integer "order_id"
     t.integer "user_id"
     t.text "text"
@@ -315,7 +315,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["order_id"], name: "index_order_comments_on_order_id"
   end
 
-  create_table "orders", force: :cascade do |t|
+  create_table "orders", id: :integer, force: :cascade do |t|
     t.integer "supplier_id"
     t.text "note"
     t.datetime "starts"
@@ -334,7 +334,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["state"], name: "index_orders_on_state"
   end
 
-  create_table "page_versions", force: :cascade do |t|
+  create_table "page_versions", id: :integer, force: :cascade do |t|
     t.integer "page_id"
     t.integer "lock_version"
     t.text "body"
@@ -345,7 +345,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["page_id"], name: "index_page_versions_on_page_id"
   end
 
-  create_table "pages", force: :cascade do |t|
+  create_table "pages", id: :integer, force: :cascade do |t|
     t.string "title"
     t.text "body"
     t.string "permalink"
@@ -359,20 +359,20 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["title"], name: "index_pages_on_title"
   end
 
-  create_table "periodic_task_groups", force: :cascade do |t|
+  create_table "periodic_task_groups", id: :integer, force: :cascade do |t|
     t.date "next_task_date"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "poll_choices", force: :cascade do |t|
+  create_table "poll_choices", id: :integer, force: :cascade do |t|
     t.integer "poll_vote_id", null: false
     t.integer "choice", null: false
     t.integer "value", null: false
     t.index ["poll_vote_id", "choice"], name: "index_poll_choices_on_poll_vote_id_and_choice", unique: true
   end
 
-  create_table "poll_votes", force: :cascade do |t|
+  create_table "poll_votes", id: :integer, force: :cascade do |t|
     t.integer "poll_id", null: false
     t.integer "user_id", null: false
     t.integer "ordergroup_id"
@@ -382,7 +382,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["poll_id", "user_id", "ordergroup_id"], name: "index_poll_votes_on_poll_id_and_user_id_and_ordergroup_id", unique: true
   end
 
-  create_table "polls", force: :cascade do |t|
+  create_table "polls", id: :integer, force: :cascade do |t|
     t.integer "created_by_user_id", null: false
     t.string "name", null: false
     t.text "description"
@@ -402,7 +402,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["final_choice"], name: "index_polls_on_final_choice"
   end
 
-  create_table "printer_job_updates", force: :cascade do |t|
+  create_table "printer_job_updates", id: :integer, force: :cascade do |t|
     t.integer "printer_job_id", null: false
     t.datetime "created_at", null: false
     t.string "state", null: false
@@ -410,7 +410,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["printer_job_id", "created_at"], name: "index_printer_job_updates_on_printer_job_id_and_created_at"
   end
 
-  create_table "printer_jobs", force: :cascade do |t|
+  create_table "printer_jobs", id: :integer, force: :cascade do |t|
     t.integer "order_id"
     t.string "document", null: false
     t.integer "created_by_user_id", null: false
@@ -419,7 +419,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["finished_at"], name: "index_printer_jobs_on_finished_at"
   end
 
-  create_table "settings", force: :cascade do |t|
+  create_table "settings", id: :integer, force: :cascade do |t|
     t.string "var", null: false
     t.text "value"
     t.integer "thing_id"
@@ -429,7 +429,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["thing_type", "thing_id", "var"], name: "index_settings_on_thing_type_and_thing_id_and_var", unique: true
   end
 
-  create_table "stock_changes", force: :cascade do |t|
+  create_table "stock_changes", id: :integer, force: :cascade do |t|
     t.integer "stock_event_id"
     t.integer "order_id"
     t.integer "stock_article_id"
@@ -439,7 +439,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["stock_event_id"], name: "index_stock_changes_on_stock_event_id"
   end
 
-  create_table "stock_events", force: :cascade do |t|
+  create_table "stock_events", id: :integer, force: :cascade do |t|
     t.integer "supplier_id"
     t.date "date"
     t.datetime "created_at"
@@ -449,13 +449,13 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["supplier_id"], name: "index_stock_events_on_supplier_id"
   end
 
-  create_table "supplier_categories", force: :cascade do |t|
+  create_table "supplier_categories", id: :integer, force: :cascade do |t|
     t.string "name", null: false
     t.string "description"
     t.integer "financial_transaction_class_id"
   end
 
-  create_table "suppliers", force: :cascade do |t|
+  create_table "suppliers", id: :integer, force: :cascade do |t|
     t.string "name", default: "", null: false
     t.string "address", default: "", null: false
     t.string "phone", default: "", null: false
@@ -477,7 +477,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["name"], name: "index_suppliers_on_name", unique: true
   end
 
-  create_table "tasks", force: :cascade do |t|
+  create_table "tasks", id: :integer, force: :cascade do |t|
     t.string "name", default: "", null: false
     t.text "description"
     t.date "due_date"
@@ -494,7 +494,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["workgroup_id"], name: "index_tasks_on_workgroup_id"
   end
 
-  create_table "users", force: :cascade do |t|
+  create_table "users", id: :integer, force: :cascade do |t|
     t.string "nick"
     t.string "password_hash", default: "", null: false
     t.string "password_salt", default: "", null: false


### PR DESCRIPTION
see https://stackoverflow.com/questions/44390225/how-to-turn-off-bigint-primary-keys-in-rails-5-1
and https://edgeguides.rubyonrails.org/5_1_release_notes.html#active-record-notable-changes

This fixes an issue introduced by me in 6b98fb2dfd9b3e5353330720b7694fe7d38b5ccc. I think this wouldn't be likely to cause any observable errors in the current master, but it breaks the PR https://github.com/foodcoops/foodsoft/pull/762 (should it ever be merged.)