### PR TITLE
Add default time_zone

### DIFF
--- a/lib/foodsoft_config.rb
+++ b/lib/foodsoft_config.rb
@@ -257,6 +257,7 @@ class FoodsoftConfig
         use_apple_points: true,
         # English is the default language, and this makes it show up as default.
         default_locale: 'en',
+        time_zone: 'Berlin',
         currency_unit: '€',
         currency_space: true,
         foodsoft_url: 'https://github.com/foodcoops/foodsoft',


### PR DESCRIPTION
There is no default time zone setting in newly created Foodsoft instances. Closes #908