### PR TITLE
Improve access to financial link feature & add option to create link when balancing an order

### DIFF
--- a/app/controllers/finance/balancing_controller.rb
+++ b/app/controllers/finance/balancing_controller.rb
@@ -80,7 +80,8 @@ class Finance::BalancingController < Finance::BaseController
   def close
     @order = Order.find(params[:id])
     @type = FinancialTransactionType.find_by_id(params.permit(:type)[:type])
-    @order.close!(@current_user, @type)
+    @link = FinancialLink.new if params[:create_financial_link]
+    @order.close!(@current_user, @type, @link)
     redirect_to finance_order_index_url, notice: t('finance.balancing.close.notice')
   rescue => error
     redirect_to new_finance_order_url(order_id: @order.id), alert: t('finance.balancing.close.alert', message: error.message)

--- a/app/views/admin/configs/_tab_payment.html.haml
+++ b/app/views/admin/configs/_tab_payment.html.haml
@@ -12,6 +12,7 @@
     = config_input_field form, :minimum_balance, as: :decimal, class: 'input-small'
 = config_input form, :charge_members_manually, as: :boolean
 = config_input form, :use_iban, as: :boolean
+= config_input form, :use_financial_links, as: :boolean
 = config_input form, :use_self_service, as: :boolean
 
 %h4= t '.schedule_title'

--- a/app/views/finance/balancing/confirm.html.haml
+++ b/app/views/finance/balancing/confirm.html.haml
@@ -4,6 +4,11 @@
     %p
       %b= heading_helper FinancialTransaction, :financial_transaction_type
       = select_tag :type, options_for_select(FinancialTransactionType.order(:name).map { |t| [ t.name, t.id ] })
+  - if FoodsoftConfig[:use_financial_links]
+    %p
+      %label
+        = check_box_tag :create_financial_link, true, params[:create_financial_link]
+        = t('.create_financial_link')
   %table.table.table-striped{:style => "width:35em"}
     - for group_order in @order.group_orders
       %tr{:class => cycle('even', 'odd')}

--- a/app/views/finance/financial_transactions/new_collection.html.haml
+++ b/app/views/finance/financial_transactions/new_collection.html.haml
@@ -73,7 +73,7 @@
       %label
         = check_box_tag :create_foodcoop_transaction, true, params[:create_foodcoop_transaction]
         = t('.create_foodcoop_transaction')
-  - if BankAccount.any?
+  - if FoodsoftConfig[:use_financial_links]
     %p
       %label
         = check_box_tag :create_financial_link, true, params[:create_financial_link]

--- a/app/views/finance/ordergroups/index.html.haml
+++ b/app/views/finance/ordergroups/index.html.haml
@@ -3,7 +3,7 @@
 - content_for :actionbar do
   = link_to t('.show_all'), finance_transactions_path, class: 'btn'
   = link_to t('.show_foodcoop'), finance_foodcoop_financial_transactions_path, class: 'btn'
-  - if FinancialLink.any?
+  - if FoodsoftConfig[:use_financial_links]
     = link_to t('.new_financial_link'), finance_links_path, method: :post, class: 'btn'
   = link_to t('.new_transaction'), finance_new_transaction_collection_path, class: 'btn btn-primary'
 

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -770,6 +770,7 @@ de:
       confirm:
         clear: Abrechnen
         first_paragraph: 'Wenn die Bestellung abgerechnet wird, werden ebenfalls alle Gruppenkonten aktualisiert.<br />Die Konten werden wie folgt belastet:'
+        create_financial_link: Erstelle einen gemeinsamen Finanzlink für die Kontotransaktionen sowie, falls vorhanden, die zugehörige Rechnung.
         or_cancel: oder zurück zur Abrechnung
         title: Bestellung abrechnen
       edit_note:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -602,6 +602,7 @@ de:
       use_apple_points: Wenn das Apfel Punktesystem aktiviert ist, ist es erforderlich, dass Mitglieder Aufgaben erledigen um bestellen zu können.
       use_boxfill: Wenn aktiviert, können Benutzer nahe am Ende der Bestellung diese nur mehr so verändern, dass sich die Gesamtsumme erhöht. Dies hilft beim auffüllen der verbleibenden Kisten. Es muss trotzdem noch das Kistenauffülldatum bei der Bestellung gesetzt werden.
       use_iban: Zusätzlich Feld für die internationale Kontonummer bei Benutzern und Lieferanten anzeigen
+      use_financial_links: Wenn aktiviert, werden Optionen zum Anlegen von Finanzlinks angezeigt, die zusammenhängende Kontotransaktionen, Rechnungen und Banktransaktionen gruppieren können.
       use_nick: Benutzernamen anstatt reale Namen zeigen und verwenden, jeder Benutzer muss dazu einen Benutzernamen (Spitznamen) haben.
       use_self_service: Wenn aktiviert, können Benutzer_innen selbständig dafür freigegebene Abrechungsfunktionen nutzen.
       webstats_tracking_code: Tracking Code für Webseitenanalyse (wie Piwik oder Google Analytics), leer lassen wenn keine Analyse erfolgt
@@ -660,6 +661,7 @@ de:
       use_apple_points: Apfelpunkte verwenden
       use_boxfill: Kistenauffüllphase
       use_iban: IBAN verwenden
+      use_financial_links: Finanzlinks verwenden
       use_nick: Benutzernamen verwenden
       use_self_service: Selbstbedienung verwenden
       webstats_tracking_code: Code für Websiteanalysetool

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -772,6 +772,7 @@ en:
       confirm:
         clear: Settle
         first_paragraph: 'When the order is settled, all group accounts will be updated.<br />The accounts will be charged as follows:'
+        create_financial_link: Create a common financial link for the transactions and, if existing, the attached invoice.
         or_cancel: or back to accounting
         title: Settle order
       edit_note:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -603,6 +603,7 @@ en:
       use_apple_points: When the apple point system is enabled, members are required to do some tasks to be able to keep ordering.
       use_boxfill: When enabled, near end of an order, members are only able to change their order when increases the total amount ordered. This helps to fill any remaining boxes. You still need to set a box-fill date for the orders.
       use_iban: When enabled, supplier and user provide an additonal field for storing the international bank account number.
+      use_financial_links: When enabled, options to create financial links will be shown, which can group associated financial transactions, invoices, and bank transactions.
       use_nick: Show and use nicknames instead of real names. When enabling this, please check that each user has a nickname.
       use_self_service: When enabled, members are able to use selected balancing functions on their own.
       webstats_tracking_code: Tracking code for web analytics (like Piwik or Google analytics). Leave empty for no tracking.
@@ -661,6 +662,7 @@ en:
       use_apple_points: Apple points
       use_boxfill: Box-fill phase
       use_iban: Use IBAN
+      use_financial_links: Use financial links
       use_nick: Use nicknames
       use_self_service: Use self service
       webstats_tracking_code: Tracking code


### PR DESCRIPTION
Implementation of #848 
I didn't know how to automatically check the checkbox to create a financial link on the confirm page, but I don't know if that would be desired anyway.
I guess we also would have to update [automatic assignment to invoice](https://github.com/foodcoops/foodsoft/blob/007ff70c486be5d93cb189fa4e13327270436e62/app/models/bank_transaction.rb#L46) to check if an invoice already has a financial link and if so, use it instead of creating a new one and overriding it. Since I cannot really test this without any bank connector, it doesn't make sense for me trying to implement it.
Also I don't know what the Rubocop error (classlength) means.