### PR TITLE
Update SETUP_DEVELOPMENT.md

### DIFF
--- a/doc/SETUP_DEVELOPMENT.md
+++ b/doc/SETUP_DEVELOPMENT.md
@@ -69,7 +69,18 @@ If instead you just want to run Foodsoft without changing its code, please refer
         # CentOS/Redhat
         sudo yum install v8 community-mysql-devel libxml2-devel libxslt-devel libffi-devel readline-devel file-devel
 
-3. Install Ruby dependencies:
+3. Install Ruby dependencies: 
+   Change your current directory to the foodsoft directory, e.g.:
+
+        cd foodsoft
+        
+   If you type `ls`, you should see a file `Gemfile` among others.
+   
+   Ensure that the command `/usr/bin/mkdir` is available, otherwise create a symbolic link:
+
+        sudo ln -s /bin/mkdir /usr/bin/mkdir
+   
+   Now you can start to install the Ruby dependencies: 
 
         bundle install
 


### PR DESCRIPTION
How to avoid errors arising during step 4. 

If /usr/bin/mkdir is not available, the compilation of nokogiri fails:
```
make: /usr/bin/mkdir: Kommando nicht gefunden
make: *** [Makefile:202: .sitearchdir.-.nokogiri.time] Fehler 127
make install failed, exit code 2

```
see also: 
https://stackoverflow.com/questions/64653051/make-usr-bin-mkdir-command-not-found-during-gem-install-nokogiri-in-ubuntu 