### PR TITLE
[Readme.md] Fix Gitpod link pointing to original repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ page on the wiki.
 
 Get a foodsoft dev-environment running in the browser with Gitpod
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/mob-programming-meetup/foodsoft)
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/foodcoops/foodsoft)
 
 Follow these [instructions](doc/SETUP_DEVELOPMENT_GITPOD.md) to complete setup from within the Gitpod workspace. 
 


### PR DESCRIPTION
The "Open in Gitpod" link in the Readme.md was pointing to a fork, so that the .gitpod.yml is picked up when opening the link.
Now that it's merged to master (#916), it should of course point to the main repo.