### PR TITLE
Update mail gem to .8.1 which fixes the permission error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 # A sample Gemfile
 source 'https://rubygems.org'
 
-gem 'mail', '~> 2.7.1' # bug with mail 2.8.0 https://github.com/mikel/mail/issues/1489
 gem 'rails', '~> 7.0'
 
 gem 'less-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -298,8 +298,11 @@ GEM
     loofah (2.21.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    mail (2.7.1)
+    mail (2.8.1)
       mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
     mailcatcher (0.2.4)
       eventmachine
       haml
@@ -318,6 +321,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2022.0105)
     mini_mime (1.1.2)
+    mini_portile2 (2.8.2)
     minitest (5.18.0)
     mono_logger (1.1.1)
     msgpack (1.6.0)
@@ -335,6 +339,9 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.8)
+    nokogiri (1.15.2)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     nokogiri (1.15.2-x86_64-linux)
       racc (~> 1.4)
     parallel (1.23.0)
@@ -591,6 +598,7 @@ GEM
     zeitwerk (2.6.8)
 
 PLATFORMS
+  ruby
   x86_64-linux
 
 DEPENDENCIES
@@ -633,7 +641,6 @@ DEPENDENCIES
   kaminari
   less-rails
   listen
-  mail (~> 2.7.1)
   mailcatcher
   midi-smtp-server
   mime-types


### PR DESCRIPTION
The mail gem was [downgraded](https://github.com/foodcoops/foodsoft/commit/34e238466f3300671bb99967e2b95c14a33162b9) to fix a permission error. This was fixed in [2.8.0.1](https://github.com/mikel/mail/pull/1555).