### PR TITLE
Issue 830

### DIFF
--- a/app/assets/javascripts/delta_input.js
+++ b/app/assets/javascripts/delta_input.js
@@ -19,7 +19,7 @@ function data_delta_update(el, direction) {
   var delta = $(el).data('delta');
   var granularity = $(el).data('granularity');
 
-  var val = $(el).val();
+  var val = $(el).val().replace(',', '.');
   var oldval = $.isNumeric(val) ? Number(val) : 0;
   var newval = oldval + delta*direction;
 
@@ -31,10 +31,11 @@ function data_delta_update(el, direction) {
   $('button[data-increment='+id+']').attr('disabled', newval>=max ? 'disabled' : null);
 
   // warn when what was entered is not a number
-  $(el).toggleClass('error', val!='' && val!='.' && (!$.isNumeric(val) || val < 0));
+  const erroneousValue = val!='' && val!='.' && (!$.isNumeric(val) || val < 0)
+  $(el).toggleClass('error', erroneousValue);
 
   // update field, unless the user is typing
-  if (!$(el).is(':focus')) {
+  if (!$(el).is(':focus') && !erroneousValue) {
     $(el).val(round_float(newval, granularity));
     $(el).trigger('changed');
   }

--- a/db/migrate/20190100000009_change_order_article_result_types.rb
+++ b/db/migrate/20190100000009_change_order_article_result_types.rb
@@ -1,0 +1,11 @@
+class ChangeOrderArticleResultTypes < ActiveRecord::Migration[4.2]
+  def self.up
+    change_column :order_articles, :units_billed, :decimal, precision: 8, scale: 3
+    change_column :order_articles, :units_received, :decimal, precision: 8, scale: 3
+  end
+
+  def self.down
+    change_column :order_articles, :units_billed, :integer
+    change_column :order_articles, :units_received, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -302,8 +302,8 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.integer "units_to_order", default: 0, null: false
     t.integer "lock_version", default: 0, null: false
     t.integer "article_price_id"
-    t.integer "units_billed"
-    t.integer "units_received"
+    t.decimal "units_billed", precision: 8, scale: 3
+    t.decimal "units_received", precision: 8, scale: 3
     t.index ["order_id", "article_id"], name: "index_order_articles_on_order_id_and_article_id", unique: true
     t.index ["order_id"], name: "index_order_articles_on_order_id"
   end


### PR DESCRIPTION
**What this fix does:**

1. Allow decimals on the `receive` page (@paroga's commit)
2. Convert any colon entered in a `delta_input` to a comma internally (To deal with values generated by `number_with_precision`)
3. Don't immediately post the ajax form, if the value is _still_ invalid. (E.g. if the user enters a non-numeric/negative/... value) The field is then just displayed with a red border signifying that it hasn't been posted. (Maybe we still should improve UX here...?)
