### PR TITLE
Improve reference calculator

### DIFF
--- a/app/views/home/reference_calculator.haml
+++ b/app/views/home/reference_calculator.haml
@@ -12,7 +12,7 @@
         $('input[data-has-name-short]').each(function() {
           var bank_account = $(this).attr('data-bank-account') || default_bank_account;
           var name = $(this).attr('name');
-          var value = Math.ceil(parseFloat($(this).val()) * 100) / 100;
+          var value = Math.round(parseFloat($(this).val()) * 100) / 100;
           if (value > 0) {
             var item = items[bank_account];
             if (!item) {
@@ -32,7 +32,7 @@
           console.dir(item);
           if (item) {
             ele.show();
-            ele.find('.amount').text(item.amount);
+            ele.find('.amount').text(item.amount.toFixed(2));
             ele.find('.reference').text((#{raw BankTransactionReference.js_code_for_user(@current_user)})(item.values));
           } else {
             ele.hide();
@@ -55,13 +55,16 @@
     %table#ordergroups
       %thead
         %tr
-          %th= heading_helper FinancialTransactionType, :name
+          %th= t('.transaction_types_headline')
           %th= heading_helper FinancialTransaction, :amount
       %tbody
         - for t in @types
           %tr
             %td= "#{t.name} (#{t.name_short}):"
-            %td= text_field_tag t.name_short, nil, class: 'input-small',
+            %td
+              .input-prepend
+                %span.add-on= t 'number.currency.format.unit'
+                = text_field_tag t.name_short, nil, class: 'input-small',
               'data-has-name-short' => true, 'data-bank-account' => t.bank_account.try(:id),
               step: 0.01, type: :number
   %p#placeholder
@@ -70,6 +73,7 @@
     %p{'data-text' => ba.id}
       = t('.text0')
       %b.amount= '?'
+      %b= t 'number.currency.format.unit'
       = t('.text1')
       %b.reference= '?'
       = t('.text2')

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1136,6 +1136,7 @@ de:
         since: "(Mitglied seit %{when})"
         title: "%{user}"
     reference_calculator:
+      transaction_types_headline: Zweck
       placeholder: Bitte fülle zuerst die einzelnen Felder mit den gewünschten Beträgen für die Überweisung aus, um die Zahlungsreferenz für diese Transaktion anzuzeigen.
       text0: Bitte überweise
       text1: mit der Zahlungsreferenz

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1139,6 +1139,7 @@ en:
         since: "(member for %{when})"
         title: "%{user}"
     reference_calculator:
+      transaction_types_headline: Target
       placeholder: Please enter the amounts you want to tranfser in every field first, to see the reference you should use for that transaction.
       text0: Please transfer
       text1: with the reference

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1139,7 +1139,7 @@ en:
         since: "(member for %{when})"
         title: "%{user}"
     reference_calculator:
-      transaction_types_headline: Target
+      transaction_types_headline: Purpose
       placeholder: Please enter the amounts you want to tranfser in every field first, to see the reference you should use for that transaction.
       text0: Please transfer
       text1: with the reference


### PR DESCRIPTION
- fix rounding error: previously, some numbers like 38.20 (which is something like 38.2000000001) were ceiled to 38.21 (was there a specific reason to use "ceil" instead of "round"?)
- always display final amount with two decimals
- add currency symbol to input fields and final amount
- better(?) headline for transaction types - you could also use "type" (as in transaction type) which would be closer to the model, but I think "purpose" is better understandable and fitting in this context.