### PR TITLE
Add API v1 financial_transactions POST endpoint

### DIFF
--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -39,6 +39,12 @@ class Api::V1::BaseController < ApplicationController
     end
   end
 
+  def require_config_enabled(config)
+    unless FoodsoftConfig[config]
+      raise Api::Errors::PermissionRequired.new(t('application.controller.error_not_enabled', config: config))
+    end
+  end
+
   def skip_session
     request.session_options[:skip] = true
   end

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -25,6 +25,20 @@ class Api::V1::BaseController < ApplicationController
     end
   end
 
+  def require_minimum_balance
+    minimum_balance = FoodsoftConfig[:minimum_balance] or return
+    if current_ordergroup.account_balance < minimum_balance
+      raise Api::Errors::PermissionRequired.new(t('application.controller.error_minimum_balance', min: minimum_balance))
+    end
+  end
+
+  def require_enough_apples
+    if current_ordergroup.not_enough_apples?
+      s = t('group_orders.messages.not_enough_apples', apples: current_ordergroup.apples, stop_ordering_under: FoodsoftConfig[:stop_ordering_under])
+      raise Api::Errors::PermissionRequired.new(s)
+    end
+  end
+
   def skip_session
     request.session_options[:skip] = true
   end

--- a/app/controllers/api/v1/user/group_order_articles_controller.rb
+++ b/app/controllers/api/v1/user/group_order_articles_controller.rb
@@ -84,20 +84,6 @@ class Api::V1::User::GroupOrderArticlesController < Api::V1::BaseController
     params.require(:group_order_article).permit(:quantity, :tolerance)
   end
 
-  def require_minimum_balance
-    minimum_balance = FoodsoftConfig[:minimum_balance] or return
-    if current_ordergroup.account_balance < minimum_balance
-      raise Api::Errors::PermissionRequired.new(t('application.controller.error_minimum_balance', min: minimum_balance))
-    end
-  end
-
-  def require_enough_apples
-    if current_ordergroup.not_enough_apples?
-      s = t('group_orders.messages.not_enough_apples', apples: current_ordergroup.apples, stop_ordering_under: FoodsoftConfig[:stop_ordering_under])
-      raise Api::Errors::PermissionRequired.new(s)
-    end
-  end
-
   def render_goa_with_oa(goa, oa = goa.order_article)
     data = {}
     data[:group_order_article] = GroupOrderArticleSerializer.new(goa) if goa

--- a/app/models/ordergroup.rb
+++ b/app/models/ordergroup.rb
@@ -90,6 +90,7 @@ class Ordergroup < Group
       if t.amount < 0 && self.account_balance < 0 && self.account_balance - t.amount >= 0
         Resque.enqueue(UserNotifier, FoodsoftConfig.scope, 'negative_balance', self.id, t.id)
       end
+      t
     end
   end
 

--- a/app/views/admin/configs/_tab_payment.html.haml
+++ b/app/views/admin/configs/_tab_payment.html.haml
@@ -12,6 +12,7 @@
     = config_input_field form, :minimum_balance, as: :decimal, class: 'input-small'
 = config_input form, :charge_members_manually, as: :boolean
 = config_input form, :use_iban, as: :boolean
+= config_input form, :use_self_service, as: :boolean
 
 %h4= t '.schedule_title'
 = form.simple_fields_for :order_schedule do |fields|

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -602,6 +602,7 @@ de:
       use_boxfill: Wenn aktiviert, können Benutzer nahe am Ende der Bestellung diese nur mehr so verändern, dass sich die Gesamtsumme erhöht. Dies hilft beim auffüllen der verbleibenden Kisten. Es muss trotzdem noch das Kistenauffülldatum bei der Bestellung gesetzt werden.
       use_iban: Zusätzlich Feld für die internationale Kontonummer bei Benutzern und Lieferanten anzeigen
       use_nick: Benutzernamen anstatt reale Namen zeigen und verwenden, jeder Benutzer muss dazu einen Benutzernamen (Spitznamen) haben.
+      use_self_service: Wenn aktiviert, können Benutzer_innen selbständig dafür freigegebene Abrechungsfunktionen nutzen.
       webstats_tracking_code: Tracking Code für Webseitenanalyse (wie Piwik oder Google Analytics), leer lassen wenn keine Analyse erfolgt
     keys:
       applepear_url: Hilfe URL für das Äpfel Punktesystem zum Engagement
@@ -659,6 +660,7 @@ de:
       use_boxfill: Kistenauffüllphase
       use_iban: IBAN verwenden
       use_nick: Benutzernamen verwenden
+      use_self_service: Selbstbedienung verwenden
       webstats_tracking_code: Code für Websiteanalysetool
     tabs:
       applications: Apps

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -603,6 +603,7 @@ en:
       use_boxfill: When enabled, near end of an order, members are only able to change their order when increases the total amount ordered. This helps to fill any remaining boxes. You still need to set a box-fill date for the orders.
       use_iban: When enabled, supplier and user provide an additonal field for storing the international bank account number.
       use_nick: Show and use nicknames instead of real names. When enabling this, please check that each user has a nickname.
+      use_self_service: When enabled, members are able to use selected balancing functions on their own.
       webstats_tracking_code: Tracking code for web analytics (like Piwik or Google analytics). Leave empty for no tracking.
     keys:
       applepear_url: Apple system help URL
@@ -660,6 +661,7 @@ en:
       use_boxfill: Box-fill phase
       use_iban: Use IBAN
       use_nick: Use nicknames
+      use_self_service: Use self service
       webstats_tracking_code: Tracking code
     tabs:
       applications: Apps

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -265,7 +265,7 @@ Rails.application.routes.draw do
 
         namespace :user do
           root to: 'users#show'
-          resources :financial_transactions, only: [:index, :show]
+          resources :financial_transactions, only: [:index, :show, :create]
           resources :group_order_articles
         end
 

--- a/doc/swagger.v1.yml
+++ b/doc/swagger.v1.yml
@@ -89,6 +89,42 @@ paths:
             $ref: '#/definitions/Error403'
       security:
         - foodsoft_auth: ['finance:user']
+    post:
+      summary: create new financial transaction
+      tags:
+        - 1. User
+        - 6. FinancialTransaction
+      parameters:
+        - in: body
+          name: body
+          description: financial transaction to create
+          required: true
+          schema:
+            $ref: '#/definitions/FinancialTransactionForCreate'
+      responses:
+        200:
+          description: success
+          schema:
+            type: object
+            properties:
+              financial_transaction:
+                $ref: '#/definitions/FinancialTransaction'
+        401:
+          description: not logged-in
+          schema:
+            $ref: '#/definitions/Error401'
+        403:
+          description: user has no ordergroup, is below minimum balance, or missing scope
+          schema:
+            $ref: '#/definitions/Error403'
+        404:
+          description: financial transaction type not found
+          schema:
+            $ref: '#/definitions/Error404'
+        422:
+          description: invalid parameter value
+          schema:
+            $ref: '#/definitions/Error422'
   /user/financial_transactions/{id}:
     parameters:
       - $ref: '#/parameters/idInUrl'
@@ -719,34 +755,40 @@ definitions:
         description: language code
     required: ['id', 'name', 'email']
 
-  FinancialTransaction:
+  FinancialTransactionForCreate:
     type: object
     properties:
-      id:
-        type: integer
-      user_id:
-        type: ['integer', 'null']
-        description: id of user who entered the transaction (may be <tt>null</tt> for deleted users or 0 for a system user)
-      user_name:
-        type: ['string', 'null']
-        description: name of user who entered the transaction (may be <tt>null</tt> or empty string for deleted users or system users)
       amount:
         type: number
         description: amount credited (negative for a debit transaction)
       financial_transaction_type_id:
         type: integer
         description: id of the type of the transaction
-      financial_transaction_type_name:
-        type: string
-        description: name of the type of the transaction
       note:
         type: string
         description: note entered with the transaction
-      created_at:
-        type: string
-        format: date-time
-        description: when the transaction was entered
-    required: ['id', 'user_id', 'user_name', 'amount', 'financial_transaction_type_id', 'financial_transaction_type_name', 'note', 'created_at']
+    required: ['amount', 'financial_transaction_type_id', 'note']
+  FinancialTransaction:
+    allOf:
+      - $ref: '#/definitions/FinancialTransactionForCreate'
+      - type: object
+        properties:
+          id:
+            type: integer
+          user_id:
+            type: ['integer', 'null']
+            description: id of user who entered the transaction (may be <tt>null</tt> for deleted users or 0 for a system user)
+          user_name:
+            type: ['string', 'null']
+            description: name of user who entered the transaction (may be <tt>null</tt> or empty string for deleted users or system users)
+          financial_transaction_type_name:
+            type: string
+            description: name of the type of the transaction
+          created_at:
+            type: string
+            format: date-time
+            description: when the transaction was entered
+        required: ['id', 'user_id', 'user_name', 'financial_transaction_type_name', 'created_at']
 
   FinancialTransactionClass:
     type: object

--- a/doc/swagger.v1.yml
+++ b/doc/swagger.v1.yml
@@ -90,7 +90,7 @@ paths:
       security:
         - foodsoft_auth: ['finance:user']
     post:
-      summary: create new financial transaction
+      summary: create new financial transaction (requires enabled self service)
       tags:
         - 1. User
         - 6. FinancialTransaction
@@ -114,7 +114,7 @@ paths:
           schema:
             $ref: '#/definitions/Error401'
         403:
-          description: user has no ordergroup, is below minimum balance, or missing scope
+          description: user has no ordergroup, is below minimum balance, self service is disabled, or missing scope
           schema:
             $ref: '#/definitions/Error403'
         404:

--- a/spec/api/v1/swagger_spec.rb
+++ b/spec/api/v1/swagger_spec.rb
@@ -50,7 +50,6 @@ describe 'API v1', type: :apivore, order: :defined do
 
         let(:create_params) { {'_data' => {financial_transaction: {amount: 1, financial_transaction_type_id: ft_1.financial_transaction_type.id, note: 'note'}}} }
 
-
         context 'without using self service' do
           it { is_expected.to validate(:post, '/user/financial_transactions', 403, api_auth(create_params)) }
         end

--- a/spec/api/v1/user/financial_transactions_spec.rb
+++ b/spec/api/v1/user/financial_transactions_spec.rb
@@ -1,0 +1,107 @@
+require 'spec_helper'
+
+# Most routes are tested in the swagger_spec, this tests endpoints that change data.
+describe Api::V1::User::FinancialTransactionsController, type: :controller do
+  include ApiOAuth
+  let(:user) { create(:user, :ordergroup) }
+  let(:api_scopes) { ['finance:user'] }
+
+  let(:ftc1) { create :financial_transaction_class }
+  let(:ftc2) { create :financial_transaction_class }
+  let(:ftt1) { create :financial_transaction_type, financial_transaction_class: ftc1 }
+  let(:ftt2) { create :financial_transaction_type, financial_transaction_class: ftc2 }
+  let(:ftt3) { create :financial_transaction_type, financial_transaction_class: ftc2 }
+
+  let(:amount) { rand(-100..100) }
+  let(:note) { Faker::Lorem.sentence }
+
+  let(:json_ft) { json_response['financial_transaction'] }
+
+  shared_examples "financial_transactions endpoint success" do
+    before { request }
+
+    it "returns status 200" do
+      expect(response.status).to eq 200
+    end
+  end
+
+  shared_examples "financial_transactions create/update success" do
+    include_examples "financial_transactions endpoint success"
+
+    it "returns the financial_transaction" do
+      expect(json_ft['id']).to be_present
+      expect(json_ft['financial_transaction_type_id']).to eq ftt1.id
+      expect(json_ft['financial_transaction_type_name']).to eq ftt1.name
+      expect(json_ft['amount']).to eq amount
+      expect(json_ft['note']).to eq note
+      expect(json_ft['user_id']).to eq user.id
+    end
+
+    it "updates the financial_transaction" do
+      resulting_ft = FinancialTransaction.where(id: json_ft['id']).first
+      expect(resulting_ft).to be_present
+      expect(resulting_ft.financial_transaction_type).to eq ftt1
+      expect(resulting_ft.amount).to eq amount
+      expect(resulting_ft.note).to eq note
+      expect(resulting_ft.user).to eq user
+    end
+  end
+
+
+  shared_examples "financial_transactions endpoint failure" do |status|
+    it "returns status #{status}" do
+      request
+      expect(response.status).to eq status
+    end
+
+    it "does not change the ordergroup" do
+      expect { request }.to_not change {
+        user.ordergroup.attributes
+      }
+    end
+
+    it "does not change the financial_transactions of ordergroup" do
+      expect { request }.to_not change {
+        user.ordergroup.financial_transactions.count
+      }
+    end
+  end
+
+
+  describe "POST :create" do
+    let(:ft_params) { { amount: amount, financial_transaction_type_id: ftt1.id, note: note } }
+    let(:request) { post :create, params: { financial_transaction: ft_params, foodcoop: 'f' } }
+
+    context 'without using self service' do
+      include_examples "financial_transactions endpoint failure", 403
+    end
+
+    context 'with using self service' do
+      before { FoodsoftConfig[:use_self_service] = true }
+
+      context "with no existing financial transaction" do
+        include_examples "financial_transactions create/update success"
+      end
+
+      context "with existing financial transaction" do
+        before { user.ordergroup.add_financial_transaction! 5000, 'for ordering', user, ftt3 }
+        include_examples "financial_transactions create/update success"
+      end
+
+      context "with invalid financial transaction type" do
+        let(:ft_params) { { amount: amount, financial_transaction_type_id: -1, note: note } }
+        include_examples "financial_transactions endpoint failure", 404
+      end
+
+      context "without note" do
+        let(:ft_params) { { amount: amount, financial_transaction_type_id: ftt1.id } }
+        include_examples "financial_transactions endpoint failure", 422
+      end
+
+      context 'without enough balance' do
+        before { FoodsoftConfig[:minimum_balance] = 1000 }
+        include_examples "financial_transactions endpoint failure", 403
+      end
+    end
+  end
+end


### PR DESCRIPTION
In a first step we allow members to create financial transactions
for their own ordergroup.