### PR TITLE
Add sd_notify

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ gem 'acts_as_tree'
 gem 'rails-settings-cached', '= 0.4.3' # caching breaks tests until Rails 5 https://github.com/huacnlee/rails-settings-cached/issues/73
 gem 'resque'
 gem 'puma'
+gem 'sd_notify'
 gem 'whenever', require: false # For defining cronjobs, see config/schedule.rb
 gem 'ruby-units'
 gem 'attribute_normalizer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -465,6 +465,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    sd_notify (0.1.1)
     select2-rails (4.0.13)
     simple-navigation (3.14.0)
       activesupport (>= 2.3.2)
@@ -623,6 +624,7 @@ DEPENDENCIES
   ruby-prof
   ruby-units
   sass-rails
+  sd_notify
   select2-rails
   simple-navigation (~> 3.14.0)
   simple-navigation-bootstrap


### PR DESCRIPTION
With this [gem](https://github.com/agis/ruby-sdnotify) Puma [supports](https://github.com/puma/puma/blob/master/docs/systemd.md) systemd's Type=notify and watchdog service. This enabled systemd to automatically restart Puma if it locks up.