### PR TITLE
Allow longer bank account descriptions

### DIFF
--- a/db/migrate/20240410093313_change_bank_account_desc.rb
+++ b/db/migrate/20240410093313_change_bank_account_desc.rb
@@ -1,5 +1,5 @@
 class ChangeBankAccountDesc < ActiveRecord::Migration[7.0]
   def change
-    change_column :bank_accounts, :description, :text, 
+    change_column :bank_accounts, :description, :text
   end
 end

--- a/db/migrate/20240410093313_change_bank_account_desc.rb
+++ b/db/migrate/20240410093313_change_bank_account_desc.rb
@@ -1,0 +1,5 @@
+class ChangeBankAccountDesc < ActiveRecord::Migration[7.0]
+  def change
+    change_column :bank_accounts, :description, :text, 
+  end
+end

--- a/db/migrate/20240410093313_change_bank_account_desc.rb
+++ b/db/migrate/20240410093313_change_bank_account_desc.rb
@@ -1,5 +1,9 @@
 class ChangeBankAccountDesc < ActiveRecord::Migration[7.0]
-  def change
+  def up
     change_column :bank_accounts, :description, :text
+  end
+
+  def down
+    change_column :bank_accounts, :description, :string
   end
 end


### PR DESCRIPTION
We recently got the following error:
```
An ActiveRecord::ValueTooLong occurred in bank_accounts#create:

Mysql2::Error: Data too long for column 'description' at row 1: INSERT INTO `bank_accounts` (`name`, `iban`, `description`) VALUES (...)
app/controllers/admin/bank_accounts_controller.rb:11:in `create'
```
Obviously someone tried to enter a long description for the bank account. At the moment the database field is of the type `varchar(255)`. This MR allows to enter longer descriptions.