### PR TITLE
Add table_print gem for debugging ActiveRecord queries in the console

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,6 +85,8 @@ group :development do
 
   # Get infos when not using proper eager loading
   gem 'bullet'
+  # Display Active Record queries as tables in the console
+  gem 'table_print'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -513,6 +513,7 @@ GEM
     sqlite3 (1.3.13)
     sqlite3-ruby (1.3.3)
       sqlite3 (>= 1.3.3)
+    table_print (1.5.7)
     temple (0.8.2)
     therubyracer (0.12.3)
       libv8 (~> 3.16.14.15)
@@ -646,6 +647,7 @@ DEPENDENCIES
   spreadsheet
   sprockets (< 4)
   sqlite3 (~> 1.3.6)
+  table_print
   therubyracer
   twitter-bootstrap-rails (~> 2.2.8)
   uglifier (>= 1.0.3)


### PR DESCRIPTION
This gem was useful while implementing #716 and maybe also for the future.