### PR TITLE
Update de.yml: Mindestmenge Euro

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -177,8 +177,8 @@ de:
         fax: Fax
         iban: IBAN
         is_subscribed: abonniert?
-        min_order_quantity: Mindestbestellmenge
-        min_order_quantity_short: Menge (mind.)
+        min_order_quantity: Mindestbestellmenge (Euro)
+        min_order_quantity_short: Menge (€ min.)
         name: Name
         note: Notiz
         order_howto: Kurzanleitung Bestellen


### PR DESCRIPTION
Mindestmenge bezieht sich auf einen Geldbetrag (und nicht auf Stück oder Gewicht, was der Begriff "Menge" eher nahelegt), daher Euro hinzugefügt zur Klärung.