### PR TITLE
Feature/tw automatic group order invoice generation

### DIFF
--- a/app/controllers/concerns/send_group_order_invoice_pdf.rb
+++ b/app/controllers/concerns/send_group_order_invoice_pdf.rb
@@ -1,0 +1,12 @@
+module Concerns::SendGroupOrderInvoicePdf
+  extend ActiveSupport::Concern
+
+  protected
+
+  def send_group_order_invoice_pdf group_order_invoice
+    invoice_data = group_order_invoice.load_data_for_invoice
+    invoice_data[:title] = "Rechnung für " + invoice_data[:supplier] # TODO Internationalise und load_data rausschmeißen
+    pdf = GroupOrderInvoicePdf.new group_order_invoice.load_data_for_invoice
+    send_data pdf.to_pdf, filename: pdf.filename, type: 'application/pdf'
+  end
+end

--- a/app/controllers/finance/balancing_controller.rb
+++ b/app/controllers/finance/balancing_controller.rb
@@ -81,9 +81,21 @@ class Finance::BalancingController < Finance::BaseController
     @order = Order.find(params[:id])
     @type = FinancialTransactionType.find_by_id(params.permit(:type)[:type])
     @order.close!(@current_user, @type)
-    redirect_to finance_order_index_url, notice: t('finance.balancing.close.notice')
-  rescue => error
-    redirect_to new_finance_order_url(order_id: @order.id), alert: t('finance.balancing.close.alert', message: error.message)
+    note =  t('finance.balancing.close.notice')
+    if @order.closed?
+      if FoodsoftConfig[:group_order_invoices]&.[](:use) && FoodsoftConfig[:contact]&.[](:tax_number)
+        @order.group_orders.each do |go|
+          goi = GroupOrderInvoice.find_or_create_by!(group_order_id: go.id)
+          if goi.save!
+            NotifyGroupOrderInvoiceJob.perform_later(goi)
+            note =  t('finance.balancing.close.notice_mail')
+          end
+        end
+      end
+    end
+    redirect_to finance_order_index_url, notice: note
+    rescue => error
+    redirect_to new_finance_order_url(order_id: @order.id), notice: note, alert: t('finance.balancing.close.alert', message: error.message)
   end
 
   # Close the order directly, without automaticly updating ordergroups account balances

--- a/app/controllers/group_order_invoices_controller.rb
+++ b/app/controllers/group_order_invoices_controller.rb
@@ -1,0 +1,38 @@
+class GroupOrderInvoicesController < ApplicationController
+  include Concerns::SendGroupOrderInvoicePdf
+
+  def show
+    @group_order_invoice = GroupOrderInvoice.find(params[:id])
+    if FoodsoftConfig[:contact][:tax_number]
+      respond_to do |format|
+        format.pdf do
+          send_group_order_invoice_pdf @group_order_invoice if FoodsoftConfig[:contact][:tax_number]
+        end
+      end
+    else raise RecordInvalid
+      redirect_back fallback_location: root_path, notice: 'Something went wrong', :alert => I18n.t('errors.general_msg', :msg => "#{error} " + I18n.t('errors.check_tax_number'))
+    end
+  end
+
+  def destroy
+    goi = GroupOrderInvoice.find(params[:id])
+    @order = goi.group_order.order
+    goi.destroy
+    respond_to do |format|
+      format.js
+      format.json { head :no_content }
+    end
+  end
+
+  def create
+    go = GroupOrder.find(params[:group_order])
+    @order = go.order
+    goi = GroupOrderInvoice.find_or_create_by!(group_order_id: go.id)
+    respond_to do |format|
+      format.js
+    end
+    redirect_back fallback_location: root_path
+  rescue => error
+    redirect_back fallback_location: root_path, notice: 'Something went wrong', :alert => I18n.t('errors.general_msg', :msg => error)
+  end
+end

--- a/app/documents/group_order_invoice_pdf.rb
+++ b/app/documents/group_order_invoice_pdf.rb
@@ -1,0 +1,142 @@
+class GroupOrderInvoicePdf < RenderPDF
+  def filename
+    I18n.t('documents.group_order_invoice_pdf.filename', :number => @options[:invoice_number]) + '.pdf'
+  end
+
+  def title
+    I18n.t('documents.group_order_invoice_pdf.title', :supplier => @options[:supplier])
+  end
+
+  def body
+    contact = FoodsoftConfig[:contact].symbolize_keys
+    ordergroup = @options[:ordergroup]
+
+    # From paragraph
+    bounding_box [margin_box.right - 200, margin_box.top-20], width: 200 do
+      text  I18n.t('documents.group_order_invoice_pdf.invoicer')
+      move_down 7
+      text FoodsoftConfig[:name], size: fontsize(9), align: :left
+      move_down 5
+      text contact[:street], size: fontsize(9), align: :left
+      move_down 5
+      text "#{contact[:zip_code]} #{contact[:city]}", size: fontsize(9), align: :left
+      move_down 5
+      unless contact[:phone].blank?
+        text "#{Supplier.human_attribute_name :phone}: #{contact[:phone]}", size: fontsize(9), align: :left
+        move_down 5
+      end
+      unless contact[:email].blank?
+        text "#{Supplier.human_attribute_name :email}: #{contact[:email]}", size: fontsize(9), align: :left
+      end
+      move_down 5
+      text I18n.t('documents.group_order_invoice_pdf.tax_number', :number => @options[:tax_number]), size: fontsize(9), align: :left
+    end
+
+
+    # Receiving Ordergroup
+    bounding_box [margin_box.left, margin_box.top - 20], width: 200 do
+      text  I18n.t('documents.group_order_invoice_pdf.invoicee')
+      move_down 7
+      text I18n.t('documents.group_order_invoice_pdf.ordergroup.name', ordergroup: ordergroup.name.to_s ), size: fontsize(9)
+      move_down 5
+      if ordergroup.contact_address
+        text I18n.t('documents.group_order_invoice_pdf.ordergroup.contact_address', contact_address: ordergroup.contact_address.to_s ), size: fontsize(9)
+        move_down 5
+      end
+      if ordergroup.contact_phone
+        text I18n.t('documents.group_order_invoice_pdf.ordergroup.contact_phone', contact_phone: ordergroup.contact_phone.to_s ), size: fontsize(9)
+        move_down 5
+      end
+    end
+
+    #invoice Date and nnvoice number
+    bounding_box [margin_box.right - 200, margin_box.top - 150], width: 200 do
+      text I18n.t('documents.group_order_invoice_pdf.invoice_date', invoice_date: @options[:invoice_date].strftime(I18n.t('date.formats.default'))), align: :left
+      move_down 5
+      text I18n.t('documents.group_order_invoice_pdf.invoice_number', invoice_number: @options[:invoice_number]), align: :left
+    end
+
+    move_down 15
+
+    # kind of the "body" of the invoice
+    text I18n.t('documents.group_order_invoice_pdf.payment_method', payment_method: @options[:payment_method])
+    move_down 15
+    text I18n.t('documents.group_order_invoice_pdf.table_headline')
+    move_down 5
+
+    #------------- Table Data -----------------------
+    total_gross = 0
+    total_net = 0
+    # Articles
+
+    tax_hash_net = Hash.new(0) #for summing up article net prices grouped into vat percentage
+    tax_hash_gross = Hash.new(0) #same here with gross prices
+
+    group_order = GroupOrder.find(@options[:group_order].id)
+    marge = FoodsoftConfig[:price_markup]
+
+    # data table looks different when price_markup > 0
+    if marge == 0
+      data = [I18n.t('documents.group_order_invoice_pdf.no_price_markup_rows')]
+    else
+      data = [I18n.t('documents.group_order_invoice_pdf.price_markup_rows', marge: marge)]
+    end
+    goa_tax_hash = GroupOrderArticle.where(group_order_id: group_order.id).find_each.group_by {|oat| oat.order_article.price.tax}
+    goa_tax_hash.each do |tax, group_order_articles|
+      group_order_articles.each do |goa|
+        # if no unit is received, nothing is to be charged
+        next if goa.result.to_i == 0
+        order_article = goa.order_article
+        goa_total_net = goa.result * order_article.price.price
+        goa_total_gross = goa.result * order_article.price.gross_price
+        data << [order_article.article.name,
+          goa.result.to_i,
+          number_to_currency(order_article.price.price),
+          number_to_currency(goa_total_net),
+          tax.to_s + '%',
+          number_to_currency(goa.total_price)]
+          tax_hash_net[tax.to_i] += goa_total_net
+          tax_hash_gross[tax.to_i] += goa_total_gross
+          total_net += goa_total_net
+          total_gross += goa_total_gross
+      end
+    end
+
+    # Two separate tables for sum and individual data
+    # article information + data
+    table data, cell_style: { size: fontsize(8), overflow: :shrink_to_fit } do |table|
+      table.header = true
+      table.position= :center
+      table.cells.border_width = 1
+      table.cells.border_color = '666666'
+
+      table.row(0).column(1).width = 40
+      table.row(0).border_bottom_width = 2
+      table.columns(1).align = :right
+      table.columns(1..6).align = :right
+    end
+
+    sum = []
+    sum << [nil, nil, nil, nil, I18n.t('documents.group_order_invoice_pdf.sum_to_pay_net'), number_to_currency(total_net)]
+    tax_hash_net.keys.each do |tax|
+      sum << [nil,nil,nil,nil, I18n.t('documents.group_order_invoice_pdf.tax_included', tax: tax), number_to_currency(tax_hash_gross[tax] - tax_hash_net[tax])]
+    end
+    unless marge == 0
+      sum << [nil, nil, nil, nil, I18n.t('documents.group_order_invoice_pdf.markup_included', marge: marge), number_to_currency(total_gross * marge/100.0)]
+    end
+    end_sum = total_gross * (1 + marge/100.0)
+    sum << [nil, nil, nil, nil, I18n.t('documents.group_order_invoice_pdf.sum_to_pay_gross'), number_to_currency(end_sum)]
+    # table for sum
+      table sum, position: :right, cell_style: { size: fontsize(8), overflow: :shrink_to_fit } do |table|
+      sum.length.times do |count|
+        table.row(count).columns(0..5).borders = []
+      end
+      table.row(sum.length-1).columns(0..4).borders = []
+      table.row(sum.length-1).border_bottom_width = 2
+      table.row(sum.length-1).columns(5).borders = [:bottom]
+
+    end
+
+    move_down 15
+  end
+end

--- a/app/jobs/notify_group_order_invoice_job.rb
+++ b/app/jobs/notify_group_order_invoice_job.rb
@@ -1,0 +1,10 @@
+class NotifyGroupOrderInvoiceJob < ApplicationJob
+  def perform(group_order_invoice)
+    ordergroup = group_order_invoice.group_order.ordergroup
+    ordergroup.users.each do |user|
+      Mailer.deliver_now_with_user_locale user do
+        Mailer.group_order_invoice(group_order_invoice, user)
+      end
+    end
+  end
+end

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -51,6 +51,19 @@ class Mailer < ActionMailer::Base
          subject: I18n.t('mailer.welcome.subject')
   end
 
+  # Sends automatically generated invoicesfor group orders to ordergroup members
+  def group_order_invoice(group_order_invoice, user)
+    @user = user
+    @group_order_invoice = group_order_invoice
+    @group_order = group_order_invoice.group_order
+    @supplier = @group_order.order.supplier.name
+    @group = @group_order.ordergroup
+    add_group_order_invoice_attachments(group_order_invoice)
+    mail to: user,
+         subject: I18n.t('mailer.group_order_invoice.subject', group: @group.name, supplier: @supplier)
+  end
+
+
   # Sends order result for specific Ordergroup
   def order_result(user, group_order)
     @order        = group_order.order
@@ -166,6 +179,11 @@ class Mailer < ActionMailer::Base
   def add_order_result_attachments(order, options = {})
     attachments['order.pdf'] = OrderFax.new(order, options).to_pdf
     attachments['order.csv'] = OrderCsv.new(order, options).to_csv
+  end
+
+  def add_group_order_invoice_attachments(group_order_invoice)
+    attachment_name = group_order_invoice.name + '.pdf'
+    attachments[attachment_name] = GroupOrderInvoicePdf.new(group_order_invoice.load_data_for_invoice).to_pdf
   end
 
   # separate method to allow plugins to mess with the text

--- a/app/models/group_order.rb
+++ b/app/models/group_order.rb
@@ -9,6 +9,7 @@ class GroupOrder < ApplicationRecord
   has_many :group_order_articles, :dependent => :destroy
   has_many :order_articles, :through => :group_order_articles
   has_one :financial_transaction
+  has_one :group_order_invoice
   belongs_to :updated_by, optional: true, class_name: 'User', foreign_key: 'updated_by_user_id'
 
   validates_presence_of :order_id

--- a/app/models/group_order_invoice.rb
+++ b/app/models/group_order_invoice.rb
@@ -1,0 +1,60 @@
+class GroupOrderInvoice < ApplicationRecord
+
+  belongs_to :group_order
+  validates_presence_of :group_order
+  validates_uniqueness_of :invoice_number
+  validate :tax_number_set
+  after_initialize :init, unless: :persisted?
+
+  def generate_invoice_number(count)
+    trailing_number = count.to_s.rjust(4, '0')
+    unless  GroupOrderInvoice.find_by(invoice_number: Time.now.strftime("%Y%m%d") + trailing_number)
+      Time.now.strftime("%Y%m%d") + trailing_number
+    else
+      generate_invoice_number(count.to_i + 1)
+    end
+  end
+
+  def tax_number_set
+    if FoodsoftConfig[:contact][:tax_number].blank?
+      errors.add(:group_order_invoice, "Keine Steuernummer in FoodsoftConfig :contact gesetzt")
+    end
+  end
+
+  def init
+    self.invoice_number = generate_invoice_number(1) unless self.invoice_number
+    self.invoice_date = Time.now unless self.invoice_date
+    self.payment_method = FoodsoftConfig[:group_order_invoices]&.[](:payment_method) || I18n.t('activerecord.attributes.group_order_invoice.payment_method') unless self.payment_method
+  end
+
+  def name
+    I18n.t('activerecord.attributes.group_order_invoice.name') + "_#{invoice_number}"
+  end
+
+  def load_data_for_invoice
+    invoice_data = {}
+    order = group_order.order
+    invoice_data[:supplier] = order.supplier.name
+    invoice_data[:ordergroup] = group_order.ordergroup
+    invoice_data[:group_order] = group_order
+    invoice_data[:invoice_number] = invoice_number
+    invoice_data[:invoice_date] = invoice_date
+    invoice_data[:tax_number] = FoodsoftConfig[:contact][:tax_number]
+    invoice_data[:payment_method] = payment_method
+    invoice_data[:order_articles] = {}
+    group_order.order_articles.each do |order_article|
+      # Get the result of last time ordering, if possible
+      goa = group_order.group_order_articles.detect { |goa| goa.order_article_id == order_article.id }
+
+      # Build hash with relevant data
+      invoice_data[:order_articles][order_article.id] = {
+        :price => order_article.article.fc_price,
+        :quantity => (goa ? goa.quantity : 0),
+        :total_price => (goa ? goa.total_price : 0),
+        :tax => order_article.article.tax
+      }
+    end
+    invoice_data
+
+  end
+end

--- a/app/views/admin/configs/_tab_foodcoop.html.haml
+++ b/app/views/admin/configs/_tab_foodcoop.html.haml
@@ -7,4 +7,5 @@
   = config_input c, :country, as: :string, input_html: {class: 'input-xlarge'}
   = config_input c, :email, required: true, input_html: {class: 'input-xlarge'}
   = config_input c, :phone, input_html: {class: 'input-medium'}
+  = config_input c, :tax_number, input_html: {class: 'input-medium'}
 = config_input form, :homepage, required: true, as: :url, input_html: {class: 'input-xlarge'}

--- a/app/views/admin/configs/_tab_payment.html.haml
+++ b/app/views/admin/configs/_tab_payment.html.haml
@@ -13,6 +13,9 @@
 = config_input form, :charge_members_manually, as: :boolean
 = config_input form, :use_iban, as: :boolean
 = config_input form, :use_self_service, as: :boolean
+= form.fields_for :group_order_invoices do |field|
+  = config_input field, :use, as: :boolean
+  = config_input field, :payment_method, as: :string, input_html: {class: 'input-mini'}
 
 %h4= t '.schedule_title'
 = form.simple_fields_for :order_schedule do |fields|

--- a/app/views/finance/balancing/_orders.html.haml
+++ b/app/views/finance/balancing/_orders.html.haml
@@ -9,6 +9,8 @@
         %th= t('.end')
         %th= t('.state')
         %th= heading_helper Order, :updated_by
+        %th= heading_helper GroupOrderInvoice,  :name
+        %th
         %th
     %tbody
       - @orders.each do |order|
@@ -17,6 +19,14 @@
           %td=h format_time(order.ends) unless order.ends.nil?
           %td= order.closed? ? t('.cleared', amount: number_to_currency(order.foodcoop_result)) : t('.ended')
           %td= show_user(order.updated_by)
+          %td{id: "generate-invoice#{order.id}"}
+            - if order.closed?
+              -if FoodsoftConfig[:contact][:tax_number]
+                = render :partial => 'group_order_invoices/links', locals:{order: order}
+              -else
+                = I18n.t('activerecord.attributes.group_order_invoice.tax_number_not_set')
+            - else
+              = t('orders.index.not_closed')
           %td
             - unless order.closed?
               - if current_user.role_orders?

--- a/app/views/group_order_invoices/_links.html.haml
+++ b/app/views/group_order_invoices/_links.html.haml
@@ -1,0 +1,11 @@
+.row
+  - order.group_orders.includes([:group_order_invoice, :ordergroup]).each do |go|
+    .row
+      = label_tag go.ordergroup.name
+      - if go.group_order_invoice
+        = link_to I18n.t('activerecord.attributes.group_order_invoice.links.download'), group_order_invoice_path(go.group_order_invoice, :format => 'pdf'), class: 'btn btn-small'
+        = link_to  I18n.t('activerecord.attributes.group_order_invoice.links.delete'), go.group_order_invoice, method: :delete, class: 'btn btn-danger btn-small', remote: true
+      - else
+        = button_to  I18n.t('activerecord.attributes.group_order_invoice.links.generate'), group_order_invoices_path(:method => :post, group_order: go) ,class: 'btn btn-small', params: {id: order.id}, remote: true
+    %br
+

--- a/app/views/group_order_invoices/create.js.erb
+++ b/app/views/group_order_invoices/create.js.erb
@@ -1,0 +1,1 @@
+$("#generate-invoice<%= params[:id] %>").html("<%= escape_javascript(render partial: 'links', locals: {order: @order}) %>");

--- a/app/views/group_order_invoices/destroy.js.erb
+++ b/app/views/group_order_invoices/destroy.js.erb
@@ -1,0 +1,1 @@
+$("#generate-invoice<%= @order.id %>").html("<%= escape_javascript(render partial: 'links', locals: {order: @order}) %>");

--- a/app/views/group_order_invoices/show.pdf.prawn
+++ b/app/views/group_order_invoices/show.pdf.prawn
@@ -1,0 +1,1 @@
+pdf.text "Hello World"

--- a/app/views/mailer/group_order_invoice.text.haml
+++ b/app/views/mailer/group_order_invoice.text.haml
@@ -1,0 +1,1 @@
+= raw t '.text', group: @group.name, supplier: @supplier , foodcoop: FoodsoftConfig[:name]

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -84,6 +84,14 @@ de:
         tolerance: Toleranz
         total_price: Summe
         unit_price: Preis/Einheit
+      group_order_invoice:
+        name: Bestellgruppenrechnung
+        links:
+          delete: Rechnung löschen
+          generate: Rechnung erzeugen
+          download: Rechnung herunterladen
+        payment_method: Guthaben
+        tax_number_not_set: Steuernummer in den Einstellungen nicht gesetzt
       invoice:
         amount: Betrag
         attachment: Anhang
@@ -600,6 +608,8 @@ de:
       tolerance_is_costly: Eine möglichst große Menge im Rahmen der Tolerenz bestellen. Wenn dies nicht aktiviert ist, wird im Rahmen der Toleranz nur so viel bestellt, dass damit komplette Einheiten (Boxen) bestellt werden können. Die Option wirkt sich auch auf die Toleranz des Gesamtpreises einer offenen Mitgliederbestellung aus.
       distribution_strategy: Wie bei der Verteilung von Artikeln nach dem Empfangen einer Bestellung vorgegangen werden soll.
       use_apple_points: Wenn das Apfel Punktesystem aktiviert ist, ist es erforderlich, dass Mitglieder Aufgaben erledigen um bestellen zu können.
+      use_automatic_invoices: Bei der Abrechnung einer Bestellung werden Rechnungen für die einzelnen Bestellgruppenautomatisch per Mail versandt
+      payment_method: Zahlungsart für Bestellgruppenrechnungen
       use_boxfill: Wenn aktiviert, können Benutzer nahe am Ende der Bestellung diese nur mehr so verändern, dass sich die Gesamtsumme erhöht. Dies hilft beim auffüllen der verbleibenden Kisten. Es muss trotzdem noch das Kistenauffülldatum bei der Bestellung gesetzt werden.
       use_iban: Zusätzlich Feld für die internationale Kontonummer bei Benutzern und Lieferanten anzeigen
       use_nick: Benutzernamen anstatt reale Namen zeigen und verwenden, jeder Benutzer muss dazu einen Benutzernamen (Spitznamen) haben.
@@ -615,6 +625,7 @@ de:
         phone: Telefon
         street: Straße
         zip_code: Postleitzahl
+        tax_number: Steuernummer
       currency_space: Leerzeichen hinzufügen
       currency_unit: Währung
       custom_css: Angepasstes CSS
@@ -658,6 +669,9 @@ de:
         first_order_first_serve: Zuerst an die verteilen, die zuerst bestellt haben
         no_automatic_distribution: Keine automatische Verteilung
       use_apple_points: Apfelpunkte verwenden
+      group_order_invoices:
+        use: Bestellgruppen Rechnungen automatisch bei Abrechnung einer Bestellung versenden
+        payment_method: Zahlungsart für Bestellgruppenrechnungen
       use_boxfill: Kistenauffüllphase
       use_iban: IBAN verwenden
       use_nick: Benutzernamen verwenden
@@ -714,6 +728,39 @@ de:
     update:
       notice: Lieferung wurde aktualisiert.
   documents:
+    group_order_invoice_pdf:
+      filename: Rechnung %{number}
+      invoicer: Rechnungsteller*in
+      invoicee: Rechnungsempfänger*in
+      invoice_date: 'Rechnungsdatum: %{invoice_date}'
+      invoice_number: 'Rechnungsnummer: %{invoice_number}'
+      markup_included: zzgl. Foodcoop Marge auf brutto Preis %{marge}%
+      ordergroup:
+        contact_phone: 'Telefonnummer: %{contact_phone}'
+        contact_address: 'Adresse :  %{contact_address}'
+        name: Bestellgruppe %{ordergroup}
+      payment_method: 'Zahlungsart: %{payment_method}'
+      sum_to_pay_net: Zu zahlen gesamt (netto)
+      sum_to_pay_gross: Zu zahlen gesamt (brutto)
+      table_headline: 'Für die Bestellung fallen folgende Posten an:'
+      tax_excluded: exkl. MwSt.
+      tax_included: zzgl. Gesamtsumme MwSt. %{tax}%
+      tax_number: 'Steuernummer: %{number}'
+      title: Rechnung für die Bestellung bei %{supplier}
+      no_price_markup_rows:
+        - Name
+        - Anzahl
+        - Einzelpreis (netto)
+        - Artikel Gesamtpreis (netto)
+        - MwSt.
+        - Artikel Gesamtpreis (brutto)
+      price_markup_rows:
+        - Name
+        - Anzahl
+        - Einzelpreis (netto)
+        - Artikel Gesamtpreis (netto)
+        - MwSt.
+        - Artikel Gesamtpreis (brutto) inkl. Foodcoopmarge %{marge}%
     order_by_articles:
       filename: Bestellung %{name}-%{date} - Artikelsortierung
       title: 'Artikelsortierung der Bestellung: %{name}, beendet am %{date}'
@@ -737,6 +784,7 @@ de:
       heading: Artikelübersicht (%{count})
       title: 'Sortiermatrix der Bestellung: %{name}, beendet am %{date}'
   errors:
+    check_tax_number: Überprüft, ob die Steuernummer der Foodcoop richtig gesetzt ist
     general: Ein Problem ist aufgetreten.
     general_again: Ein Fehler ist aufgetreten. Bitte erneut versuchen.
     general_msg: 'Ein Fehler ist aufgetreten: %{msg}'
@@ -760,6 +808,8 @@ de:
       close:
         alert: 'Ein Fehler ist beim Abrechnen aufgetreten: %{message}'
         notice: Bestellung wurde erfolgreich abgerechnet, die Kontostände aktualisiert.
+        notice_mail: Bestellung wurde erfolgreich abgerechnet, die Kontostände aktualisiert. Außerdem wurden automatisch Rechnungen an die Bestellgruppenmitglieder geschickt.
+        settings_not_set: Keine Emails mit Rechnungen versendet. Bitte überprüfe die Einstellungen.
       close_all_direct_with_invoice:
         notice: 'Es wurden %{count} Bestellung abgerechnet.'
       close_direct:
@@ -824,6 +874,7 @@ de:
         ended: beendet
         name: Lieferantin
         no_closed_orders: Derzeit gibt es keine beendeten Bestellungen.
+
         state: Status
       summary:
         changed: Daten wurden verändert!
@@ -1235,6 +1286,15 @@ de:
     feedback:
       header: "%{user} schrieb am %{date}:"
       subject: Feedback zur Foodsoft
+    group_order_invoice:
+      subject: Bestellgruppenrechnung für %{group} bei %{supplier}
+      text: |
+        Liebe Bestellgruppe %{group},
+
+        Die Sammelbestellung bei %{supplier} wurde soeben abgerechnet und für die jeweiligen Bestellgruppen Rechnungen angelegt.
+        Im Anhang befindet sich daher eure Rechnung.
+
+        Viele Grüße von %{foodcoop}
     invite:
       subject: Einladung in die Foodcoop
       text: |
@@ -1467,6 +1527,7 @@ de:
       orders_finished: Beendet
       orders_open: Laufend
       orders_settled: Abgerechnet
+      not_closed: Bestellung noch nicht abgerechnet
       title: Bestellungen verwalten
     model:
       close_direct_message: Die Bestellung wurde abgechlossen, ohne die Mitgliederkonten zu belasten.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -84,6 +84,14 @@ en:
         tolerance: Tolerance
         total_price: Sum
         unit_price: Price/Unit
+      group_order_invoice:
+        name: Group order invoice
+        links:
+          delete: delete invoice
+          generate: generate invoice
+          download: download invoice
+        payment_method: Credit
+        tax_number_not_set: Tax number not set in configs
       invoice:
         amount: Amount
         attachment: Attachment
@@ -601,6 +609,8 @@ en:
       tolerance_is_costly: Order as much of the member tolerance as possible (compared to only as much needed to fill the last box). Enabling this also includes the tolerance in the total price of the open member order.
       distribution_strategy: How articles should be distributed after an order has been received.
       use_apple_points: When the apple point system is enabled, members are required to do some tasks to be able to keep ordering.
+      use_automatic_invoices: When an order is settled, invoices for the individual order groups are automatically sent by mail
+      payment_method: Payment Method for group order invoices
       use_boxfill: When enabled, near end of an order, members are only able to change their order when increases the total amount ordered. This helps to fill any remaining boxes. You still need to set a box-fill date for the orders.
       use_iban: When enabled, supplier and user provide an additonal field for storing the international bank account number.
       use_nick: Show and use nicknames instead of real names. When enabling this, please check that each user has a nickname.
@@ -616,6 +626,7 @@ en:
         phone: Phone
         street: Street
         zip_code: Postcode
+        tax_number: Tax number
       currency_space: add space
       currency_unit: Currency
       custom_css: Custom CSS
@@ -659,6 +670,9 @@ en:
         first_order_first_serve: First distribute to those who ordered first
         no_automatic_distribution: No automatic distribution
       use_apple_points: Apple points
+      group_order_invoices:
+        use: Automatically send group order invoices when an order is settled
+        payment_method: Payment method for group order invoices
       use_boxfill: Box-fill phase
       use_iban: Use IBAN
       use_nick: Use nicknames
@@ -716,6 +730,39 @@ en:
     update:
       notice: Delivery was updated.
   documents:
+    group_order_invoice_pdf:
+      ordergroup:
+        contact_phone: 'Phone: %{contact_phone}'
+        contact_address: 'Adress :  %{contact_address}'
+        name: 'Ordergroup: %{ordergroup}'
+      filename: Invoice %{number}
+      invoicee: Invoicee
+      invoicer: Invoicer
+      invoice_date: 'Invoice date: %{invoice_date}'
+      invoice_number: 'Invoice number: %{invoice_number}'
+      markup_included: incl Foodcoop Marge on gross price %{marge}%
+      payment_method: 'Payment_method: %{payment_method}'
+      sum_to_pay_net: Total sum (net)
+      sum_to_pay_gross: Total sum (gross)
+      table_headline: 'The following items will be charged for the order:'
+      tax_excluded: excl. MwSt.
+      tax_included: incl. VAT %{tax}%
+      tax_number: 'Tax number: %{number}'
+      title: Invoice for order at %{supplier}
+      no_price_markup_rows:
+        - Name
+        - Amount
+        - Unit price (net)
+        - Total price (net)
+        - VAT
+        - Total price (gross)
+      price_markup_rows:
+        - Name
+        - Amount
+        - Unit price (net)
+        - Total price (net)
+        - VAT
+        - Total price (gross) incl. foodcoop margin
     order_by_articles:
       filename: Order %{name}-%{date} - by articles
       title: 'Order sorted by articles: %{name}, closed at %{date}'
@@ -739,6 +786,7 @@ en:
       heading: Article overview (%{count})
       title: 'Order sorting matrix: %{name}, closed at %{date}'
   errors:
+    check_tax_number: Please check whether the foodcoop's tax number is set correctly.
     general: A problem has occured.
     general_again: A problem has occured. Please try again.
     general_msg: 'A problem has occured: %{msg}'
@@ -762,6 +810,7 @@ en:
       close:
         alert: 'An error occured while accounting: %{message}'
         notice: Order was settled succesfully, the balance of the account was updated.
+        settings_not_set: No emails with invoices sent. Please check the settings.
       close_all_direct_with_invoice:
         notice: '%{count} orders have been settled.'
       close_direct:
@@ -1239,6 +1288,15 @@ en:
     feedback:
       header: "%{user} wrote at %{date}:"
       subject: Feedback for Foodsoft
+    group_order_invoice:
+      subject: Order group invoice for %{group} at %{supplier}
+      text: |
+        Dear order group %{group},
+
+        The collective order at %{supplier} has just been settled and invoices have been created for the respective order groups.
+        Attached you will find your invoice.
+
+        Best regards from %{foodcoop}
     from_via_foodsoft: "%{name} via Foodsoft"
     invite:
       subject: Invitation to the Foodcoop
@@ -1478,6 +1536,7 @@ en:
       orders_finished: Closed
       orders_open: Open
       orders_settled: Settled
+      not_closed: Order not yet settled
       title: Manage orders
     model:
       close_direct_message: Order settled without charging member accounts.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -139,7 +139,7 @@ Rails.application.routes.draw do
         end
       end
     end
-
+    resources :group_order_invoices
     resources :article_categories
 
     ########### Finance
@@ -171,6 +171,7 @@ Rails.application.routes.draw do
         get :form_on_supplier_id_change, on: :collection
         get :unpaid, on: :collection
       end
+
 
       resources :links, controller: 'financial_links', only: [:create, :show] do
         collection do

--- a/db/migrate/20211208142719_create_group_order_invoices.rb
+++ b/db/migrate/20211208142719_create_group_order_invoices.rb
@@ -1,0 +1,13 @@
+class CreateGroupOrderInvoices < ActiveRecord::Migration[5.2]
+  def change
+    create_table :group_order_invoices do |t|
+      t.integer :group_order_id
+      t.bigint :invoice_number, unique: true, limit: 8
+      t.date :invoice_date
+      t.string :payment_method
+
+      t.timestamps
+    end
+    add_index :group_order_invoices, :group_order_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,15 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_05_090257) do
+ActiveRecord::Schema.define(version: 2021_12_08_142719) do
 
-  create_table "article_categories", id: :integer, force: :cascade do |t|
+  create_table "article_categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name", default: "", null: false
     t.string "description"
     t.index ["name"], name: "index_article_categories_on_name", unique: true
   end
 
-  create_table "article_prices", id: :integer, force: :cascade do |t|
+  create_table "article_prices", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "article_id", null: false
     t.decimal "price", precision: 8, scale: 2, default: "0.0", null: false
     t.decimal "tax", precision: 8, scale: 2, default: "0.0", null: false
@@ -28,7 +28,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["article_id"], name: "index_article_prices_on_article_id"
   end
 
-  create_table "articles", id: :integer, force: :cascade do |t|
+  create_table "articles", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name", default: "", null: false
     t.integer "supplier_id", default: 0, null: false
     t.integer "article_category_id", default: 0, null: false
@@ -54,14 +54,14 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["type"], name: "index_articles_on_type"
   end
 
-  create_table "assignments", id: :integer, force: :cascade do |t|
+  create_table "assignments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "user_id", default: 0, null: false
     t.integer "task_id", default: 0, null: false
     t.boolean "accepted", default: false
     t.index ["user_id", "task_id"], name: "index_assignments_on_user_id_and_task_id", unique: true
   end
 
-  create_table "bank_accounts", id: :integer, force: :cascade do |t|
+  create_table "bank_accounts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name", null: false
     t.string "iban"
     t.string "description"
@@ -70,7 +70,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.string "import_continuation_point"
   end
 
-  create_table "bank_transactions", id: :integer, force: :cascade do |t|
+  create_table "bank_transactions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "bank_account_id", null: false
     t.string "external_id"
     t.date "date"
@@ -84,7 +84,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["financial_link_id"], name: "index_bank_transactions_on_financial_link_id"
   end
 
-  create_table "documents", id: :integer, force: :cascade do |t|
+  create_table "documents", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name"
     t.string "mime"
     t.binary "data", limit: 4294967295
@@ -95,16 +95,16 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["parent_id"], name: "index_documents_on_parent_id"
   end
 
-  create_table "financial_links", id: :integer, force: :cascade do |t|
+  create_table "financial_links", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.text "note"
   end
 
-  create_table "financial_transaction_classes", id: :integer, force: :cascade do |t|
+  create_table "financial_transaction_classes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name", null: false
     t.boolean "ignore_for_account_balance", default: false, null: false
   end
 
-  create_table "financial_transaction_types", id: :integer, force: :cascade do |t|
+  create_table "financial_transaction_types", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name", null: false
     t.integer "financial_transaction_class_id", null: false
     t.string "name_short"
@@ -112,7 +112,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["name_short"], name: "index_financial_transaction_types_on_name_short"
   end
 
-  create_table "financial_transactions", id: :integer, force: :cascade do |t|
+  create_table "financial_transactions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "ordergroup_id"
     t.decimal "amount", precision: 8, scale: 2, default: "0.0", null: false
     t.text "note", null: false
@@ -126,7 +126,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["reverts_id"], name: "index_financial_transactions_on_reverts_id", unique: true
   end
 
-  create_table "group_order_article_quantities", id: :integer, force: :cascade do |t|
+  create_table "group_order_article_quantities", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "group_order_article_id", default: 0, null: false
     t.integer "quantity", default: 0
     t.integer "tolerance", default: 0
@@ -134,7 +134,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["group_order_article_id"], name: "index_group_order_article_quantities_on_group_order_article_id"
   end
 
-  create_table "group_order_articles", id: :integer, force: :cascade do |t|
+  create_table "group_order_articles", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "group_order_id", default: 0, null: false
     t.integer "order_article_id", default: 0, null: false
     t.integer "quantity", default: 0, null: false
@@ -147,7 +147,17 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["order_article_id"], name: "index_group_order_articles_on_order_article_id"
   end
 
-  create_table "group_orders", id: :integer, force: :cascade do |t|
+  create_table "group_order_invoices", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.integer "group_order_id"
+    t.bigint "invoice_number"
+    t.date "invoice_date"
+    t.string "payment_method"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["group_order_id"], name: "index_group_order_invoices_on_group_order_id", unique: true
+  end
+
+  create_table "group_orders", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "ordergroup_id"
     t.integer "order_id", default: 0, null: false
     t.decimal "price", precision: 8, scale: 2, default: "0.0", null: false
@@ -160,7 +170,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["ordergroup_id"], name: "index_group_orders_on_ordergroup_id"
   end
 
-  create_table "groups", id: :integer, force: :cascade do |t|
+  create_table "groups", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "type", default: "", null: false
     t.string "name", default: "", null: false
     t.string "description"
@@ -185,7 +195,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["name"], name: "index_groups_on_name", unique: true
   end
 
-  create_table "invites", id: :integer, force: :cascade do |t|
+  create_table "invites", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "token", default: "", null: false
     t.datetime "expires_at", null: false
     t.integer "group_id", default: 0, null: false
@@ -194,7 +204,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["token"], name: "index_invites_on_token"
   end
 
-  create_table "invoices", id: :integer, force: :cascade do |t|
+  create_table "invoices", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "supplier_id"
     t.string "number"
     t.date "date"
@@ -212,7 +222,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["supplier_id"], name: "index_invoices_on_supplier_id"
   end
 
-  create_table "links", id: :integer, force: :cascade do |t|
+  create_table "links", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name", null: false
     t.string "url", null: false
     t.integer "workgroup_id"
@@ -220,7 +230,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.string "authorization"
   end
 
-  create_table "mail_delivery_status", id: :integer, force: :cascade do |t|
+  create_table "mail_delivery_status", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.datetime "created_at"
     t.string "email", null: false
     t.string "message", null: false
@@ -229,13 +239,13 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["email"], name: "index_mail_delivery_status_on_email"
   end
 
-  create_table "memberships", id: :integer, force: :cascade do |t|
+  create_table "memberships", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "group_id", default: 0, null: false
     t.integer "user_id", default: 0, null: false
     t.index ["user_id", "group_id"], name: "index_memberships_on_user_id_and_group_id", unique: true
   end
 
-  create_table "message_recipients", id: :integer, force: :cascade do |t|
+  create_table "message_recipients", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "message_id", null: false
     t.integer "user_id", null: false
     t.integer "email_state", default: 0, null: false
@@ -244,7 +254,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["user_id", "read_at"], name: "index_message_recipients_on_user_id_and_read_at"
   end
 
-  create_table "messages", id: :integer, force: :cascade do |t|
+  create_table "messages", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "sender_id"
     t.string "subject", null: false
     t.text "body"
@@ -256,7 +266,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.binary "received_email", limit: 16777215
   end
 
-  create_table "oauth_access_grants", id: :integer, force: :cascade do |t|
+  create_table "oauth_access_grants", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "resource_owner_id", null: false
     t.integer "application_id", null: false
     t.string "token", null: false
@@ -268,7 +278,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["token"], name: "index_oauth_access_grants_on_token", unique: true
   end
 
-  create_table "oauth_access_tokens", id: :integer, force: :cascade do |t|
+  create_table "oauth_access_tokens", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "resource_owner_id"
     t.integer "application_id"
     t.string "token", null: false
@@ -282,7 +292,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["token"], name: "index_oauth_access_tokens_on_token", unique: true
   end
 
-  create_table "oauth_applications", id: :integer, force: :cascade do |t|
+  create_table "oauth_applications", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name", null: false
     t.string "uid", null: false
     t.string "secret", null: false
@@ -294,7 +304,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
   end
 
-  create_table "order_articles", id: :integer, force: :cascade do |t|
+  create_table "order_articles", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "order_id", default: 0, null: false
     t.integer "article_id", default: 0, null: false
     t.integer "quantity", default: 0, null: false
@@ -308,7 +318,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["order_id"], name: "index_order_articles_on_order_id"
   end
 
-  create_table "order_comments", id: :integer, force: :cascade do |t|
+  create_table "order_comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "order_id"
     t.integer "user_id"
     t.text "text"
@@ -316,7 +326,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["order_id"], name: "index_order_comments_on_order_id"
   end
 
-  create_table "orders", id: :integer, force: :cascade do |t|
+  create_table "orders", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "supplier_id"
     t.text "note"
     t.datetime "starts"
@@ -335,7 +345,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["state"], name: "index_orders_on_state"
   end
 
-  create_table "page_versions", id: :integer, force: :cascade do |t|
+  create_table "page_versions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "page_id"
     t.integer "lock_version"
     t.text "body"
@@ -346,7 +356,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["page_id"], name: "index_page_versions_on_page_id"
   end
 
-  create_table "pages", id: :integer, force: :cascade do |t|
+  create_table "pages", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "title"
     t.text "body"
     t.string "permalink"
@@ -360,20 +370,20 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["title"], name: "index_pages_on_title"
   end
 
-  create_table "periodic_task_groups", id: :integer, force: :cascade do |t|
+  create_table "periodic_task_groups", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.date "next_task_date"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "poll_choices", id: :integer, force: :cascade do |t|
+  create_table "poll_choices", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "poll_vote_id", null: false
     t.integer "choice", null: false
     t.integer "value", null: false
     t.index ["poll_vote_id", "choice"], name: "index_poll_choices_on_poll_vote_id_and_choice", unique: true
   end
 
-  create_table "poll_votes", id: :integer, force: :cascade do |t|
+  create_table "poll_votes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "poll_id", null: false
     t.integer "user_id", null: false
     t.integer "ordergroup_id"
@@ -383,7 +393,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["poll_id", "user_id", "ordergroup_id"], name: "index_poll_votes_on_poll_id_and_user_id_and_ordergroup_id", unique: true
   end
 
-  create_table "polls", id: :integer, force: :cascade do |t|
+  create_table "polls", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "created_by_user_id", null: false
     t.string "name", null: false
     t.text "description"
@@ -403,7 +413,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["final_choice"], name: "index_polls_on_final_choice"
   end
 
-  create_table "printer_job_updates", id: :integer, force: :cascade do |t|
+  create_table "printer_job_updates", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "printer_job_id", null: false
     t.datetime "created_at", null: false
     t.string "state", null: false
@@ -411,7 +421,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["printer_job_id", "created_at"], name: "index_printer_job_updates_on_printer_job_id_and_created_at"
   end
 
-  create_table "printer_jobs", id: :integer, force: :cascade do |t|
+  create_table "printer_jobs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "order_id"
     t.string "document", null: false
     t.integer "created_by_user_id", null: false
@@ -420,7 +430,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["finished_at"], name: "index_printer_jobs_on_finished_at"
   end
 
-  create_table "settings", id: :integer, force: :cascade do |t|
+  create_table "settings", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "var", null: false
     t.text "value"
     t.integer "thing_id"
@@ -430,7 +440,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["thing_type", "thing_id", "var"], name: "index_settings_on_thing_type_and_thing_id_and_var", unique: true
   end
 
-  create_table "stock_changes", id: :integer, force: :cascade do |t|
+  create_table "stock_changes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "stock_event_id"
     t.integer "order_id"
     t.integer "stock_article_id"
@@ -440,7 +450,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["stock_event_id"], name: "index_stock_changes_on_stock_event_id"
   end
 
-  create_table "stock_events", id: :integer, force: :cascade do |t|
+  create_table "stock_events", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "supplier_id"
     t.date "date"
     t.datetime "created_at"
@@ -450,13 +460,13 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["supplier_id"], name: "index_stock_events_on_supplier_id"
   end
 
-  create_table "supplier_categories", id: :integer, force: :cascade do |t|
+  create_table "supplier_categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name", null: false
     t.string "description"
     t.integer "financial_transaction_class_id"
   end
 
-  create_table "suppliers", id: :integer, force: :cascade do |t|
+  create_table "suppliers", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name", default: "", null: false
     t.string "address", default: "", null: false
     t.string "phone", default: "", null: false
@@ -478,7 +488,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["name"], name: "index_suppliers_on_name", unique: true
   end
 
-  create_table "tasks", id: :integer, force: :cascade do |t|
+  create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name", default: "", null: false
     t.text "description"
     t.date "due_date"
@@ -495,7 +505,7 @@ ActiveRecord::Schema.define(version: 2021_02_05_090257) do
     t.index ["workgroup_id"], name: "index_tasks_on_workgroup_id"
   end
 
-  create_table "users", id: :integer, force: :cascade do |t|
+  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "nick"
     t.string "password_hash", default: "", null: false
     t.string "password_salt", default: "", null: false

--- a/spec/factories/group_order_invoice.rb
+++ b/spec/factories/group_order_invoice.rb
@@ -1,0 +1,7 @@
+require 'factory_bot'
+
+FactoryBot.define do
+  factory :group_order_invoice do
+    group_order{ create :group_order}
+  end
+end

--- a/spec/integration/group_order_invoices_spec.rb
+++ b/spec/integration/group_order_invoices_spec.rb
@@ -1,0 +1,61 @@
+require_relative '../spec_helper'
+
+feature GroupOrderInvoice, js: true do
+  let(:admin) { create :user, groups: [create(:workgroup, role_finance: true)] }
+  let(:article) { create :article, unit_quantity: 1 }
+  let(:order) { create :order, supplier: article.supplier, article_ids: [article.id], ends: Time.now  } # need to ref article
+  let(:go) { create :group_order, order: order }
+  let(:oa) { order.order_articles.find_by_article_id(article.id) }
+  let(:ftt) { create :financial_transaction_type }
+  let(:goa) { create :group_order_article, group_order: go, order_article: oa }
+
+
+
+  describe 'trigger process' do
+
+    include ActiveJob::TestHelper
+
+    before { login admin }
+    after { clear_enqueued_jobs }
+
+    it 'does not enqueue MailerJob when order is settled if tax_number or options not set' do
+      goa.update_quantities 2, 0
+      oa.update_results!
+      visit confirm_finance_order_path(id: order.id)
+      click_link_or_button I18n.t('finance.balancing.confirm.clear')
+      expect(NotifyGroupOrderInvoiceJob).not_to have_been_enqueued
+    end
+
+    it 'enqueues MailerJob when order is settled if tax_number or options are set' do
+      goa.update_quantities 2, 0
+      oa.update_results!
+      order.reload
+      FoodsoftConfig[:group_order_invoices] = { use: true }
+      FoodsoftConfig[:contact][:tax_number] = 12345678
+      visit confirm_finance_order_path(id: order.id, type: ftt)
+      expect(page).to have_selector(:link_or_button, I18n.t('finance.balancing.confirm.clear'))
+      click_link_or_button I18n.t('finance.balancing.confirm.clear')
+      expect(NotifyGroupOrderInvoiceJob).to have_been_enqueued
+    end
+
+    it 'does not generate Group Order Invoice when order is closed if tax_number not set' do
+      goa.update_quantities 2, 0
+      oa.update_results!
+      order.update!(state: 'closed')
+      order.reload
+      visit finance_order_index_path
+      expect(page).to have_content(I18n.t('activerecord.attributes.group_order_invoice.tax_number_not_set'))
+    end
+
+    it 'generates Group Order Invoice when order is closed if tax_number is set' do
+      goa.update_quantities 2, 0
+      oa.update_results!
+      FoodsoftConfig[:contact][:tax_number] = 12345678
+      order.update!(state: 'closed')
+      order.reload
+      visit finance_order_index_path
+      click_link_or_button I18n.t('activerecord.attributes.group_order_invoice.links.generate')
+      expect(GroupOrderInvoice.all.count).to eq(1)
+    end
+  end
+end

--- a/spec/models/group_order_invoice_spec.rb
+++ b/spec/models/group_order_invoice_spec.rb
@@ -1,0 +1,61 @@
+require_relative '../spec_helper'
+
+describe GroupOrderInvoice do
+  let(:user) { create :user, groups: [create(:ordergroup)] }
+  let(:supplier) { create :supplier }
+  let(:article) { create :article, supplier: supplier }
+  let(:order){ create :order }
+  let(:group_order) {create :group_order, order: order, ordergroup: user.ordergroup }
+
+  describe 'erroneous group order invoice' do
+    let(:goi) { create :group_order_invoice, group_order_id: group_order.id }
+
+    it 'does not create group order invoice if tax_number not set' do
+      expect{goi}.to raise_error(ActiveRecord::RecordInvalid)
+    end
+
+  end
+
+  describe 'valid group order invoice' do
+    before do
+      FoodsoftConfig[:contact][:tax_number] = 12345678
+    end
+
+    invoice_number1 = Time.now.strftime("%Y%m%d") + '0001'
+    invoice_number2 = Time.now.strftime("%Y%m%d") + '0002'
+
+    let(:user_2) { create :user, groups: [create(:ordergroup)] }
+
+    let(:goi_1) { create :group_order_invoice, group_order_id: group_order.id }
+    let(:goi_2) { create :group_order_invoice, group_order_id: group_order.id }
+
+    let(:group_order_2) {create :group_order, order: order, ordergroup: user_2.ordergroup }
+
+    let(:goi_3) { create :group_order_invoice, group_order_id: group_order_2.id }
+    let(:goi_4) { create :group_order_invoice, group_order_id: group_order_2.id, invoice_number: invoice_number1 }
+
+    it 'creates group order invoice if tax_number is set' do
+      expect(goi_1).to be_valid
+    end
+
+    it 'sets invoice_number according to date' do
+      number = Time.now.strftime("%Y%m%d") + '0001'
+      expect(goi_1.invoice_number).to eq(number.to_i)
+    end
+
+    it 'fails to create if group_order_id is used multiple times for creation' do
+      expect(goi_1.group_order.id).to eq(group_order.id)
+      expect{goi_2}.to raise_error(ActiveRecord::RecordNotUnique)
+    end
+
+    it 'creates two different group order invoice with different invoice_numbers' do
+      expect(goi_1.invoice_number).to eq(invoice_number1.to_i)
+      expect(goi_3.invoice_number).to eq(invoice_number2.to_i)
+    end
+
+    it 'fails to create two different group order invoice with same invoice_numbers' do
+      goi_1
+      expect{goi_4}.to raise_error(ActiveRecord::RecordInvalid)
+    end
+  end
+end


### PR DESCRIPTION
Offers the possibility to generate Invoices for given Group Orders.
Generation is possible after an order is closed.
If order is 'settled' then there's additionally the possibility to let the software send e-mails automatically on button press. The corresponding invoices will be sent as attachment via mail to the order group members.

Notes:
To use automatic sending of invoices, select option in "Admin/Finance" config
You can enter a "payment method " in "Admin/Finance"
To make things work, it is mandatory to enter a tax_number in "Admin/Foodcoop" config

As for now "payment method" determines the "body" of the invoice. 
An example of new options and the resulting invoice can be found here:

![tax_number](https://user-images.githubusercontent.com/20905449/147212544-d483a45e-11fd-4dec-a7f8-ce443f1bf7ca.png)
![finance](https://user-images.githubusercontent.com/20905449/147212550-24e855e8-4af1-48fd-8284-e170dec669e1.png)
![invoice](https://user-images.githubusercontent.com/20905449/147212553-d6b97b04-12e9-4ba1-ab33-9dd8b505a9d8.png)

Additionally for older and already settled orders, group order invoices can be generated manually under "finance/balancing"
![generate](https://user-images.githubusercontent.com/20905449/147212881-0e5d7e0a-7e72-4889-a924-c2cf216d3927.png)
![download](https://user-images.githubusercontent.com/20905449/147212884-3d7ccb58-3bbe-4d7e-afec-1b75ad591bfd.png)

Invoices will be generated given the momentarily given information about invoicee and invoicer (tax_number, contact details...). SO take care when delting an invoice.
