### PR TITLE
Invoice: change label "delivery" to "stock delivery"

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -91,7 +91,7 @@ de:
         created_by: Erstellt von
         date: Rechnungsdatum
         delete_attachment: Anhang löschen
-        deliveries: Lieferung
+        deliveries: Lager-Lieferung
         deposit: Pfand berechnet
         deposit_credit: Pfand gutgeschrieben
         financial_link: Finanzlink

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -91,7 +91,7 @@ en:
         created_by: Created by
         date: Billing date
         delete_attachment: Delete attachment
-        deliveries: Delivery
+        deliveries: Stock delivery
         deposit: Deposit charged
         deposit_credit: Deposit returned
         financial_link: Financial link

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -90,7 +90,7 @@ es:
         created_by: Creado por
         date: Fecha de Pago
         delete_attachment: Borra adjunto
-        deliveries: Entregas
+        deliveries: Entregas en stock
         deposit: Depósito cobrado
         deposit_credit: Depósito devuelto
         financial_link: Enlace financiero

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -66,7 +66,7 @@ fr:
         created_by: Établi par
         date: Date de facturation
         delete_attachment: Supprimer appendice
-        deliveries: Réapprovisionnement
+        deliveries: Réapprovisionnement en cellier
         deposit: Consigne facturée
         deposit_credit: Consigne remboursée
         net_amount: Montant recalculé en excluant les consignes

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -90,7 +90,7 @@ nl:
         created_by: Gemaakt door
         date: Factuurdatum
         delete_attachment: Verwijder bijlage
-        deliveries: Levering
+        deliveries: Voorraad levering
         deposit: Statiegeld in rekening gebracht
         deposit_credit: Statiegeld teruggekregen
         financial_link: Financiële link


### PR DESCRIPTION
Bei unseren Produzenten Betreuerinnen kommt es regelmäßig zu Verwirrung, weil eine Bestellung ja auch meist eine Lieferung beinhaltet und diese Begriffe oft synonym verwendet werden. Bei Bestellungen gibt es auch die Funktion "Lieferung annehmen". Daher werden mit einer Rechnung zu verknüpfende Bestellungen oft irrtümlich bei "Lieferung" gesucht. Mit "Lieferung" ist hier aber hier ausschließlich eine Lieferung ins Lager gemeint. Das sollte sich auch in der Bezeichnung niederschlagen.
Siehe auch https://docs.foodcoops.net/de/documentation/admin/terms-definitions