### PR TITLE
Improve parsing of BankTransactionReference

### DIFF
--- a/lib/bank_transaction_reference.rb
+++ b/lib/bank_transaction_reference.rb
@@ -2,7 +2,7 @@ class BankTransactionReference
 
   # parses a string from a bank transaction field
   def self.parse(data)
-    m = /(^|\s)FS(?<group>\d+)(\.(?<user>\d+))?(?<parts>([A-Za-z]+\d+(\.\d+)?)+)(\s|$)/.match(data)
+    m = /(^|[^\w\.])FS(?<group>\d+)(\.(?<user>\d+))?(?<parts>([A-Za-z]+\d+(\.\d+)?)+)([^\w\.]|$)/.match(data)
     return unless m
 
     parts = {}
@@ -12,8 +12,8 @@ class BankTransactionReference
       parts[category] = value
     end
 
-    ret = { group: m[:group], parts: parts }
-    ret[:user] = m[:user] if m[:user]
+    ret = { group: m[:group].to_i, parts: parts }
+    ret[:user] = m[:user].to_i if m[:user]
     return ret
   end
 

--- a/spec/lib/bank_transaction_reference_spec.rb
+++ b/spec/lib/bank_transaction_reference_spec.rb
@@ -21,40 +21,76 @@ describe BankTransactionReference do
     expect(BankTransactionReference.parse('xFS1A1')).to be nil
   end
 
+  it 'returns nil for .FS1A1' do
+    expect(BankTransactionReference.parse('.FS1A1')).to be nil
+  end
+
   it 'returns nil for FS1A1x' do
     expect(BankTransactionReference.parse('FS1A1x')).to be nil
   end
 
-  it 'returns correct value for FS1A1' do
-    expect(BankTransactionReference.parse('FS1A1')).to be { { group: 1, parts: { A: 1 } } }
+  it 'returns nil for FS1A1.' do
+    expect(BankTransactionReference.parse('FS1A1.')).to be nil
   end
 
   it 'returns correct value for FS1A1' do
-    expect(BankTransactionReference.parse('FS1.2A3')).to be { { group: 1, user: 2, parts: { A: 3 } } }
+    expect(BankTransactionReference.parse('FS1A1')).to match({ group: 1, parts: { "A" => 1 } })
   end
 
-  it 'returns correct value for FS1A2B3' do
-    expect(BankTransactionReference.parse('FS1A2B3C4')).to be { { group: 1, parts: { A: 2, B: 3, C: 4 } } }
+  it 'returns correct value for FS1.2A3' do
+    expect(BankTransactionReference.parse('FS1.2A3')).to match({ group: 1, user: 2, parts: { "A" => 3 } })
+  end
+
+  it 'returns correct value for FS1A2B3C4' do
+    expect(BankTransactionReference.parse('FS1A2B3C4')).to match({ group: 1, parts: { "A" => 2, "B" => 3, "C" => 4 } })
   end
 
   it 'returns correct value for FS1A2B3A4' do
-    expect(BankTransactionReference.parse('FS1A2B3C4')).to be { { group: 1, parts: { A: 6, B: 3 } } }
+    expect(BankTransactionReference.parse('FS1A2B3A4')).to match({ group: 1, parts: { "A" => 6, "B" => 3 } })
   end
 
   it 'returns correct value for FS1A2.34B5.67C8.90' do
-    expect(BankTransactionReference.parse('FS1A2B3C4')).to be { { group: 1, parts: { A: 2.34, B: 5.67, C: 8.90 } } }
+    expect(BankTransactionReference.parse('FS1A2.34B5.67C8.90')).to match({ group: 1, parts: { "A" => 2.34, "B" => 5.67, "C" => 8.90 } })
   end
 
-  it 'returns correct value for FS123A456 with prefix' do
-    expect(BankTransactionReference.parse('x FS123A456')).to be { { group: 123, parts: { A: 456 } } }
+  it 'returns correct value for FS123A456 with comma-separated prefix' do
+    expect(BankTransactionReference.parse('x,FS123A456')).to match({ group: 123, parts: { "A" => 456 } })
   end
 
-  it 'returns correct value for FS234A567 with suffix' do
-    expect(BankTransactionReference.parse('FS234A567 x')).to be { { group: 234, parts: { A: 567 } } }
+  it 'returns correct value for FS123A456 with minus-separated prefix' do
+    expect(BankTransactionReference.parse('x-FS123A456')).to match({ group: 123, parts: { "A" => 456 } })
+  end
+
+  it 'returns correct value for FS123A456 with semicolon-separated prefix' do
+    expect(BankTransactionReference.parse('x;FS123A456')).to match({ group: 123, parts: { "A" => 456 } })
+  end
+
+  it 'returns correct value for FS123A456 with space-separated prefix' do
+    expect(BankTransactionReference.parse('x FS123A456')).to match({ group: 123, parts: { "A" => 456 } })
+  end
+
+  it 'returns correct value for FS234A567 with comma-separated suffix' do
+    expect(BankTransactionReference.parse('FS234A567,x')).to match({ group: 234, parts: { "A" => 567 } })
+  end
+
+  it 'returns correct value for FS234A567 with minus-separated suffix' do
+    expect(BankTransactionReference.parse('FS234A567-x')).to match({ group: 234, parts: { "A" => 567 } })
+  end
+
+  it 'returns correct value for FS234A567 with space-separated suffix' do
+    expect(BankTransactionReference.parse('FS234A567 x')).to match({ group: 234, parts: { "A" => 567 } })
+  end
+
+  it 'returns correct value for FS234A567 with semicolon-separated suffix' do
+    expect(BankTransactionReference.parse('FS234A567;x')).to match({ group: 234, parts: { "A" => 567 } })
+  end
+
+  it 'returns correct value for FS234A567 with minus-separated suffix' do
+    expect(BankTransactionReference.parse('FS234A567-x')).to match({ group: 234, parts: { "A" => 567 } })
   end
 
   it 'returns correct value for FS34.56A67.89 with prefix and suffix' do
-    expect(BankTransactionReference.parse('x FS34.56A67.89 x')).to be { { group: 34, user: 56, parts: { A: 67.89 } } }
+    expect(BankTransactionReference.parse('prefix FS34.56A67.89, suffix')).to match({ group: 34, user: 56, parts: { "A" => 67.89 } })
   end
 
 end


### PR DESCRIPTION
Allow more characters before and after the actual reference.
Also use the correct matching method during testing.