### PR TITLE
Specify an URL to redirect after logout via settings

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -21,7 +21,11 @@ class SessionsController < ApplicationController
 
   def destroy
     logout
-    redirect_to login_url, :notice => I18n.t('sessions.logged_out')
+    if FoodsoftConfig[:logout_redirect_url].present?
+      redirect_to FoodsoftConfig[:logout_redirect_url]
+    else
+      redirect_to login_url, :notice => I18n.t('sessions.logged_out')
+    end
   end
 
   # redirect to root, going to default foodcoop when none given

--- a/config/app_config.yml.SAMPLE
+++ b/config/app_config.yml.SAMPLE
@@ -32,6 +32,9 @@ default: &defaults
   # custom foodsoft software URL (used in footer)
   #foodsoft_url: https://github.com/foodcoops/foodsoft
 
+  # URL to redirect to after logging out
+  # logout_redirect_url: https://foodcoop.test
+
   # Default language
   #default_locale: en
   # By default, foodsoft takes the language from the webbrowser/operating system.


### PR DESCRIPTION
This change make it possbile to specify an URL via `logout_redirect_url` at `config/app_config.yml`. After logging out the application redirects to this URL.

We use is to redirect the logout of the [Demo](https://app.foodcoops.net) instance to the [info](https://foodcoops.net/demo/) page.

Maybe this is also useful for other foodcoops.