### PR TITLE
Change password validation to allow longer passwords

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,7 +33,7 @@ class User < ApplicationRecord
   validates_presence_of :first_name # for simple_form validations
   validates_length_of :first_name, :in => 2..50
   validates_confirmation_of :password
-  validates_length_of :password, :in => 5..25, :allow_blank => true
+  validates_length_of :password, :in => 12..50, :allow_blank => true
   # allow nick to be nil depending on foodcoop config
   # TODO Rails 4 may have a more beautiful way
   #   http://stackoverflow.com/questions/19845910/conditional-allow-nil-part-of-validation
@@ -132,7 +132,7 @@ class User < ApplicationRecord
   end
 
   # Returns a random password.
-  def new_random_password(size = 3)
+  def new_random_password(size = 6)
     c = %w(b c d f g h j k l m n p qu r s t v w x z ch cr fr nd ng nk nt ph pr rd sh sl sp st th tr)
     v = %w(a e i o u y)
     f, r = true, ''

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -23,28 +23,28 @@ describe User do
   end
 
   describe do
-    let(:user) { create :user, password: 'blahblah' }
+    let(:user) { create :user, password: 'blahblahblah' }
 
     it 'can authenticate with correct password' do
-      expect(User.authenticate(user.nick, 'blahblah')).to be_truthy
+      expect(User.authenticate(user.nick, 'blahblahblah')).to be_truthy
     end
     it 'can not authenticate with incorrect password' do
       expect(User.authenticate(user.nick, 'foobar')).to be_nil
     end
     it 'can not authenticate with nil nick' do
-      expect(User.authenticate(nil, 'blahblah')).to be_nil
+      expect(User.authenticate(nil, 'blahblahblah')).to be_nil
     end
     it 'can not authenticate with nil password' do
       expect(User.authenticate(user.nick, nil)).to be_nil
     end
     it 'can not set a password without matching confirmation' do
-      user.password = 'abcdefghij'
-      user.password_confirmation = 'foobarxyz'
+      user.password = 'abcdefghijkl'
+      user.password_confirmation = 'foobaruvwxyz'
       expect(user).to be_invalid
     end
     it 'can set a password with matching confirmation' do
-      user.password = 'abcdefghij'
-      user.password_confirmation = 'abcdefghij'
+      user.password = 'abcdefghijkl'
+      user.password_confirmation = 'abcdefghijkl'
       expect(user).to be_valid
     end
 
@@ -56,13 +56,13 @@ describe User do
     end
 
     it 'can authenticate using email address' do
-      expect(User.authenticate(user.email, 'blahblah')).to be_truthy
+      expect(User.authenticate(user.email, 'blahblahblah')).to be_truthy
     end
 
     it 'can authenticate when there is no nick' do
       user.nick = nil
       expect(user).to be_valid
-      expect(User.authenticate(user.email, 'blahblah')).to be_truthy
+      expect(User.authenticate(user.email, 'blahblahblah')).to be_truthy
     end
   end
 


### PR DESCRIPTION
Usally recommendations about good and secure passwords are about a minimun lenght of 12 characters. I propose to change the validation to enforce stronger password.
Also in times of password managers there is no need to limit the lenght to 25 characters.

In addition to #903 I changed also the specs.

