### PR TITLE
fix translation missing: xxx.orders.state.received

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1530,6 +1530,7 @@ de:
       closed: abgerechnet
       finished: beendet
       open: laufend
+      received: in Empfang genommen
     update:
       notice: Die Bestellung wurde aktualisiert.
     update_order_amounts:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1541,6 +1541,7 @@ en:
       closed: settled
       finished: closed
       open: open
+      received: received
     update:
       notice: The order was updated.
     update_order_amounts:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1344,6 +1344,7 @@ es:
       closed: cerrado
       finished: terminado
       open: abierto
+      received: recibido
     update:
       notice: Se actualizó el pedido.
     update_order_amounts:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1093,6 +1093,7 @@ fr:
       closed: décomptée
       finished: clôturée
       open: en cours
+      received: reçu      
     update:
       notice: La commande a été mise à jour.
     update_order_amounts:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -1535,6 +1535,7 @@ nl:
       closed: afgerekend
       finished: gesloten
       open: lopende
+      received: ontvangen
     update:
       notice: De bestelling is bijgewerkt.
     update_order_amounts:


### PR DESCRIPTION
Added missing translation for de.orders.state.received.
![grafik](https://user-images.githubusercontent.com/57668028/153928850-f5b1e525-aa63-4f0c-a5da-0e5487d947b2.png)
