### PR TITLE
Removed Logging to stdout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ RUN supercronicUrl=https://github.com/aptible/supercronic/releases/download/v0.1
 ENV PORT=3000 \
     SMTP_SERVER_PORT=2525 \
     RAILS_ENV=production \
-    RAILS_LOG_TO_STDOUT=true \
     RAILS_SERVE_STATIC_FILES=true
 
 WORKDIR /usr/src/app


### PR DESCRIPTION
I think in general it's a good idea to have log files. I disk space is factor on can use logrotate to limit the size a a single log file.