### PR TITLE
Add option to set all received items to zero

### DIFF
--- a/app/views/orders/_edit_amounts.html.haml
+++ b/app/views/orders/_edit_amounts.html.haml
@@ -41,6 +41,13 @@
 
     $(document).on('touchclick', '#order_articles .unlocker', unlock_receive_input_field);
 
+    $(document).on('click', '#set_all_to_zero', function() {
+      $('tbody input').each(function(i, input) {
+        $(input).val(0);
+        update_delta(input);
+      });
+    })
+
     $(function() {
       $('input[data-units-expected]').each(function() {
         update_delta(this);
@@ -97,7 +104,10 @@
       = render :partial => 'edit_amount', :locals => {:order_article => order_article}
   %tfoot
     %tr
-      %th{:colspan => 10}
+      %th{colspan: 6}
         %select#add_article{:style => 'width: 500px;'}
           - new_article_data.each do |option|
             %option{id: "add_article_#{option[:id]}", value: option[:id]}= option[:text]
+      %th{colspan: 4}
+        %button.btn#set_all_to_zero{type: :button}
+          = t '.set_all_to_zero'

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1415,6 +1415,7 @@ de:
       field_unlocked_title: Die Verteilung dieses Artikels auf die einzelnen Bestellgruppen wurde manuell angepasst. Wenn du die gelieferte Menge änderst, werden die vorherigen manuellen Änderungen überschrieben.
     edit_amounts:
       no_articles_available: Keine Artikel zum hinzufügen verfügbar
+      set_all_to_zero: Alle auf Null setzen
     fax:
       amount: Menge
       articles: Artikel

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1428,6 +1428,7 @@ en:
       field_unlocked_title: The distribution of this article among the ordergroups was changed manually. When you change the amount, those manual changes will be overwritten.
     edit_amounts:
       no_articles_available: No articles to add.
+      set_all_to_zero: Set all to zero
     fax:
       amount: Amount
       articles: Articles


### PR DESCRIPTION
When an order could not be delivered, this option makes it easy to
set all amounts to zero with only one click.