### PR TITLE
Introduce Message Formatting with Actiontext Trix Editor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,9 +49,10 @@ RUN export DATABASE_URL=mysql2://localhost/temp?encoding=utf8 && \
     rm -Rf /var/lib/apt/lists/* /var/cache/apt/*
 
 # Make relevant dirs and files writable for app user
-RUN mkdir -p tmp && \
+RUN mkdir -p tmp storage && \
     chown nobody config/app_config.yml && \
-    chown nobody tmp
+    chown nobody tmp && \
+    chown nobody storage
 
 # Run app as unprivileged user
 USER nobody

--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,8 @@ gem 'whenever', require: false # For defining cronjobs, see config/schedule.rb
 gem 'exception_notification'
 gem 'gaffe'
 gem 'hashie', '~> 3.4.6', require: false # https://github.com/westfieldlabs/apivore/issues/114
+gem "image_processing", "~> 1.12"
+gem "importmap-rails", "~> 1.1"
 gem 'midi-smtp-server'
 gem 'mime-types'
 gem 'recurring_select', git: 'https://github.com/gregschmit/recurring_select'
@@ -58,6 +60,7 @@ gem 'rswag-api'
 gem 'rswag-ui'
 gem 'ruby-filemagic'
 gem 'spreadsheet'
+gem "terser", "~> 1.1"
 
 # we use the git version of acts_as_versioned, and need to include it in this Gemfile
 gem 'acts_as_versioned', git: 'https://github.com/technoweenie/acts_as_versioned.git'
@@ -122,6 +125,3 @@ group :test do
   # api
   gem 'rswag-specs'
 end
-
-gem "importmap-rails", "~> 1.1"
-gem "terser", "~> 1.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -254,6 +254,9 @@ GEM
     i18n-spec (0.6.0)
       iso
     ice_cube (0.16.4)
+    image_processing (1.12.2)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     importmap-rails (1.1.5)
       actionpack (>= 6.0.0)
       railties (>= 6.0.0)
@@ -320,8 +323,8 @@ GEM
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2022.0105)
+    mini_magick (4.12.0)
     mini_mime (1.1.2)
-    mini_portile2 (2.8.2)
     minitest (5.18.0)
     mono_logger (1.1.1)
     msgpack (1.6.0)
@@ -339,9 +342,6 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.8)
-    nokogiri (1.15.2)
-      mini_portile2 (~> 2.8.2)
-      racc (~> 1.4)
     nokogiri (1.15.2-x86_64-linux)
       racc (~> 1.4)
     parallel (1.23.0)
@@ -499,6 +499,8 @@ GEM
     ruby-prof (1.4.5)
     ruby-progressbar (1.13.0)
     ruby-units (3.0.0)
+    ruby-vips (2.1.4)
+      ffi (~> 1.12)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     sass-rails (6.0.0)
@@ -635,6 +637,7 @@ DEPENDENCIES
   i18n-js (~> 3.0.0.rc8)
   i18n-spec
   ice_cube
+  image_processing (~> 1.12)
   importmap-rails (~> 1.1)
   inherited_resources
   jquery-rails
@@ -692,4 +695,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   2.4.13
+   2.4.5

--- a/app/assets/stylesheets/actiontext.css
+++ b/app/assets/stylesheets/actiontext.css
@@ -1,0 +1,31 @@
+/*
+ * Provides a drop-in pointer for the default Trix stylesheet that will format the toolbar and
+ * the trix-editor content (whether displayed or under editing). Feel free to incorporate this
+ * inclusion directly in any other asset bundle and remove this file.
+ *
+ *= require trix
+*/
+
+/*
+ * We need to override trix.css’s image gallery styles to accommodate the
+ * <action-text-attachment> element we wrap around attachments. Otherwise,
+ * images in galleries will be squished by the max-width: 33%; rule.
+*/
+.trix-content .attachment-gallery > action-text-attachment,
+.trix-content .attachment-gallery > .attachment {
+  flex: 1 0 33%;
+  padding: 0 0.5em;
+  max-width: 33%;
+}
+
+.trix-content .attachment-gallery.attachment-gallery--2 > action-text-attachment,
+.trix-content .attachment-gallery.attachment-gallery--2 > .attachment, .trix-content .attachment-gallery.attachment-gallery--4 > action-text-attachment,
+.trix-content .attachment-gallery.attachment-gallery--4 > .attachment {
+  flex-basis: 50%;
+  max-width: 50%;
+}
+
+.trix-content action-text-attachment .attachment {
+  padding: 0 !important;
+  max-width: 100% !important;
+}

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -7,4 +7,5 @@
 *= require list.unlist
 *= require list.missing
 *= require recurring_select
+*= require actiontext
 */

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,1 +1,4 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
+import "trix"
+import "@rails/actiontext"
+import "./trix-editor-overrides"

--- a/app/javascript/trix-editor-overrides.js
+++ b/app/javascript/trix-editor-overrides.js
@@ -1,0 +1,7 @@
+// app/javascript/trix-editor-overrides.js
+window.addEventListener("trix-file-accept", function(event) {
+  if (event.file.size > 1024 * 1024 * 512) {
+    event.preventDefault()
+    alert(I18n.t('js.trix_editor.file_size_alert'))
+  }
+})

--- a/app/views/active_storage/blobs/_blob.html.haml
+++ b/app/views/active_storage/blobs/_blob.html.haml
@@ -1,0 +1,9 @@
+%figure{class: "attachment attachment--#{blob.representable? ? "preview" : "file"} attachment--#{blob.filename.extension}"}
+  - if blob.representable?
+    = image_tag blob.representation(resize_to_limit: local_assigns[:in_gallery] ? [ 800, 600 ] : [ 1024, 768 ])
+  %figcaption.attachment__caption
+    - if caption = blob.try(:caption)
+      = caption
+    - else
+      %span.attachment__name= link_to blob.filename, blob
+      %span.attachment__size= number_to_human_size blob.byte_size

--- a/app/views/layouts/action_text/contents/_content.html.erb
+++ b/app/views/layouts/action_text/contents/_content.html.erb
@@ -1,0 +1,3 @@
+<div class="trix-content">
+  <%= yield -%>
+</div>

--- a/app/views/layouts/email.html.haml
+++ b/app/views/layouts/email.html.haml
@@ -1,0 +1,12 @@
+= yield
+\
+%hr
+%ul
+  %li
+    %a{href: root_url} Foodsoft
+  - if FoodsoftConfig[:homepage]
+    %li
+      %a{href: FoodsoftConfig[:homepage]} Foodcoop
+  - if FoodsoftConfig[:help_url]
+    %li
+      %a{href: FoodsoftConfig[:help_url]}= t '.help'

--- a/config/app_config.yml.SAMPLE
+++ b/config/app_config.yml.SAMPLE
@@ -173,6 +173,9 @@ default: &defaults
   # default to allow automatically adding new articles on sync only when less than 200 articles in total
   #shared_supplier_article_sync_limit: 200
 
+  # number of days after which attachment files get deleted
+  #attachment_retention_days: 365
+
 development:
   <<: *defaults
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -68,6 +68,8 @@ module Foodsoft
     config.active_record.yaml_column_permitted_classes = [Symbol, BigDecimal]
 
     config.autoloader = :zeitwerk
+
+    config.active_storage.variant_processor = :mini_magick
   end
 
   # Foodsoft version

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,2 +1,4 @@
 # Pin npm packages by running ./bin/importmap
 pin "application", preload: true
+pin "trix"
+pin "@rails/actiontext", to: "actiontext.js"

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1216,12 +1216,15 @@ de:
   js:
     ordering:
       confirm_change: Änderungen an dieser Bestellung gehen verloren, wenn zu einer anderen Bestellung gewechselt wird. Möchtest Du trotzdem wechseln?
+    trix_editor:
+      file_size_alert: Der Dateianhang ist zu groß! Die maximale Größe beträgt 512Mb
   layouts:
     email:
       footer_1_separator: "--"
       footer_2_foodsoft: 'Foodsoft: %{url}'
       footer_3_homepage: 'Foodcoop: %{url}'
       footer_4_help: 'Hilfe: %{url}'
+      help: 'Hilfe'
     foodsoft: Foodsoft
     footer:
       revision: Revision %{revision}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1219,12 +1219,15 @@ en:
   js:
     ordering:
       confirm_change: Modifications to this order will be lost when you change the order. Do you want to lose the changes you made and continue?
+    trix_editor:
+      file_size_alert: The file is to large! The supported file size is 512Mb!
   layouts:
     email:
       footer_1_separator: "--"
       footer_2_foodsoft: 'Foodsoft: %{url}'
       footer_3_homepage: 'Foodcoop: %{url}'
       footer_4_help: 'Help: %{url}'
+      help: 'Help'
     foodsoft: Foodsoft
     footer:
       revision: revision %{revision}

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1080,9 +1080,12 @@ es:
   js:
     ordering:
       confirm_change: Las modificaciones sobre este pedido se perderán cuando cambies el pedido. ¿Quieres perder los cambios que has hecho y continuar?
+    trix_editor:
+      file_size_alert: ¡El archivo adjunto es demasiado grande!  El tamaño máximo es de 512Mb
   layouts:
     email:
       footer_4_help: 'Ayuda: %{url}'
+      help: 'Ayuda'
     footer:
       revision: revisión %{revision}
     header:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -831,10 +831,13 @@ fr:
   js:
     ordering:
       confirm_change: Les changements apportés à cette commande vont être perdus. Est-ce que tu veux vraiment continuer?
+    trix_editor:
+      file_size_alert: Le fichier joint est trop volumineux ! La taille maximale est de 512Mb
   layouts:
     email:
       footer_3_homepage: 'Boufcoop: %{url}'
       footer_4_help: 'Aide: %{url}'
+      help: 'Aide'
     footer:
       revision: révision %{revision}
     header:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -1189,12 +1189,15 @@ nl:
   js:
     ordering:
       confirm_change: Als je naar een andere bestelling gaat, gaan je aanpassingen in deze bestelling verloren. Wijzigingen vergeten en naar de andere bestelling gaan?
+    trix_editor:
+      file_size_alert: De bestandsbijlage is te groot! De maximale grootte is 512Mb!
   layouts:
     email:
       footer_1_separator: "--"
       footer_2_foodsoft: 'Foodsoft: %{url}'
       footer_3_homepage: 'Foodcoop: %{url}'
       footer_4_help: 'Help: %{url}'
+      help: 'Help'
     foodsoft: Foodsoft
     footer:
       revision: revisie %{revision}

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -1218,6 +1218,8 @@ tr:
   js:
     ordering:
       confirm_change: Bu siparişe yapılan değişiklikler kaybolacak. Değişikliklerinizi kaybetmek ve devam etmek istiyor musunuz?
+    trix_editor:
+      file_size_alert: Dosya eki çok büyük! Maksimum boyut 512Mb
   layouts:
     email:
       footer_1_separator: "--"

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -12,9 +12,10 @@ every :weekday, at: %w[5:56am 6:04pm] do
   rake 'multicoops:run TASK=foodsoft:import_and_assign_bank_transactions'
 end
 
-# Weekly taks
+# Weekly tasks
 every :sunday, at: '7:14 am' do
   rake 'multicoops:run TASK=foodsoft:create_upcoming_periodic_tasks'
+  rake 'multicoops:run TASKS=foodsoft:prune_old_attachments'
 end
 
 # Finish ended orders

--- a/db/migrate/20230209105256_create_action_text_tables.action_text.rb
+++ b/db/migrate/20230209105256_create_action_text_tables.action_text.rb
@@ -1,0 +1,27 @@
+# This migration comes from action_text (originally 20180528164100)
+class CreateActionTextTables < ActiveRecord::Migration[6.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :action_text_rich_texts, id: primary_key_type do |t|
+      t.string     :name, null: false
+      t.text       :body, size: :long
+      t.references :record, null: false, polymorphic: true, index: false, type: foreign_key_type
+
+      t.timestamps
+
+      t.index [:record_type, :record_id, :name], name: "index_action_text_rich_texts_uniqueness", unique: true
+    end
+  end
+
+  private
+
+  def primary_and_foreign_key_types
+    config = Rails.configuration.generators
+    setting = config.options[config.orm][:primary_key_type]
+    primary_key_type = setting || :primary_key
+    foreign_key_type = setting || :bigint
+    [primary_key_type, foreign_key_type]
+  end
+end

--- a/db/migrate/20230215085312_migrate_message_body_to_action_text.rb
+++ b/db/migrate/20230215085312_migrate_message_body_to_action_text.rb
@@ -1,0 +1,32 @@
+class MigrateMessageBodyToActionText < ActiveRecord::Migration[7.0]
+  include ActionView::Helpers::TextHelper
+
+  class Message < ApplicationRecord
+    has_rich_text :body
+  end
+
+  def change
+    reversible do |dir|
+      dir.up do
+        rename_column :messages, :body, :body_old
+        Message.all.each do |message|
+          message.update(body: simple_format(message.body_old))
+          message.body.update(record_type: :Message) # action_text_rich_texts uses STI record_type field and has to be set to the real model
+        end
+        remove_column :messages, :body_old, :text
+      end
+      dir.down do
+        execute "ALTER TABLE `messages` ADD `body_old` text"
+        execute "UPDATE `messages` m
+                  INNER JOIN `action_text_rich_texts` a
+                    ON m.id = a.record_id
+                set m.body_old = a.body"
+        Message.all.each do |message|
+          message.update(body_old: strip_tags(message.body_old))
+        end
+        execute "DELETE FROM `action_text_rich_texts` WHERE `action_text_rich_texts`.`record_type` = 'Message'"
+        execute "ALTER TABLE `messages` CHANGE `body_old` `body` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL DEFAULT NULL;"
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_06_144440) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_15_085312) do
+  create_table "action_text_rich_texts", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+    t.string "name", null: false
+    t.text "body", size: :long
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["record_type", "record_id", "name"], name: "index_action_text_rich_texts_uniqueness", unique: true
+  end
+
   create_table "active_storage_attachments", id: :integer, charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -292,7 +292,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_15_085312) do
   create_table "messages", id: :integer, charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.integer "sender_id"
     t.string "subject", null: false
-    t.text "body"
     t.boolean "private", default: false
     t.datetime "created_at", precision: nil
     t.integer "reply_to"

--- a/lib/tasks/foodsoft.rake
+++ b/lib/tasks/foodsoft.rake
@@ -1,6 +1,6 @@
 # put in here all foodsoft tasks
 # => :environment loads the environment an gives easy access to the application
-namespace :foodsoft do
+namespace :foodsoft do # rubocop:disable Metrics/BlockLength
   desc 'Finish ended orders'
   task finish_ended_orders: :environment do
     Order.finish_ended!
@@ -77,6 +77,19 @@ namespace :foodsoft do
       importer.finish
       assign_count = ba.assign_unlinked_transactions
       rake_say "#{ba.name}: imported #{importer.count}, assigned #{assign_count}"
+    end
+  end
+
+  desc 'Prune attachments older than maximum age'
+  task prune_old_attachments: :environment do
+    if FoodsoftConfig[:attachment_retention_days]
+      rake_say "Pruning attachments older than #{FoodsoftConfig[:attachment_retention_days]} days"
+      ActiveStorage::Attachment.where("created_at < ?", FoodsoftConfig[:attachment_retention_days].days.ago).each do |attachment|
+        rake_say attachment.inspect
+        attachment.purge_later
+      end
+    else
+      rake_say "Please configure your app_config.yml accordingly:\nattachment_retention_days: <number of days>"
     end
   end
 end

--- a/plugins/messages/app/controllers/messages_controller.rb
+++ b/plugins/messages/app/controllers/messages_controller.rb
@@ -21,7 +21,8 @@ class MessagesController < ApplicationController
       @message.subject = I18n.t('messages.model.reply_subject', subject: original_message.subject)
       @message.body = I18n.t('messages.model.reply_header', user: original_message.sender.display,
                                                             when: I18n.l(original_message.created_at, format: :short)) + "\n"
-      original_message.body.each_line { |l| @message.body += I18n.t('messages.model.reply_indent', line: l) }
+      @message.body = I18n.t('messages.model.reply_header', user: original_message.sender.display, when: I18n.l(original_message.created_at, format: :short)) + "\n" \
+      + "<blockquote>" + original_message.body.to_trix_html + "</blockquote>"
     else
       redirect_to new_message_url, alert: I18n.t('messages.new.error_private')
     end

--- a/plugins/messages/app/helpers/messages_helper.rb
+++ b/plugins/messages/app/helpers/messages_helper.rb
@@ -5,7 +5,7 @@ module MessagesHelper
       body = ''
     else
       subject = message.subject
-      body = truncate(message.body, length: length - subject.length)
+      body = truncate(message.body.to_plain_text, length: length - subject.length)
     end
     "<b>#{link_to(h(subject), message)}</b> <span style='color:grey'>#{h(body)}</span>".html_safe
   end

--- a/plugins/messages/app/models/message.rb
+++ b/plugins/messages/app/models/message.rb
@@ -22,6 +22,8 @@ class Message < ApplicationRecord
   validates_presence_of :message_recipients, :subject, :body
   validates_length_of :subject, in: 1..255
 
+  has_rich_text :body
+
   after_initialize do
     @recipients_ids ||= []
     @send_method ||= 'recipients'

--- a/plugins/messages/app/views/messages/new.haml
+++ b/plugins/messages/app/views/messages/new.haml
@@ -110,7 +110,7 @@
     = f.input :recipient_tokens, :input_html => { 'data-pre' => User.where(id: @message.recipients_ids).map(&:token_attributes).to_json }
   = f.input :private, inline_label: t('.hint_private')
   = f.input :subject, input_html: {class: 'input-xxlarge'}
-  = f.input :body, input_html: {class: 'input-xxlarge', rows: 13}
+  = f.rich_text_area :body, input_html: {class: 'input-xxlarge', rows: 13}
   .form-actions
     = f.submit class: 'btn btn-primary'
     = link_to t('ui.or_cancel'), :back

--- a/plugins/messages/app/views/messages/show.haml
+++ b/plugins/messages/app/views/messages/show.haml
@@ -33,7 +33,7 @@
         - if @message.can_toggle_private?(current_user)
           = link_to t('.change_visibility'), toggle_private_message_path(@message), method: :post, class: 'btn btn-mini'
   %hr/
-  %p= simple_format(h(@message.body))
+  .trix-content= @message.body
   %hr/
   %p
     = link_to t('.reply'), new_message_path(:message => {:reply_to => @message.id}), class: 'btn'

--- a/plugins/messages/app/views/messages_mailer/foodsoft_message.html.haml
+++ b/plugins/messages/app/views/messages_mailer/foodsoft_message.html.haml
@@ -1,0 +1,11 @@
+= raw @message.body
+%hr
+%ul
+  - if @message.group
+    %li= t '.footer_group', group: @message.group.name
+  %li
+    %a{href: new_message_url('message[reply_to]' => @message.id)}= t '.reply'
+  %li
+    %a{href: message_url(@message)}= t '.see_message_online'
+  %li
+    %a{href: my_profile_url}= t '.messaging_options'

--- a/plugins/messages/config/locales/de.yml
+++ b/plugins/messages/config/locales/de.yml
@@ -138,6 +138,9 @@ de:
         Antworten: %{reply_url}
         Nachricht online einsehen: %{msg_url}
         Nachrichten-Einstellungen: %{profile_url}
+      reply: Antworten
+      see_message_online: Nachricht online einsehen
+      messaging_options: Nachrichten-Einstellungen
       footer_group: |
         Gesendet an Gruppe: %{group}
   navigation:

--- a/plugins/messages/config/locales/en.yml
+++ b/plugins/messages/config/locales/en.yml
@@ -140,6 +140,9 @@ en:
         Reply: %{reply_url}
         See message online: %{msg_url}
         Messaging options: %{profile_url}
+      reply: Reply
+      see_message_online: See message online
+      messaging_options: Messaging options
       footer_group: |
         Sent to group: %{group}
   navigation:

--- a/plugins/messages/config/locales/fr.yml
+++ b/plugins/messages/config/locales/fr.yml
@@ -67,6 +67,9 @@ fr:
         Répondre: %{reply_url}
         Afficher ce message dans ton navigateur: %{msg_url}
         Préférences des messages: %{profile_url}
+      reply: Répondre
+      see_message_online: Afficher ce message dans ton navigateur
+      messaging_options: Préférences des messages
   simple_form:
     labels:
       settings:

--- a/plugins/messages/config/locales/nl.yml
+++ b/plugins/messages/config/locales/nl.yml
@@ -140,6 +140,9 @@ nl:
         Antwoorden: %{reply_url}
         Bericht online lezen: %{msg_url}
         Berichtinstellingen: %{profile_url}
+      reply: Antwoorden
+      see_message_online: Bericht online lezen
+      messaging_options: Berichtinstellingen
       footer_group: |
         Verzenden aan groep: %{group}
   navigation:


### PR DESCRIPTION
This introduces to possibility to send formatted messages and attachments with the messages plugin.

* [x] fix render attachment to actually display a link to attachement
* [x] scheduled cleanup for attachments
* [x] max file size
*~~[ ] test email reply with attachment, is it shown in foodsoft then?~~
  tried  around a bit but still not sure what's going on there, I'd guess the message data will just be shown as a plaintext.
  I think if this is a use case we can have a look at some other point ...

