### PR TITLE
Show instance name at login screen

### DIFF
--- a/app/views/sessions/new.html.haml
+++ b/app/views/sessions/new.html.haml
@@ -6,6 +6,8 @@
 
 - title t('.title')
 
+.lead= FoodsoftConfig[:name]
+
 %noscript
   .alert.alert-error
     != t '.nojs', link: link_to(t('.noscript'), "http://noscript.net/")


### PR DESCRIPTION
This commit is useful for multi_coop_installs. At the moment the login screen of every multi_coop instance looks the same.
It can happen that users log in to another instance because they mistyped the URL.
With this change to name of a foodsoft instance will be shown as the title of the login screen.