### PR TITLE
Finance ordergroup sums

### DIFF
--- a/app/controllers/finance/ordergroups_controller.rb
+++ b/app/controllers/finance/ordergroups_controller.rb
@@ -11,7 +11,10 @@ class Finance::OrdergroupsController < Finance::BaseController
     @ordergroups = Ordergroup.undeleted.order(sort)
     @ordergroups = @ordergroups.include_transaction_class_sum
     @ordergroups = @ordergroups.where('groups.name LIKE ?', "%#{params[:query]}%") unless params[:query].nil?
-
     @ordergroups = @ordergroups.page(params[:page]).per(@per_page)
+
+    @total_balances = FinancialTransactionClass.sorted.each_with_object({}) do |c, tmp|
+      tmp[c.id] = c.financial_transactions.reduce(0) { | sum, t | sum + t.amount }
+    end
   end
 end

--- a/app/controllers/finance/ordergroups_controller.rb
+++ b/app/controllers/finance/ordergroups_controller.rb
@@ -14,7 +14,7 @@ class Finance::OrdergroupsController < Finance::BaseController
     @ordergroups = @ordergroups.page(params[:page]).per(@per_page)
 
     @total_balances = FinancialTransactionClass.sorted.each_with_object({}) do |c, tmp|
-      tmp[c.id] = c.financial_transactions.reduce(0) { | sum, t | sum + t.amount }
+      tmp[c.id] = c.financial_transactions.reduce(0) { |sum, t| sum + t.amount }
     end
   end
 end

--- a/app/views/finance/ordergroups/_ordergroups.html.haml
+++ b/app/views/finance/ordergroups/_ordergroups.html.haml
@@ -22,3 +22,12 @@
         %td
           = link_to t('.new_transaction'), new_finance_ordergroup_transaction_path(ordergroup), class: 'btn btn-mini'
           = link_to t('.account_statement'), finance_ordergroup_transactions_path(ordergroup), class: 'btn btn-mini'
+  %thead
+    %tr
+      %th= t 'Total'
+      %th
+      - FinancialTransactionClass.sorted.each do |c|
+        - name = FinancialTransactionClass.has_multiple_classes ? c.display : heading_helper(Ordergroup, :account_balance)
+        %th.numeric= format_currency @total_balances[c.id]
+      %th.numeric
+        = format_currency @total_balances.values.reduce(:+)

--- a/app/views/finance/ordergroups/_ordergroups.html.haml
+++ b/app/views/finance/ordergroups/_ordergroups.html.haml
@@ -28,6 +28,6 @@
       %th
       - FinancialTransactionClass.sorted.each do |c|
         - name = FinancialTransactionClass.has_multiple_classes ? c.display : heading_helper(Ordergroup, :account_balance)
-        %th.numeric= format_currency @total_balances[c.id]
-      %th.numeric
+        %th.numeric{:id => "total_balance#{c.id}"}= format_currency @total_balances[c.id]
+      %th.numeric#total_balance_sum
         = format_currency @total_balances.values.reduce(:+)

--- a/spec/controllers/finance/ordergroups_controller_spec.rb
+++ b/spec/controllers/finance/ordergroups_controller_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Finance::OrdergroupsController do
+  let(:user) { create(:user, :role_finance, :role_orders, :ordergroup) }
+  let(:fin_trans_type1) { create(:financial_transaction_type) }
+  let(:fin_trans_type2) { create(:financial_transaction_type) }
+  let(:fin_trans1) do
+    create(:financial_transaction,
+           user: user,
+           ordergroup: user.ordergroup,
+           financial_transaction_type: fin_trans_type1)
+  end
+  let(:fin_trans2) do
+    create(:financial_transaction,
+           user: user,
+           ordergroup: user.ordergroup,
+           financial_transaction_type: fin_trans_type1)
+  end
+  let(:fin_trans3) do
+    create(:financial_transaction,
+           user: user,
+           ordergroup: user.ordergroup,
+           financial_transaction_type: fin_trans_type2)
+  end
+
+  before { login user }
+
+  describe 'GET index' do
+    before do
+      fin_trans1
+      fin_trans2
+      fin_trans3
+    end
+
+    it 'renders index page' do
+      get_with_defaults :index
+      expect(response).to have_http_status(:success)
+      expect(response).to render_template('finance/ordergroups/index')
+    end
+
+    it 'calculates total balance sums correctly' do
+      get_with_defaults :index
+      expect(assigns(:total_balances).size).to eq(2)
+      expect(assigns(:total_balances)[fin_trans_type1.id]).to eq(fin_trans1.amount + fin_trans2.amount)
+      expect(assigns(:total_balances)[fin_trans_type2.id]).to eq(fin_trans3.amount)
+    end
+  end
+end

--- a/spec/controllers/finance/ordergroups_controller_spec.rb
+++ b/spec/controllers/finance/ordergroups_controller_spec.rb
@@ -49,8 +49,8 @@ describe Finance::OrdergroupsController do
       get_with_defaults :index
       expect(response).to have_http_status(:success)
 
-      assert_select "#total_balance#{fin_trans_type1.id}", number_to_currency(300)
-      assert_select "#total_balance#{fin_trans_type2.id}", number_to_currency(42.23)
+      assert_select "#total_balance#{fin_trans_type1.financial_transaction_class_id}", number_to_currency(300)
+      assert_select "#total_balance#{fin_trans_type2.financial_transaction_class_id}", number_to_currency(42.23)
       assert_select '#total_balance_sum', number_to_currency(342.23)
     end
   end

--- a/spec/controllers/finance/ordergroups_controller_spec.rb
+++ b/spec/controllers/finance/ordergroups_controller_spec.rb
@@ -3,24 +3,30 @@
 require 'spec_helper'
 
 describe Finance::OrdergroupsController do
+  include ActionView::Helpers::NumberHelper
+  render_views
+
   let(:user) { create(:user, :role_finance, :role_orders, :ordergroup) }
   let(:fin_trans_type1) { create(:financial_transaction_type) }
   let(:fin_trans_type2) { create(:financial_transaction_type) }
   let(:fin_trans1) do
     create(:financial_transaction,
            user: user,
+           amount: 100,
            ordergroup: user.ordergroup,
            financial_transaction_type: fin_trans_type1)
   end
   let(:fin_trans2) do
     create(:financial_transaction,
            user: user,
+           amount: 200,
            ordergroup: user.ordergroup,
            financial_transaction_type: fin_trans_type1)
   end
   let(:fin_trans3) do
     create(:financial_transaction,
            user: user,
+           amount: 42.23,
            ordergroup: user.ordergroup,
            financial_transaction_type: fin_trans_type2)
   end
@@ -37,14 +43,15 @@ describe Finance::OrdergroupsController do
     it 'renders index page' do
       get_with_defaults :index
       expect(response).to have_http_status(:success)
-      expect(response).to render_template('finance/ordergroups/index')
     end
 
     it 'calculates total balance sums correctly' do
       get_with_defaults :index
-      expect(assigns(:total_balances).size).to eq(2)
-      expect(assigns(:total_balances)[fin_trans_type1.id]).to eq(fin_trans1.amount + fin_trans2.amount)
-      expect(assigns(:total_balances)[fin_trans_type2.id]).to eq(fin_trans3.amount)
+      expect(response).to have_http_status(:success)
+
+      assert_select "#total_balance#{fin_trans_type1.id}", number_to_currency(300)
+      assert_select "#total_balance#{fin_trans_type2.id}", number_to_currency(42.23)
+      assert_select '#total_balance_sum', number_to_currency(342.23)
     end
   end
 end


### PR DESCRIPTION
This PR add's a sum row to the grouporder finance view. It allows to see the total sum for each financial transaction type and the total sum. This can be very useful for foodcoops to know how much money they should actually have on their bank account.

![grafik](https://github.com/foodcoops/foodsoft/assets/16109235/ebb6a331-9aa7-4492-8129-ddd8329ba837)
