### PR TITLE
Update de.yml for minimum order quantity - currency independant

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -177,8 +177,8 @@ de:
         fax: Fax
         iban: IBAN
         is_subscribed: abonniert?
-        min_order_quantity: Mindestbestellmenge
-        min_order_quantity_short: Menge (mind.)
+        min_order_quantity: Mindestbestellwert
+        min_order_quantity_short: Wert (mind.)
         name: Name
         note: Notiz
         order_howto: Kurzanleitung Bestellen


### PR DESCRIPTION
"Wert" repräsentiert für mich eher einen Geldbetrag als "Menge", daher wird die deutsche Übersetzung aus meiner Sicht klarer.