### PR TITLE
allow_other_host for discourse plugin redirects

### DIFF
--- a/plugins/discourse/app/controllers/discourse_controller.rb
+++ b/plugins/discourse/app/controllers/discourse_controller.rb
@@ -13,7 +13,9 @@ class DiscourseController < ApplicationController
     base64_payload = Base64.strict_encode64 payload.to_query
     sso = CGI.escape base64_payload
     sig = get_hmac_hex_string base64_payload
-    redirect_to "#{url}#{url.include?('?') ? '&' : '?'}sso=#{sso}&sig=#{sig}"
+
+                             
+    redirect_to "#{url}#{url.include?('?') ? '&' : '?'}sso=#{sso}&sig=#{sig}", allow_other_host: true
   end
 
   def parse_payload

--- a/plugins/discourse/app/controllers/discourse_controller.rb
+++ b/plugins/discourse/app/controllers/discourse_controller.rb
@@ -13,8 +13,6 @@ class DiscourseController < ApplicationController
     base64_payload = Base64.strict_encode64 payload.to_query
     sso = CGI.escape base64_payload
     sig = get_hmac_hex_string base64_payload
-
-                             
     redirect_to "#{url}#{url.include?('?') ? '&' : '?'}sso=#{sso}&sig=#{sig}", allow_other_host: true
   end
 


### PR DESCRIPTION
Seems to be necessary to use the keyword allow_other_host: true for external redirects now. 