### PR TITLE
Add accounting buttons in order management views (usability enhancement)

### DIFF
--- a/app/views/orders/index.html.haml
+++ b/app/views/orders/index.html.haml
@@ -58,6 +58,8 @@
               %td
                 - unless order.stockit?
                   = receive_button order, class: 'btn-small'
+                - if current_user.role_finance?
+                  = link_to t('finance.balancing.orders.clear'), new_finance_order_path(order_id: order.id), class: 'btn btn-small btn-primary'
 
               %td
                 = link_to t('ui.copy'), new_order_path(order_id: order), class: 'btn btn-small'

--- a/app/views/orders/show.html.haml
+++ b/app/views/orders/show.html.haml
@@ -75,11 +75,14 @@
         - else
           = link_to t('.stock_order'), new_group_order_path(order_id: @order.id, stock_order: true), class: 'btn'
       = link_to t('ui.edit'), edit_order_path(@order), class: 'btn'
-    - elsif not @order.closed? and not @order.stockit?
-      = link_to t('.send_to_supplier'), send_result_to_supplier_order_path(@order), method: :post,
-        class: "btn#{' btn-primary' unless @order.last_sent_mail}",
-        data: {confirm: @order.last_sent_mail && t('.confirm_send_to_supplier', when: format_time(@order.last_sent_mail)) }
-      = receive_button @order
+    - elsif not @order.closed?
+      - unless @order.stockit?
+        = link_to t('.send_to_supplier'), send_result_to_supplier_order_path(@order), method: :post,
+          class: "btn#{' btn-primary' unless @order.last_sent_mail}",
+          data: {confirm: @order.last_sent_mail && t('.confirm_send_to_supplier', when: format_time(@order.last_sent_mail)) }
+        = receive_button @order
+      - if current_user.role_finance?
+        = link_to t('finance.balancing.orders.clear'), new_finance_order_path(order_id: @order.id), class: 'btn btn-primary'
     - unless @order.closed?
       = link_to t('ui.delete'), @order, data: {confirm: t('.confirm_delete')}, method: :delete,
         class: 'btn btn-danger'


### PR DESCRIPTION
I think it's useful to be able to jump directly to the accounting form of an order from the order management view, instead of having to look for it in `finances/account orders`. Especially if the order has been closed a while ago and moved down to page 2+ at `finances/account orders`. Also if you want to skip the receive form.

Of course, this button will only show up if the user has the finance role.
For stock orders, the `receive` button remains omitted since they can't be received.

![grafik](https://github.com/foodcoops/foodsoft/assets/22921479/b5f98138-c0c3-482a-8bed-9de17d0a6114)

![grafik](https://github.com/foodcoops/foodsoft/assets/22921479/bb1c0334-b3db-4ba1-b438-245809a1e70c)

![grafik](https://github.com/foodcoops/foodsoft/assets/22921479/1d1816b8-8337-4d38-827b-8c2a0bf04e3e)

What do you think? :)