### PR TITLE
Improve financial link feature & transaction links

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -208,7 +208,7 @@ Metrics/BlockNesting:
 # Offense count: 18
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 294
+  Max: 304
 
 # Offense count: 51
 # Configuration parameters: AllowedMethods, AllowedPatterns.

--- a/app/controllers/finance/balancing_controller.rb
+++ b/app/controllers/finance/balancing_controller.rb
@@ -80,7 +80,8 @@ class Finance::BalancingController < Finance::BaseController
   def close
     @order = Order.find(params[:id])
     @type = FinancialTransactionType.find_by_id(params.permit(:type)[:type])
-    @order.close!(@current_user, @type)
+    @link = FinancialLink.new if params[:create_financial_link]
+    @order.close!(@current_user, @type, @link, create_foodcoop_transaction: params[:create_foodcoop_transaction])
     redirect_to finance_order_index_url, notice: t('.notice')
   rescue StandardError => e
     redirect_to new_finance_order_url(order_id: @order.id), alert: t('.alert', message: e.message)

--- a/app/controllers/finance/financial_links_controller.rb
+++ b/app/controllers/finance/financial_links_controller.rb
@@ -13,10 +13,16 @@ class Finance::FinancialLinksController < Finance::BaseController
       }
     end
     @items += @financial_link.financial_transactions.map do |ft|
+      ft_note =
+        if ft.group_order
+          view_context.link_to ft.note, new_finance_order_path(order_id: ft.group_order.order.id)
+        else
+          ft.note
+        end
       {
         date: ft.created_on,
         type: t('activerecord.models.financial_transaction'),
-        description: "#{ft.ordergroup_name}: #{ft.note}",
+        description: "#{ft.ordergroup_name}: #{ft_note}",
         amount: ft.amount,
         link_to: finance_group_transactions_path(ft.ordergroup),
         remove_path: remove_financial_transaction_finance_link_path(@financial_link, ft)
@@ -80,8 +86,7 @@ class Finance::FinancialLinksController < Finance::BaseController
   end
 
   def index_financial_transaction
-    @financial_transactions = FinancialTransaction.without_financial_link.includes(:financial_transaction_type,
-                                                                                   :ordergroup)
+    @financial_transactions = FinancialTransaction.without_financial_link.includes(:financial_transaction_type, :ordergroup, :group_order)
   end
 
   def add_financial_transaction

--- a/app/views/admin/configs/_tab_payment.html.haml
+++ b/app/views/admin/configs/_tab_payment.html.haml
@@ -12,6 +12,7 @@
     = config_input_field form, :minimum_balance, as: :decimal, class: 'input-small'
 = config_input form, :charge_members_manually, as: :boolean
 = config_input form, :use_iban, as: :boolean
+= config_input form, :use_financial_links, as: :boolean
 = config_input form, :use_self_service, as: :boolean
 
 %h4= t '.schedule_title'

--- a/app/views/finance/balancing/confirm.html.haml
+++ b/app/views/finance/balancing/confirm.html.haml
@@ -9,6 +9,14 @@
       %tr{:class => cycle('even', 'odd')}
         %td= group_order.ordergroup_name
         %td.numeric= number_to_currency(group_order.total)
+  - if FoodsoftConfig[:use_financial_links]
+    %p
+      %label
+        = check_box_tag :create_financial_link, true, params.fetch(:create_financial_link, true)
+        = t('.create_financial_link')
+      %label
+        = check_box_tag :create_foodcoop_transaction, true, params.fetch(:create_foodcoop_transaction, true)
+        = t('.create_foodcoop_transaction', sum: number_to_currency(@order.sum(:groups)))
   .form-actions
     = submit_tag t('.clear'), class: 'btn btn-primary'
     = link_to t('.or_cancel'), new_finance_order_path(order_id: @order.id)

--- a/app/views/finance/financial_links/_index_financial_transaction.html.haml
+++ b/app/views/finance/financial_links/_index_financial_transaction.html.haml
@@ -7,6 +7,7 @@
       %tr
         %th= heading_helper FinancialTransaction, :created_on
         %th= heading_helper FinancialTransaction, :ordergroup
+        %th= heading_helper FinancialTransaction, :note
         - if FinancialTransactionType.has_multiple_types
           %th= heading_helper FinancialTransaction, :financial_transaction_type
         %th= heading_helper FinancialTransaction, :amount
@@ -15,6 +16,7 @@
         %tr
           %td= link_to format_time(t.created_on), add_financial_transaction_finance_link_path(@financial_link, financial_transaction: t.id), method: :put
           %td= t.ordergroup_name
+          %td= render 'finance/financial_transactions/order_note', financial_transaction:t, with_grouporder_link: false
           - if FinancialTransactionType.has_multiple_types
             %td= h t.financial_transaction_type.name
           %td= number_to_currency t.amount

--- a/app/views/finance/financial_links/show.html.haml
+++ b/app/views/finance/financial_links/show.html.haml
@@ -27,9 +27,9 @@
           - else
             = format_date item[:date]
         %td= item[:type]
-        %td= item[:description]
+        %td= sanitize item[:description]
         %td.numeric{style: 'width:5em'}= format_currency item[:amount]
-        %td= link_to t('ui.delete'), item[:remove_path], :data => {:confirm => t('ui.confirm_delete', name: item[:description])}, :method => :delete,
+        %td= link_to t('.remove_from_link'), item[:remove_path], :data => {:confirm => t('.remove_from_link_confirm')}, :method => :delete,
           class: 'btn btn-danger btn-mini'
 
 %p

--- a/app/views/finance/financial_transactions/_order_note.html.haml
+++ b/app/views/finance/financial_transactions/_order_note.html.haml
@@ -1,0 +1,9 @@
+- financial_transaction = local_assigns[:financial_transaction]
+- with_grouporder_link = local_assigns[:with_grouporder_link]
+- if financial_transaction.group_order
+  - if with_grouporder_link
+    = link_to financial_transaction.note, financial_transaction.group_order
+  - else
+    = link_to financial_transaction.note, new_finance_order_path(order_id: financial_transaction.group_order.order.id)
+- else
+  = financial_transaction.note

--- a/app/views/finance/financial_transactions/_transactions.html.haml
+++ b/app/views/finance/financial_transactions/_transactions.html.haml
@@ -1,6 +1,7 @@
 - with_ordergroup = local_assigns[:with_ordergroup]
 - with_hidden = local_assigns[:with_hidden]
 - with_csv = local_assigns[:with_csv]
+- with_grouporder_links = local_assigns[:with_grouporder_links]
 - with_payment = @financial_transactions.with_payment_plugin.any?
 .pull-right
   - if with_csv
@@ -36,7 +37,7 @@
     - @financial_transactions.each do |t|
       %tr{class: "#{'deleted_row' if t.hidden?}"}
         %td
-          - if t.financial_link
+          - if t.financial_link && current_user.role_finance?
             = link_to format_time(t.created_on), finance_link_path(t.financial_link)
           - else
             = format_time(t.created_on)
@@ -45,11 +46,7 @@
         %td= h show_user(t.user)
         - if FinancialTransactionType.has_multiple_types
           %td= h t.financial_transaction_type.name
-        %td
-          - if t.group_order
-            = link_to t.note, t.group_order
-          - else
-            = t.note
+        %td= render "finance/financial_transactions/order_note", financial_transaction:t, with_grouporder_link: with_grouporder_links
         - if with_payment
           %td= t.payment_plugin
           %td= t.payment_method

--- a/app/views/finance/financial_transactions/new_collection.html.haml
+++ b/app/views/finance/financial_transactions/new_collection.html.haml
@@ -68,16 +68,14 @@
   %p
     = link_to t('.new_ordergroup'), '#', 'data-add-transaction' => true, class: 'btn'
     = link_to t('.add_all_ordergroups'), '#', 'data-add-all-ordergroups' => true, class: 'btn'
-  - if FinancialTransaction.where(ordergroup: nil).any?
+  - if FoodsoftConfig[:use_financial_links]
     %p
       %label
-        = check_box_tag :create_foodcoop_transaction, true, params[:create_foodcoop_transaction]
-        = t('.create_foodcoop_transaction')
-  - if BankAccount.any?
-    %p
-      %label
-        = check_box_tag :create_financial_link, true, params[:create_financial_link]
+        = check_box_tag :create_financial_link, true, params.fetch(:create_financial_link, true)
         = t('.create_financial_link')
+      %label
+        = check_box_tag :create_foodcoop_transaction, true, params.fetch(:create_foodcoop_transaction, true)
+        = t('.create_foodcoop_transaction')
   %p
     - Ordergroup.custom_fields.each do |f|
       - if f[:financial_transaction_source]

--- a/app/views/finance/ordergroups/index.html.haml
+++ b/app/views/finance/ordergroups/index.html.haml
@@ -2,8 +2,8 @@
 
 - content_for :actionbar do
   = link_to t('.show_all'), finance_transactions_path, class: 'btn'
-  = link_to t('.show_foodcoop'), finance_foodcoop_financial_transactions_path, class: 'btn'
-  - if FinancialLink.any?
+  - if FoodsoftConfig[:use_financial_links]
+    = link_to t('.show_foodcoop'), finance_foodcoop_financial_transactions_path, class: 'btn'
     = link_to t('.new_financial_link'), finance_links_path, method: :post, class: 'btn'
   = link_to t('.new_transaction'), finance_new_transaction_collection_path, class: 'btn btn-primary'
 

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -85,7 +85,7 @@
             %td= h(show_user(ft.user))
             - if FinancialTransactionType.has_multiple_types
               %td= h(ft.financial_transaction_type.name)
-            %td= h(ft.note)
+            %td= h(render "finance/financial_transactions/order_note", financial_transaction:ft, with_grouporder_link: true)
             - if with_payment
               %td= h(ft.payment_state)
             - FinancialTransactionClass.sorted.each do |fc|

--- a/app/views/home/ordergroup.html.haml
+++ b/app/views/home/ordergroup.html.haml
@@ -31,4 +31,4 @@
         'data-submit-onchange' => true, class: 'form-search' do
         = text_field_tag :query, params[:query], class: 'input-medium search-query',
           placeholder: t('.search')
-    #transactions= render "finance/financial_transactions/transactions", with_csv: false
+    #transactions= render "finance/financial_transactions/transactions", with_csv: false, with_grouporder_links: true

--- a/config/app_config.yml.SAMPLE
+++ b/config/app_config.yml.SAMPLE
@@ -68,6 +68,24 @@ default: &defaults
   # not fully enforced right now, since the check is only client-side
   #minimum_balance: 0
 
+  # When you keep track of who received what elsewhere (e.g. on paper), and you don't want to
+  # enter this into Foodsoft, set this to true. You'll need to charge member accounts 
+  # manually (using "Add new transactions"). You still need to settle orders in the 
+  # balancing screen, but this will not charge any member accounts.
+  #charge_members_manually: true
+
+  # When enabled, supplier and user provide an additonal field for storing the international bank account number.
+  #use_iban: true
+
+  # When enabled, options to create financial links will be shown, which can group associated 
+  # financial transactions, invoices, and bank transactions. Also, options to create foodcoop transactions 
+  # will be shown (transactions which aren't assigned to any ordergroup, but serve as balancing entries 
+  # for double-entry accounting.)
+  #use_financial_links: true
+
+  # When enabled, members are able to use selected balancing functions on their own.
+  #use_self_service: true
+
   # how many days there are between two periodic tasks
   #tasks_period_days: 7
   # how many days upfront periodic tasks are created

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -632,6 +632,7 @@ de:
       use_apple_points: Wenn das Apfel Punktesystem aktiviert ist, ist es erforderlich, dass Mitglieder Aufgaben erledigen um bestellen zu können.
       use_boxfill: Wenn aktiviert, können Benutzer nahe am Ende der Bestellung diese nur mehr so verändern, dass sich die Gesamtsumme erhöht. Dies hilft beim auffüllen der verbleibenden Kisten. Es muss trotzdem noch das Kistenauffülldatum bei der Bestellung gesetzt werden.
       use_iban: Zusätzlich Feld für die internationale Kontonummer bei Benutzern und Lieferanten anzeigen
+      use_financial_links: Wenn aktiviert, werden Optionen zum Anlegen von Finanzlinks angezeigt, die zusammenhängende Kontotransaktionen, Rechnungen und Banktransaktionen gruppieren können. Außerdem werden Optionen zum Anlegen von Foodcoop-Transaktionen angezeigt (Transaktionen, die keiner Bestellgruppe zugeordnet sind, sondern als Ausgleichsbuchungen zwecks doppelter Buchführung dienen).
       use_nick: Benutzernamen anstatt reale Namen zeigen und verwenden, jeder Benutzer muss dazu einen Benutzernamen (Spitznamen) haben.
       use_self_service: Wenn aktiviert, können Benutzer_innen selbständig dafür freigegebene Abrechungsfunktionen nutzen.
       webstats_tracking_code: Tracking Code für Webseitenanalyse (wie Piwik oder Google Analytics), leer lassen wenn keine Analyse erfolgt
@@ -691,6 +692,7 @@ de:
       use_apple_points: Apfelpunkte verwenden
       use_boxfill: Kistenauffüllphase
       use_iban: IBAN verwenden
+      use_financial_links: Finanzlinks & Foodcoop-Transaktionen verwenden
       use_nick: Benutzernamen verwenden
       use_self_service: Selbstbedienung verwenden
       webstats_tracking_code: Code für Websiteanalysetool
@@ -792,6 +794,8 @@ de:
       confirm:
         clear: Abrechnen
         first_paragraph: 'Wenn die Bestellung abgerechnet wird, werden ebenfalls alle Gruppenkonten aktualisiert.<br />Die Konten werden wie folgt belastet:'
+        create_financial_link: Erstelle einen gemeinsamen Finanzlink für die neuen Transaktionen.
+        create_foodcoop_transaction: Erstelle eine Foodcoop-Transaktion mit der invertierten Summe (%{sum}).
         or_cancel: oder zurück zur Abrechnung
         title: Bestellung abrechnen
       edit_note:
@@ -886,11 +890,11 @@ de:
       notice: Rechnung wurde erstellt.
     financial_links:
       add_bank_transaction:
-        notice: Verlinkung wurde zu der Banktransaktion wurde hinzugefügt.
+        notice: Verlinkung zu der Banktransaktion wurde hinzugefügt.
       add_financial_transaction:
-        notice: Verlinkung wurde zu der Kontotransaktion wurde hinzugefügt.
+        notice: Verlinkung zu der Kontotransaktion wurde hinzugefügt.
       add_invoice:
-        notice: Verlinkung wurde zu der Rechnung wurde hinzugefügt.
+        notice: Verlinkung zu der Rechnung wurde hinzugefügt.
       create:
         notice: Ein neuer Finanzlink wurde erstellt.
       create_financial_transaction:
@@ -904,11 +908,11 @@ de:
       new_financial_transaction:
         title: Neue Kontotransaktion hinzufügen
       remove_bank_transaction:
-        notice: Verlinkung wurde zu der Banktransaktion wurde entfernt.
+        notice: Verlinkung zu der Banktransaktion wurde entfernt.
       remove_financial_transaction:
-        notice: Verlinkung wurde zu der Kontotransaktion wurde entfernt.
+        notice: Verlinkung zu der Kontotransaktion wurde entfernt.
       remove_invoice:
-        notice: Verlinkung wurde zu der Rechnung wurde entfernt.
+        notice: Verlinkung zu der Rechnung wurde entfernt.
       show:
         add_bank_transaction: Banktransaktion hinzufügen
         add_financial_transaction: Kontotransaktion hinzufügen
@@ -919,6 +923,8 @@ de:
         new_financial_transaction: Neue Kontotransaktion hinzufügen
         title: Finanzlink %{number}
         type: Typ
+        remove_from_link: Von Link entfernen
+        remove_from_link_confirm: Hierdurch wird die Transaktion nicht gelöscht, sondern nur vom Finanzlink entfernt. Möchtest du fortfahren?
     financial_transactions:
       controller:
         create:
@@ -934,29 +940,30 @@ de:
         last_updated_at: "(zuletzt aktualisiert vor %{when})"
         new_transaction: Neue Transaktion anlegen
         title: Kontoauszug für %{name}
+        title_foodcoop: Foodcoop-Kontoauszug
       index_collection:
         show_groups: Konten verwalten
         title: Kontotransaktionen
       new:
         paragraph: Hier kannst du der Bestellgruppe <b>%{name}</b> Geld gutschreiben/abziehen.
-        paragraph_foodcoop: Hier kannst du der <b>Foodcooop</b> Geld gutschreiben/abziehen.
+        paragraph_foodcoop: Hier kannst du der <b>Foodcoop</b> Geld gutschreiben/abziehen.
         title: Neue Transaktion
       new_collection:
         add_all_ordergroups: Alle Bestellgruppen hinzufügen
         add_all_ordergroups_custom_field: Alle Bestellgruppen mit %{label} hinzufügen
         create_financial_link: Erstelle einen gemeinsamen Finanzlink für die neuen Transaktionen.
-        create_foodcoop_transaction: Erstelle einen Transaktion mit der der invertieten Summe für die Foodcoop (für den Fall der "doppelte Buchführung")
+        create_foodcoop_transaction: Erstelle eine Foodcoop-Transaktion mit der invertierten Summe (für den Fall der "doppelten Buchführung")
         new_ordergroup: Weitere Bestellgruppe hinzufügen
         save: Transaktionen speichern
         set_balance: Setze den Kontostand der Bestellgruppe auf den eingegebenen Betrag.
-        sidebar: Hier kannst Du mehrere Konten gleichzeitig aktualsieren. Z.B. alle Überweisungen der Bestellgruppen aus einem Kontoauszug.
+        sidebar: Hier kannst Du mehrere Konten gleichzeitig aktualisieren. Z.B. alle Überweisungen der Bestellgruppen aus einem Kontoauszug.
         title: Mehrere Konten aktualisieren
       ordergroup:
         remove: Entfernen
         remove_group: Gruppe enfernen
       transactions:
-        confirm_revert: Wills du %{name} wirklich rückgängig machen? Hierbei wird eine zusätzliche Transaktion mit dem invertierten Betrag hinzugefügt und gemeinsam mit der originalen Transaktion versteckt. Diese versteckten Transaktionen sind nur über die Option 'Versteckte anzeigen' sichtbar und können von normalen Benutzer_innen überhaupt nicht angezeigt werden.
-        revert_title: Transaktion rückgängig machen, um sie vor normalen Benutzer_innen versteckt.
+        confirm_revert: Willst du %{name} wirklich rückgängig machen? Hierbei wird eine zusätzliche Transaktion mit dem invertierten Betrag hinzugefügt und gemeinsam mit der originalen Transaktion versteckt. Diese versteckten Transaktionen sind nur über die Option 'Versteckte anzeigen' sichtbar und können von normalen Benutzer_innen überhaupt nicht angezeigt werden.
+        revert_title: Transaktion rückgängig machen und vor normalen Benutzer_innen verstecken.
       transactions_search:
         show_hidden: Versteckte anzeigen
     index:
@@ -990,7 +997,7 @@ de:
         new_financial_link: Neuer Finanzlink
         new_transaction: Neue Überweisungen eingeben
         show_all: Alle Transaktionen
-        show_foodcoop: Foodcoop Transaktionen
+        show_foodcoop: Foodcoop-Transaktionen
         title: Konten verwalten
       ordergroups:
         account_statement: Kontoauszug

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -632,6 +632,7 @@ en:
       use_apple_points: When the apple point system is enabled, members are required to do some tasks to be able to keep ordering.
       use_boxfill: When enabled, near end of an order, members are only able to change their order when increases the total amount ordered. This helps to fill any remaining boxes. You still need to set a box-fill date for the orders.
       use_iban: When enabled, supplier and user provide an additonal field for storing the international bank account number.
+      use_financial_links: When enabled, options to create financial links will be shown, which can group associated financial transactions, invoices, and bank transactions. Also, options to create foodcoop transactions will be shown (transactions which aren't assigned to any ordergroup, but serve as balancing entries for double-entry accounting.)
       use_nick: Show and use nicknames instead of real names. When enabling this, please check that each user has a nickname.
       use_self_service: When enabled, members are able to use selected balancing functions on their own.
       webstats_tracking_code: Tracking code for web analytics (like Piwik or Google analytics). Leave empty for no tracking.
@@ -691,6 +692,7 @@ en:
       use_apple_points: Apple points
       use_boxfill: Box-fill phase
       use_iban: Use IBAN
+      use_financial_links: Use financial links & foodcoop transactions
       use_nick: Use nicknames
       use_self_service: Use self service
       webstats_tracking_code: Tracking code
@@ -792,6 +794,8 @@ en:
       confirm:
         clear: Settle
         first_paragraph: 'When the order is settled, all group accounts will be updated.<br />The accounts will be charged as follows:'
+        create_financial_link: Create a common financial link for the new transactions.
+        create_foodcoop_transaction: Create a foodcoop transaction with the inverted sum (%{sum}).
         or_cancel: or back to accounting
         title: Settle order
       edit_note:
@@ -919,6 +923,8 @@ en:
         new_financial_transaction: New financial transaction
         title: Financial link %{number}
         type: Type
+        remove_from_link: Remove from link
+        remove_from_link_confirm: This won't delete the transaction, but only remove it from the link. Do you want to proceed?
     financial_transactions:
       controller:
         create:
@@ -934,6 +940,7 @@ en:
         last_updated_at: "(last updated %{when} ago)"
         new_transaction: Create new transaction
         title: Account statement for %{name}
+        title_foodcoop: Foodcoop account statement
       index_collection:
         show_groups: Manage accounts
         title: Financial transactions
@@ -990,7 +997,7 @@ en:
         new_financial_link: New financial link
         new_transaction: Add new transactions
         show_all: All transactions
-        show_foodcoop: Foodcoop transaktions
+        show_foodcoop: Foodcoop transactions
         title: Manage accounts
       ordergroups:
         account_statement: Account statement

--- a/db/migrate/20240404004950_add_use_financial_links_setting.rb
+++ b/db/migrate/20240404004950_add_use_financial_links_setting.rb
@@ -1,0 +1,9 @@
+class AddUseFinancialLinksSetting < ActiveRecord::Migration[7.0]
+  def up
+    FoodsoftConfig[:use_financial_links] = true if FinancialLink.any? || FinancialTransaction.where(ordergroup: nil).any?
+  end
+
+  def down
+    FoodsoftConfig[:use_financial_links] = nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_26_111615) do
+ActiveRecord::Schema[7.0].define(version: 2024_04_04_004950) do
   create_table "action_text_rich_texts", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.string "name", null: false
     t.text "body", size: :long


### PR DESCRIPTION
- add a config option "use_financial_links" for activating both finance links and foodcoop transaction features
- add migration: set this option to true if any financial link or foodcoop transaction exists
- add options to create a financial link and/or foodcoop transaction when balancing an order
- show links to finance links only to users with finance role (required anyway, but links were shown in home/ordergroup)
- add note column when adding a financial transaction to a link
- financial transactions: show link to group_order only in `home/ordergroup` and (additionally) dashboard; replace with link to order's balancing page in finance views
- finance link: show link in financial transaction note to respective order's balancing page (also when adding a financial transaction)
- finance link: replace misleading "delete" button for removing a transaction with "remove from link", also adapt confirm message
- adapt en/de locales, fix finance-related locale typos

Notes:
- I wonder if the additional if/else conditions per row (in multiple views) will have a noticeable effect on performance if there are a lot of rows. I couldn't test this as the performance is horrible anyway in my local docker environment.
- Foodcoop transactions don't show links to the respective order since they don't belong to a group_order and don't have a relation to `order` either. I thought about adding the relation, but I think it's unnecessary to add a column in the db just for foodcoop transactions, as you can go to the order with one additional click (by opening the financial link and clicking on a non-foodcoop transaction).
- I tried to outsource the code for the _transaction note with order link_ to a new template `finance/financial_transactions/_order_note`, but I couldn't call it from financial_links_controller. See comment for details.

Implementation of #848
Replaces #860