### PR TITLE
feat: Disable member list via configuration

### DIFF
--- a/app/controllers/foodcoop/users_controller.rb
+++ b/app/controllers/foodcoop/users_controller.rb
@@ -1,4 +1,6 @@
 class Foodcoop::UsersController < ApplicationController
+  before_action -> { require_config_disabled :disable_members_overview }
+
   def index
     @users = User.undeleted.sort_by_param(params["sort"])
 

--- a/app/views/admin/configs/_tab_others.html.haml
+++ b/app/views/admin/configs/_tab_others.html.haml
@@ -4,5 +4,6 @@
 = config_input form, :distribution_strategy, as: :select, collection: distribution_strategy_options,
   include_blank: false, input_html: {class: 'input-xxlarge'}, label_method: ->(s){ t("config.keys.distribution_strategy_options.#{s}") }
 = config_input form, :disable_invite, as: :boolean
+= config_input form, :disable_members_overview, as: :boolean
 = config_input form, :help_url, as: :url, input_html: {class: 'input-xlarge'}
 = config_input form, :webstats_tracking_code, as: :text, input_html: {class: 'input-xxlarge', rows: 3}

--- a/app/views/home/_start_nav.haml
+++ b/app/views/home/_start_nav.haml
@@ -2,7 +2,8 @@
   %h3= t '.title'
   %ul.nav.nav-list
     %li.nav-header= t '.foodcoop'
-    %li= link_to t('.members'), foodcoop_users_path
+    - unless FoodsoftConfig[:disable_members_overview]
+      %li= link_to t('.members'), foodcoop_users_path
     %li= link_to t('.tasks'), user_tasks_path
 
     - has_ordergroup = !@current_user.ordergroup.nil?

--- a/config/app_config.yml.SAMPLE
+++ b/config/app_config.yml.SAMPLE
@@ -90,6 +90,9 @@ default: &defaults
   #use_wiki: true
   #use_messages: true
 
+  # When enabled only administrators can access the member list.
+  #disable_members_overview: true
+
   # Base font size for generated PDF documents
   #pdf_font_size: 12
   # Page size for generated PDF documents

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -655,6 +655,7 @@ de:
       default_role_pickups: Abholtage
       default_role_suppliers: Lieferanten
       disable_invite: Einladungen deaktivieren
+      disable_members_overview: Mitgliederliste deaktivieren
       email_from: Absenderadresse
       email_replyto: Antwortadresse
       email_sender: Senderadresse

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -656,6 +656,7 @@ en:
       default_role_pickups: Pickup days
       default_role_suppliers: Suppliers
       disable_invite: Disable invites
+      disable_members_overview: Disable members list
       email_from: From address
       email_replyto: Reply-to address
       email_sender: Sender address

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -580,6 +580,7 @@ es:
       custom_css: CSS adicional
       default_locale: Idioma por defecto
       disable_invite: Desactivar invitaciones
+      disable_members_overview: Desactivar la lista de miembros
       email_from: Dirección de email de origen
       email_replyto: Dirección reply-to
       email_sender: Dirección del remitente

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -418,6 +418,7 @@ fr:
         zip_code: Code postal
       currency_unit: Monnaie
       name: Nom
+      disable_members_overview: Désactiver la liste des membres
       distribution_strategy: Stratégie de distribution
       distribution_strategy_options:
         first_order_first_serve: Distribuez d'abord à ceux qui ont commandé en premier

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -626,6 +626,7 @@ nl:
       default_role_pickups: Ophaaldagen
       default_role_suppliers: Leveranciers
       disable_invite: Uitnodigingen deactiveren
+      disable_members_overview: Ledenlijst deactiveren
       email_from: From adres
       email_replyto: Reply-to adres
       email_sender: Sender adres

--- a/config/navigation.rb
+++ b/config/navigation.rb
@@ -12,7 +12,7 @@ SimpleNavigation::Configuration.run do |navigation|
     primary.item :dashboard_nav_item, I18n.t('navigation.dashboard'), root_path(anchor: '')
 
     primary.item :foodcoop, I18n.t('navigation.foodcoop'), '#' do |subnav|
-      subnav.item :members, I18n.t('navigation.members'), foodcoop_users_path
+      subnav.item :members, I18n.t('navigation.members'), foodcoop_users_path, unless: Proc.new { FoodsoftConfig[:disable_members_overview] }
       subnav.item :workgroups, I18n.t('navigation.workgroups'), foodcoop_workgroups_path
       subnav.item :ordergroups, I18n.t('navigation.ordergroups'), foodcoop_ordergroups_path
       subnav.item :tasks, I18n.t('navigation.tasks'), tasks_path


### PR DESCRIPTION
By default every member can access the full member list via  `/foodcoop/users`. But not every Foodcoop wants to share this member overview with all users. With this MR it's possible to hide the member overview. Only administrators can access the members lust via `/admin/users`.

Note: It's still possible to randomly search for user names via the search field in the new message view (`/messages/new`).