### PR TITLE
Fixes filtering of active ordergroups

### DIFF
--- a/app/models/ordergroup.rb
+++ b/app/models/ordergroup.rb
@@ -20,7 +20,7 @@ class Ordergroup < Group
 
   after_create :update_stats!
 
-  scope :active, -> { joins(:orders).where(orders: { starts: (Time.now.months_ago(3)..) }).group(:id) }
+  scope :active, -> { joins(:orders).where(orders: { starts: (Time.now.months_ago(3)..Time.now) }).group(:id) }
 
   def contact
     "#{contact_phone} (#{contact_person})"

--- a/spec/models/ordergroup_spec.rb
+++ b/spec/models/ordergroup_spec.rb
@@ -1,20 +1,4 @@
-require './db/seeds/seed_helper'
 require_relative '../spec_helper'
-
-# should be extracted to a helper file
-def create_order(starts)
-  og = user.ordergroup
-
-  SupplierCategory.create!(:id => 1, :name => "Other", :financial_transaction_class_id => ftc1.id)
-  Supplier.create!([{ :id => 1, :name => "Beautiful bakery", :supplier_category_id => 1, :address => "Smallstreet 1, Cookilage", :phone => "0123456789", :email => "info@bbakery.test", :min_order_quantity => "100" }])
-  ArticleCategory.create!(:id => 5, :name => "Bread & Bakery")
-  Article.create!(:name => "Brown whole", :supplier_id => 1, :article_category_id => 5, :unit => "pc", :note => "organic", :availability => true, :manufacturer => "The Baker", :origin => "NL", :price => 0.22E1, :tax => 6.0, :deposit => 0.0, :unit_quantity => 1)
-
-  order = seed_order(supplier_id: 1, starts: starts, ends: starts + 5.days, created_by_user_id: user.id, updated_by_user_id: user.id)
-
-  go = og.group_orders.create!(order: order, updated_by_user_id: 1)
-  go.group_order_articles.find_or_create_by!(order_article: order.order_articles.first)
-end
 
 describe Ordergroup do
   let(:ftc1) { create :financial_transaction_class }
@@ -25,12 +9,16 @@ describe Ordergroup do
   let(:user) { create :user, groups: [create(:ordergroup)] }
 
   it 'shows no active ordergroups when all orders are older than 3 months' do
-    create_order(4.months.ago)
+    order = create :order, starts: 4.months.ago
+    user.ordergroup.group_orders.create!(order: order)
+
     expect(Ordergroup.active).to be_empty
   end
 
   it 'shows active ordergroups when there are recent orders' do
-    create_order(2.days.ago)
+    order = create :order, starts: 2.days.ago
+    user.ordergroup.group_orders.create!(order: order)
+
     expect(Ordergroup.active).not_to be_empty
   end
 

--- a/spec/models/ordergroup_spec.rb
+++ b/spec/models/ordergroup_spec.rb
@@ -1,4 +1,19 @@
+require './db/seeds/seed_helper.rb'
 require_relative '../spec_helper'
+
+def create_order(starts) # should be extracted to a helper file
+    og = user.ordergroup
+
+    SupplierCategory.create!(:id => 1, :name => "Other", :financial_transaction_class_id => ftc1.id)
+    Supplier.create!([{ :id => 1, :name => "Beautiful bakery", :supplier_category_id => 1, :address => "Smallstreet 1, Cookilage", :phone => "0123456789", :email => "info@bbakery.test", :min_order_quantity => "100" },])
+    ArticleCategory.create!(:id => 5, :name => "Bread & Bakery")
+    Article.create!(:name => "Brown whole", :supplier_id => 1, :article_category_id => 5, :unit => "pc", :note => "organic", :availability => true, :manufacturer => "The Baker", :origin => "NL", :price => 0.22E1, :tax => 6.0, :deposit => 0.0, :unit_quantity => 1)
+
+    order = seed_order(supplier_id: 1, starts: starts, ends: starts + 5.days, created_by_user_id: user.id, updated_by_user_id: user.id)
+
+    go = og.group_orders.create!(order: order, updated_by_user_id: 1)
+    goa = go.group_order_articles.find_or_create_by!(order_article: order.order_articles.first)
+end
 
 describe Ordergroup do
   let(:ftc1) { create :financial_transaction_class }
@@ -7,7 +22,17 @@ describe Ordergroup do
   let(:ftt2) { create :financial_transaction_type, financial_transaction_class: ftc2 }
   let(:ftt3) { create :financial_transaction_type, financial_transaction_class: ftc2 }
   let(:user) { create :user, groups: [create(:ordergroup)] }
+  
+  it 'shows no active ordergroups when all orders are older than 3 months' do
+    create_order(4.months.ago)
+    expect(Ordergroup.active).to be_empty
+  end
 
+  it 'shows active ordergroups when there are recent orders' do
+    create_order(2.days.ago)    
+    expect(Ordergroup.active).not_to be_empty
+  end
+  
   context 'with financial transactions' do
     before do
       og = user.ordergroup

--- a/spec/models/ordergroup_spec.rb
+++ b/spec/models/ordergroup_spec.rb
@@ -1,18 +1,19 @@
-require './db/seeds/seed_helper.rb'
+require './db/seeds/seed_helper'
 require_relative '../spec_helper'
 
-def create_order(starts) # should be extracted to a helper file
-    og = user.ordergroup
+# should be extracted to a helper file
+def create_order(starts)
+  og = user.ordergroup
 
-    SupplierCategory.create!(:id => 1, :name => "Other", :financial_transaction_class_id => ftc1.id)
-    Supplier.create!([{ :id => 1, :name => "Beautiful bakery", :supplier_category_id => 1, :address => "Smallstreet 1, Cookilage", :phone => "0123456789", :email => "info@bbakery.test", :min_order_quantity => "100" },])
-    ArticleCategory.create!(:id => 5, :name => "Bread & Bakery")
-    Article.create!(:name => "Brown whole", :supplier_id => 1, :article_category_id => 5, :unit => "pc", :note => "organic", :availability => true, :manufacturer => "The Baker", :origin => "NL", :price => 0.22E1, :tax => 6.0, :deposit => 0.0, :unit_quantity => 1)
+  SupplierCategory.create!(:id => 1, :name => "Other", :financial_transaction_class_id => ftc1.id)
+  Supplier.create!([{ :id => 1, :name => "Beautiful bakery", :supplier_category_id => 1, :address => "Smallstreet 1, Cookilage", :phone => "0123456789", :email => "info@bbakery.test", :min_order_quantity => "100" }])
+  ArticleCategory.create!(:id => 5, :name => "Bread & Bakery")
+  Article.create!(:name => "Brown whole", :supplier_id => 1, :article_category_id => 5, :unit => "pc", :note => "organic", :availability => true, :manufacturer => "The Baker", :origin => "NL", :price => 0.22E1, :tax => 6.0, :deposit => 0.0, :unit_quantity => 1)
 
-    order = seed_order(supplier_id: 1, starts: starts, ends: starts + 5.days, created_by_user_id: user.id, updated_by_user_id: user.id)
+  order = seed_order(supplier_id: 1, starts: starts, ends: starts + 5.days, created_by_user_id: user.id, updated_by_user_id: user.id)
 
-    go = og.group_orders.create!(order: order, updated_by_user_id: 1)
-    goa = go.group_order_articles.find_or_create_by!(order_article: order.order_articles.first)
+  go = og.group_orders.create!(order: order, updated_by_user_id: 1)
+  go.group_order_articles.find_or_create_by!(order_article: order.order_articles.first)
 end
 
 describe Ordergroup do
@@ -22,17 +23,17 @@ describe Ordergroup do
   let(:ftt2) { create :financial_transaction_type, financial_transaction_class: ftc2 }
   let(:ftt3) { create :financial_transaction_type, financial_transaction_class: ftc2 }
   let(:user) { create :user, groups: [create(:ordergroup)] }
-  
+
   it 'shows no active ordergroups when all orders are older than 3 months' do
     create_order(4.months.ago)
     expect(Ordergroup.active).to be_empty
   end
 
   it 'shows active ordergroups when there are recent orders' do
-    create_order(2.days.ago)    
+    create_order(2.days.ago)
     expect(Ordergroup.active).not_to be_empty
   end
-  
+
   context 'with financial transactions' do
     before do
       og = user.ordergroup


### PR DESCRIPTION
While working on the first complete version of #716 I realized that the filtering of active ordergroups does not work anymore. At least this was my observation in my development environment.

This change fixes the issue for me.

Thinking about it, I guess an autotest would be nice... Will create this PR as a draft and check if it's easy for me to create a failing test for this bug.

Update:
I've added 2 tests for the `Ordergroup.active` scope. The helper method probably should be moved to a better location, but wanted to hear your opinion first if this is useful. Also, it contains duplications from `seeds_helper.rb`...