### PR TITLE
de.yml: Aufgaben "Verantwortliche"

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -196,7 +196,7 @@ de:
         duration: Dauer
         name: Aufgabe
         required_users: Anzahl
-        user_list: Verantwortlichen
+        user_list: Verantwortliche
         workgroup: Arbeitsgruppe
       user:
         email: E-Mail


### PR DESCRIPTION
"Verantwortlichen" should be grammatically correct "Verantwortliche". It is used as a label for a list of persons.
![aufgabe2](https://user-images.githubusercontent.com/57668028/115209935-60bbf480-a0fe-11eb-92ee-22f79ec17f4a.png)
