### PR TITLE
feat: only show shared suppliers that are allowed to be shown

### DIFF
--- a/app/models/shared_supplier.rb
+++ b/app/models/shared_supplier.rb
@@ -6,6 +6,7 @@ class SharedSupplier < ApplicationRecord
 
   has_many :suppliers, -> { undeleted }
   has_many :shared_articles, foreign_key: :supplier_id
+  default_scope { where(foodcoop: [FoodsoftConfig[:name], ""]) }
 
   def find_article_by_number(order_number)
     # NOTE: that `shared_articles` uses number instead order_number


### PR DESCRIPTION
[This SharedLists commit](https://github.com/foodcoops/sharedlists/commit/8b8afaaf0a2d26edee8c940a90a1b8e0707c558a) introduces a new *foodcoop* column at the SharedLists suppliers table.

The web interface will show a field that expects the name of a Foodcoop (has to be defined via `[FoodsoftConfig[:name]`). If the field is empty, the supplier will be show to all Foodsoft multisite instances.

If the field contains a string the Foodsoft will use it to filter out suppliers that are only allowed to be shown for a specific Foodcoop instance.

This MR introduces the filter at the Foodsoft side.

Closes #1033