### PR TITLE
Add ability to include custom gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -117,3 +117,7 @@ group :test do
   gem 'apivore', require: false
   gem 'hashie', '~> 3.4.6', require: false # https://github.com/westfieldlabs/apivore/issues/114
 end
+
+# Use a local Gemfile to include custom dependencies that might be relevant for
+# hosting environments or developement.
+eval_gemfile 'Gemfile.local' if File.exist? 'Gemfile.local'


### PR DESCRIPTION
This might be useful if you want to include gems that are not part of this project. E.g. when a Foodsoft hosting provider want to include [turnout](https://github.com/biola/turnout) to inform about maintenance.