### PR TITLE
Enabled systemd socket activation

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -11,6 +11,9 @@ threads threads_count, threads_count
 #
 port        ENV.fetch("PORT") { 3000 }
 
+# Bind automatically to all systemd activated sockets
+bind_to_activated_sockets
+
 # Specifies the `environment` that Puma will run in.
 #
 environment ENV.fetch("RAILS_ENV") { "development" }


### PR DESCRIPTION
With this [configuration](https://github.com/puma/puma/blob/master/docs/systemd.md) puma automatically binds to all systemd activated sockets. With socket activation systemd opens the listening socket(s) in advance and provides them to the Puma master process on startup. This keeps listening sockets open across puma restarts and achieves graceful restarts.