### PR TITLE
Improve various dl-horizontal views

### DIFF
--- a/app/assets/stylesheets/bootstrap_and_overrides.css.less
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css.less
@@ -335,10 +335,9 @@ td.symbol, th.symbol {
 // https://github.com/twbs/bootstrap/issues/4550#issuecomment-31916049
 .dropdown-backdrop { position: static; }
 
-// need more space for supplier&order information (in German, at least)
 .dl-horizontal {
-  dt { width: 160px; }
-  dd { margin-left: 170px; }
+  dt { width: 200px; margin-bottom: 0.2em; }
+  dd { margin-left: 210px; }
 }
 
 // get rid of extra bottom margin inside well

--- a/app/views/finance/invoices/show.html.haml
+++ b/app/views/finance/invoices/show.html.haml
@@ -2,74 +2,76 @@
 
 - total = 0
 
-%p
-  %b= heading_helper(Invoice, :created_at) + ':'
-  = format_time(@invoice.created_at)
-%p
-  %b= heading_helper(Invoice, :created_by) + ':'
-  = show_user(@invoice.created_by)
-%p
-  %b= heading_helper(Invoice, :supplier) + ':'
-  = @invoice.supplier.name
+.row-fluid
+  .span6
+    %dl.dl-horizontal
+      %dt= heading_helper(Invoice, :created_at) + ':'
+      %dd= format_date(@invoice.created_at)
 
-- if @invoice.deliveries.any?
-  %p
-    %b= heading_helper(Invoice, :deliveries) + ':'
-    %span><
-      - @invoice.deliveries.order(:date).each_with_index do |delivery, index|
-        - sum = delivery.sum
-        - total += sum
-        = ', ' if index > 0
-        = link_to format_date(delivery.date), [delivery.supplier, delivery]
-        = ' (' + number_to_currency(sum) + ')'
-- if @invoice.orders.any?
-  %p
-    %b= heading_helper(Invoice, :orders) + ':'
-    %span><
-      - @invoice.orders.order(:ends).each_with_index do |order, index|
-        - sum = order.sum
-        - total += sum
-        = ', ' if index > 0
-        = link_to format_date(order.ends), new_finance_order_path(order_id: order)
-        = ' (' + number_to_currency(sum) + ')'
+      %dt= heading_helper(Invoice, :created_by) + ':'
+      %dd= show_user(@invoice.created_by)
 
-%p
-  %b= heading_helper(Invoice, :number) + ':'
-  = @invoice.number
-%p
-  %b= heading_helper(Invoice, :date) + ':'
-  = @invoice.date
-%p
-  %b= heading_helper(Invoice, :paid_on) + ':'
-  = @invoice.paid_on
-%p
-  %b= heading_helper(Invoice, :amount) + ':'
-  = number_to_currency @invoice.amount
-%p
-  %b= heading_helper(Invoice, :deposit) + ':'
-  = number_to_currency @invoice.deposit
-%p
-  %b= heading_helper(Invoice, :deposit_credit) + ':'
-  = number_to_currency @invoice.deposit_credit
-%p
-  %b= heading_helper(Invoice, :net_amount) + ':'
-  = number_to_currency @invoice.net_amount
-- if @invoice.deliveries.any? || @invoice.orders.any?
-  %p
-    %b= heading_helper(Invoice, :total) + ':'
-    = number_to_currency total
-%p
-  %b= heading_helper(Invoice, :attachment) + ':'
-  - if @invoice.attachment_data
-    = link_to t('ui.download'), finance_invoice_attachment_path(@invoice)
-%p
-  %b= heading_helper(Invoice, :note) + ':'
-  =h @invoice.note
-- if @invoice.financial_link
-  %p
-    %b= heading_helper(Invoice, :financial_link) + ':'
-    = link_to t('ui.show'), finance_link_path(@invoice.financial_link)
+      %dt= heading_helper(Invoice, :supplier) + ':'
+      %dd= @invoice.supplier.name
 
-- if @invoice.user_can_edit?(current_user)
-  = link_to t('ui.edit'), edit_finance_invoice_path(@invoice), class: 'btn'
-= link_to t('ui.or_cancel'), finance_invoices_path
+      - if @invoice.deliveries.any?
+        %dt= heading_helper(Invoice, :deliveries) + ':'
+        %dd><
+          - @invoice.deliveries.order(:date).each_with_index do |delivery, index|
+            - sum = delivery.sum
+            - total += sum
+            = ', ' if index > 0
+            = link_to format_date(delivery.date), [delivery.supplier, delivery]
+            = ' (' + number_to_currency(sum) + ')'
+
+      - if @invoice.orders.any?
+        %dt= heading_helper(Invoice, :orders) + ':'
+        %dd><
+          - @invoice.orders.order(:ends).each_with_index do |order, index|
+            - sum = order.sum
+            - total += sum
+            = ', ' if index > 0
+            = link_to format_date(order.ends), new_finance_order_path(order_id: order) #, style: "margin-right: 0.2em;"
+            = ' (' + number_to_currency(sum) + ')'
+
+      %dt= heading_helper(Invoice, :number) + ':'
+      %dd= @invoice.number
+
+      %dt= heading_helper(Invoice, :date) + ':'
+      %dd= format_date(@invoice.date)
+
+      %dt= heading_helper(Invoice, :paid_on) + ':'
+      %dd= format_date(@invoice.paid_on)
+
+      %dt= heading_helper(Invoice, :amount) + ':'
+      %dd= number_to_currency @invoice.amount
+
+      %dt= heading_helper(Invoice, :deposit) + ':'
+      %dd= number_to_currency @invoice.deposit
+
+      %dt= heading_helper(Invoice, :deposit_credit) + ':'
+      %dd= number_to_currency @invoice.deposit
+
+      %dt= heading_helper(Invoice, :net_amount) + ':'
+      %dd= number_to_currency @invoice.net_amount
+
+      - if @invoice.deliveries.any? || @invoice.orders.any?
+        %dt= heading_helper(Invoice, :total) + ':'
+        %dd= number_to_currency total
+
+      - if @invoice.attachment_data
+        %dt= heading_helper(Invoice, :attachment) + ':'
+        %dd= link_to t('ui.download'), finance_invoice_attachment_path(@invoice)
+
+      %dt= heading_helper(Invoice, :note) + ':'
+      %dd= simple_format(@invoice.note)
+
+      - if @invoice.financial_link
+        %dt= heading_helper(Invoice, :financial_link) + ':'
+        %dd= link_to t('ui.show'), finance_link_path(@invoice.financial_link)
+
+    .clearfix
+      .form-actions
+        - if @invoice.user_can_edit?(current_user)
+          = link_to t('ui.edit'), edit_finance_invoice_path(@invoice), class: 'btn'
+        = link_to t('ui.or_cancel'), finance_invoices_path

--- a/app/views/finance/invoices/show.html.haml
+++ b/app/views/finance/invoices/show.html.haml
@@ -31,7 +31,7 @@
             - sum = order.sum
             - total += sum
             = ', ' if index > 0
-            = link_to format_date(order.ends), new_finance_order_path(order_id: order) #, style: "margin-right: 0.2em;"
+            = link_to format_date(order.ends), new_finance_order_path(order_id: order)
             = ' (' + number_to_currency(sum) + ')'
 
       %dt= heading_helper(Invoice, :number) + ':'

--- a/app/views/finance/invoices/show.html.haml
+++ b/app/views/finance/invoices/show.html.haml
@@ -50,7 +50,7 @@
       %dd= number_to_currency @invoice.deposit
 
       %dt= heading_helper(Invoice, :deposit_credit) + ':'
-      %dd= number_to_currency @invoice.deposit
+      %dd= number_to_currency @invoice.deposit_credit
 
       %dt= heading_helper(Invoice, :net_amount) + ':'
       %dd= number_to_currency @invoice.net_amount

--- a/app/views/finance/invoices/show.html.haml
+++ b/app/views/finance/invoices/show.html.haml
@@ -6,7 +6,7 @@
   .span6
     %dl.dl-horizontal
       %dt= heading_helper(Invoice, :created_at) + ':'
-      %dd= format_date(@invoice.created_at)
+      %dd= format_time(@invoice.created_at)
 
       %dt= heading_helper(Invoice, :created_by) + ':'
       %dd= show_user(@invoice.created_by)

--- a/app/views/suppliers/show.html.haml
+++ b/app/views/suppliers/show.html.haml
@@ -38,9 +38,9 @@
       %dt= heading_helper(Supplier, :delivery_days) + ':'
       %dd= @supplier.delivery_days
       %dt= heading_helper(Supplier, :order_howto) + ':'
-      %dd= @supplier.order_howto
+      %dd= simple_format(@supplier.order_howto)
       %dt= heading_helper(Supplier, :note) + ':'
-      %dd= @supplier.note
+      %dd= simple_format(@supplier.note)
       %dt= heading_helper(Supplier, :min_order_quantity) + ':'
       %dd= @supplier.min_order_quantity
 


### PR DESCRIPTION
I raised the width of dl-horizontal titles (used on pages like suppliers/show, group_orders/show, and here finance/invoices/show as well), as some titles, esp. in German, were cut off before. I'm not sure if this could have negative effects on small screens like on mobile devices. I guess there has been a reason this wasn't changed.
Also I added some 'line spacing' via margin-bottom to increase the readability of those pages.

With these changes, we could also use dl-horizontal for the invoices/show page, which would again improve readability and make it easier to compare dates, amounts, deposit etc.