### PR TITLE
Open external websites in new browser window

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -13,9 +13,9 @@
           %li= link_to t('.reference_calculator'), home_reference_calculator_path
         %li= link_to t('.logout'), logout_path
     %li{class: ('disabled' if FoodsoftConfig[:homepage].blank?)}
-      = link_to FoodsoftConfig[:name], FoodsoftConfig[:homepage]
+      = link_to FoodsoftConfig[:name], FoodsoftConfig[:homepage], target: '_blank'
     - if FoodsoftConfig[:help_url]
-      %li= link_to t('.help'), FoodsoftConfig[:help_url]
+      %li= link_to t('.help'), FoodsoftConfig[:help_url], target: '_blank'
     %li= link_to t('.feedback.title'), new_feedback_path, title: t('.feedback.desc')
   .clearfix
 


### PR DESCRIPTION
Usually the Foodcoop's website and the help pages are external resources. If they load in the same window one could forget to logout from the Foodsoft.