### PR TITLE
In edit order form: Mark yellow all articles, that have free tolerance…

### DIFF
--- a/app/assets/javascripts/ordering.js
+++ b/app/assets/javascripts/ordering.js
@@ -133,7 +133,7 @@ function update(item, quantity, tolerance) {
 
     if (missing_units <= 0 || missing_units == unit[item]) {
         missing_units = 0;
-        if (units > 0) {
+        if (quantity > 0) {
             missing_units_css = 'missing-none';
         } else {
             missing_units_css = '';

--- a/app/assets/stylesheets/list.missing.css
+++ b/app/assets/stylesheets/list.missing.css
@@ -1,3 +1,18 @@
+.list .has-free-tolerance td, .list .has-free-tolerance:hover td {
+	/* Class `has-free-tolerance` is set by backend code iff and only if
+	** no items are ordered by this group and there is free tolerance.
+	** It only comes to function, if it is not shadowed by one of the 
+	** classes `m̀issing-*` below.
+	**
+	** It is set to yellow here, because it fits well with the
+	** semantics "You get it, if you order one more item" of
+	** class `missing-few`. However, unlike for `missing-few`,
+	** "If you order one more, one more package will be completed" is
+	** not true here, so you may consider another color more appropriate here.
+	*/
+	background-color: #ffee75;
+}
+
 .list .missing-many td, .list .missing-many:hover td {
 	background-color: #ebbebe;
 }
@@ -9,3 +24,4 @@
 .list .missing-none td, .list .missing-none:hover td {
 	background-color: #E4EED6;
 }
+

--- a/app/helpers/group_orders_helper.rb
+++ b/app/helpers/group_orders_helper.rb
@@ -44,11 +44,17 @@ module GroupOrdersHelper
     { group_order_article: goa, quantity: quantity, tolerance: tolerance, result: result, sub_total: sub_total }
   end
 
-  def get_missing_units_css_class(quantity_missing)
+  def get_missing_units_css_class(ordering_data)
+    quantity_missing = ordering_data[:missing_units]
     if (quantity_missing == 1)
       return 'missing-few';
     elsif (quantity_missing == 0)
-      return ''
+      if ( ordering_data[:others_tolerance] > 0 and ordering_data[:quantity] == 0 )
+        # see comment in file list.missing.css
+        return 'has-free-tolerance'
+      else
+        return ''
+      end
     else
       return 'missing-many'
     end

--- a/app/views/group_orders/_form.html.haml
+++ b/app/views/group_orders/_form.html.haml
@@ -94,7 +94,7 @@
             %i.icon-tag
           %td{colspan: "9"}
         - order_articles.each do |order_article|
-          %tr{class: "#{cycle('even', 'odd', name: 'articles')} order-article #{get_missing_units_css_class(@ordering_data[:order_articles][order_article.id][:missing_units])}", valign: "top"}
+          %tr{class: "#{cycle('even', 'odd', name: 'articles')} order-article #{get_missing_units_css_class(@ordering_data[:order_articles][order_article.id])}", valign: "top"}
             %td.name= order_article.article.name
             - if @order.stockit?
               %td= truncate order_article.article.supplier.name, length: 15


### PR DESCRIPTION
and are not yet ordered by this group.

Additionally, make colors more consistent, when clicking order back to zero.