### PR TITLE
Update midi-smtp-server because v2.3.2 was yanked

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -295,7 +295,7 @@ GEM
       rack-contrib (>= 1.1, < 3)
       railties (>= 3.0.0, < 7)
     method_source (1.0.0)
-    midi-smtp-server (2.3.2)
+    midi-smtp-server (3.0.3)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0212)


### PR DESCRIPTION
Looks like the `midi-smtp-server` version referenced in the Gemfile.lock was yanked.

Is there any reason not updating to the latest version would be preferable? I guess updating to v2.3.3 would be an alternative. 