### PR TITLE
Preselect more fields when creating new user

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -45,8 +45,15 @@ class User < ApplicationRecord
 
   before_validation :set_password
   after_initialize do
-    settings.defaults['profile']  = { 'language' => I18n.default_locale } unless settings.profile
-    settings.defaults['messages'] = { 'send_as_email' => true }           unless settings.messages
+    unless settings.profile
+      settings.defaults['profile'] = { 'language' => FoodsoftConfig[:default_locale] || I18n.default_locale } unless settings.profile
+      if FoodsoftConfig[:profile_data_public_by_default]
+        settings.defaults['profile']['phone_is_public'] = true
+        settings.defaults['profile']['email_is_public'] = true
+        settings.defaults['profile']['name_is_public'] = true
+      end
+    end
+    settings.defaults['messages'] = { 'send_as_email' => true } unless settings.messages
     settings.defaults['notify']   = { 'upcoming_tasks' => true } unless settings.notify
   end
 

--- a/app/views/admin/configs/_tab_others.html.haml
+++ b/app/views/admin/configs/_tab_others.html.haml
@@ -1,4 +1,5 @@
 = config_input form, :use_nick, as: :boolean
+= config_input form, :profile_data_public_by_default, as: :boolean
 = config_input form, :tolerance_is_costly, as: :boolean
 - distribution_strategy_options = FoodsoftConfig::DistributionStrategy.constants.map { |c| FoodsoftConfig::DistributionStrategy.const_get(c) }
 = config_input form, :distribution_strategy, as: :select, collection: distribution_strategy_options,

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -633,6 +633,7 @@ de:
       use_boxfill: Wenn aktiviert, können Benutzer nahe am Ende der Bestellung diese nur mehr so verändern, dass sich die Gesamtsumme erhöht. Dies hilft beim auffüllen der verbleibenden Kisten. Es muss trotzdem noch das Kistenauffülldatum bei der Bestellung gesetzt werden.
       use_iban: Zusätzlich Feld für die internationale Kontonummer bei Benutzern und Lieferanten anzeigen
       use_nick: Benutzernamen anstatt reale Namen zeigen und verwenden, jeder Benutzer muss dazu einen Benutzernamen (Spitznamen) haben.
+      profile_data_public_by_default: Beim Anlegen einer neuen Benutzer:in werden bei den Privatsphäre-Optionen "Telefon/E-Mail/Name ist für Mitglieder sichtbar" standardmäßig Haken gesetzt. Wenn Benutzernamen deaktiviert sind, sind Namen immer für alle sichtbar.
       use_self_service: Wenn aktiviert, können Benutzer_innen selbständig dafür freigegebene Abrechungsfunktionen nutzen.
       webstats_tracking_code: Tracking Code für Webseitenanalyse (wie Piwik oder Google Analytics), leer lassen wenn keine Analyse erfolgt
     keys:
@@ -692,6 +693,7 @@ de:
       use_boxfill: Kistenauffüllphase
       use_iban: IBAN verwenden
       use_nick: Benutzernamen verwenden
+      profile_data_public_by_default: Profildaten standardmäßig für andere sichtbar
       use_self_service: Selbstbedienung verwenden
       webstats_tracking_code: Code für Websiteanalysetool
     tabs:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -633,6 +633,7 @@ en:
       use_boxfill: When enabled, near end of an order, members are only able to change their order when increases the total amount ordered. This helps to fill any remaining boxes. You still need to set a box-fill date for the orders.
       use_iban: When enabled, supplier and user provide an additonal field for storing the international bank account number.
       use_nick: Show and use nicknames instead of real names. When enabling this, please check that each user has a nickname.
+      profile_data_public_by_default: When creating a new user, the pricacy options "Phone number / Email / Name is visible for other members" will be checked by default. If nicknames are disabled, name will be visible either way.
       use_self_service: When enabled, members are able to use selected balancing functions on their own.
       webstats_tracking_code: Tracking code for web analytics (like Piwik or Google analytics). Leave empty for no tracking.
     keys:
@@ -692,6 +693,7 @@ en:
       use_boxfill: Box-fill phase
       use_iban: Use IBAN
       use_nick: Use nicknames
+      profile_data_public_by_default: Profile data visible to others by default
       use_self_service: Use self service
       webstats_tracking_code: Tracking code
     tabs:


### PR DESCRIPTION
- use default language from config to preselect language of new user
- add config option "profile_data_public_by_default"; if enabled, the privacy options ("phone/email/name is public") will be pre-checked when creating a new user

In my experience, admins easily forget to set all options correctly when creating a new user. This lead to many users having their language set to English although a translation exists (but often they don't know that they can change it or how) or unintentionally having their phone and email private (i.e. only visible to admins), which really hampers communication within the coop.

I chose to create only one config option for all three privacy options in order not to create too many config options.

One questionable consequence of this is that, if the config option is enabled, created users will have the setting "name is visible" set to true (visible in the admin/users/show view) even if nicknames are disabled, so "name is visible" is irrelevant. This also means, if you later enable nicknames, the names of the respective users will remain visible (unless changed in their profiles), which I think is good.