### PR TITLE
Show the recipients in the thread view of messages.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ config/environments/development.rb
 nbproject/
 .*.sw?
 *~
+*.iml
 
 coverage
 tags

--- a/app/assets/stylesheets/bootstrap_and_overrides.css.less
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css.less
@@ -540,3 +540,7 @@ span.negative_amout {
 .deleted_row {
   text-decoration: line-through;
 }
+
+details {
+  cursor: pointer;
+}

--- a/plugins/messages/app/views/messages/thread.haml
+++ b/plugins/messages/app/views/messages/thread.haml
@@ -9,6 +9,11 @@
     .panel-heading
       %b= h(message.sender_name)
       = format_time(message.created_at)
+      %br
+      - # show the list of recipients in a expandable detail/summary panel
+      %details
+        %summary= t '.recipients'
+        = message.recipients.map(&:display).join(', ')
     .panel-body= simple_format(h(message.body))
 
 %p

--- a/plugins/messages/config/locales/de.yml
+++ b/plugins/messages/config/locales/de.yml
@@ -119,6 +119,7 @@ de:
     thread:
       all_message_threads: Alle Nachrichtenverläufe
       reply: Antworten
+      recipients: Empfänger_innen
     toggle_private:
       not_allowed: Du kannst die Sichtbarkeit dieser Nachricht nicht ändern.
   message_threads:

--- a/plugins/messages/config/locales/en.yml
+++ b/plugins/messages/config/locales/en.yml
@@ -119,6 +119,7 @@ en:
     thread:
       all_message_threads: All message threads
       reply: Reply
+      recipients: Recipients
     toggle_private:
       not_allowed: You can not change the visibility of the message.
   message_threads:

--- a/plugins/messages/config/locales/es.yml
+++ b/plugins/messages/config/locales/es.yml
@@ -119,6 +119,7 @@ es:
     thread:
       all_message_threads: Todos los hilos de mensaje
       reply: Responde
+      recipients: Destinatarios
     toggle_private:
       not_allowed: No puede cambiar la visibilidad del mensaje.
   message_threads:

--- a/plugins/messages/config/locales/nl.yml
+++ b/plugins/messages/config/locales/nl.yml
@@ -119,6 +119,7 @@ nl:
     thread:
       all_message_threads: Alle conversaties
       reply: Antwoord
+      recipients: Geadresseerden
     toggle_private:
       not_allowed: Je kunt de zichtbaarheid van het bericht niet wijzigen.
   message_threads:

--- a/plugins/messages/config/locales/tr.yml
+++ b/plugins/messages/config/locales/tr.yml
@@ -119,6 +119,7 @@ tr:
     thread:
       all_message_threads: Tüm mesaj konuları
       reply: Yanıtla
+      recipients: Alıcılar
     toggle_private:
       not_allowed: Mesajın görünürlüğünü değiştiremezsiniz.
   message_threads:


### PR DESCRIPTION
This PR shows the recipients of a message in the message thread view as an expandable summary/details panel.

I don't know yet how to handle translations, so I just added as much translations to the files as possible :-)

I added *.iml (Intellij-Project Files) to the .gitignore.