### PR TITLE
Enable to configure feedback recipient address

### DIFF
--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -103,7 +103,7 @@ class Mailer < ActionMailer::Base
     @user = user
     @feedback = feedback
 
-    mail to: FoodsoftConfig[:notification][:error_recipients],
+    mail to: feedback_recipients,
          from: user,
          subject: I18n.t('mailer.feedback.subject')
   end
@@ -178,5 +178,10 @@ class Mailer < ActionMailer::Base
     address = Mail::Address.new email
     address.display_name = name
     address.format
+  end
+
+  # use the (new) feedback_recipients option, but fallback to error_recipients for backwards compatibility
+  def feedback_recipients
+    FoodsoftConfig[:notification][:feedback_recipients] || FoodsoftConfig[:notification][:error_recipients]
   end
 end

--- a/config/app_config.yml.SAMPLE
+++ b/config/app_config.yml.SAMPLE
@@ -137,6 +137,8 @@ default: &defaults
   notification:
     error_recipients:
       - admin@foodcoop.test
+    feedback_recipients:
+      - support@foodcoop.test
     sender_address: "\"Foodsoft Error\" <foodsoft@foodcoop.test>"
     email_prefix: "[Foodsoft]"
 


### PR DESCRIPTION
Enable to set a different address for mails send through a Foodsoft's feedback form. Make it possible to send error notifications to an admin group and feedback/ support requests to a support mailing list.