### PR TITLE
fix: Add missing migration for articles table

### DIFF
--- a/db/migrate/20240712072045_add_max_quantity_to_articles.rb
+++ b/db/migrate/20240712072045_add_max_quantity_to_articles.rb
@@ -1,0 +1,5 @@
+class AddMaxQuantityToArticles < ActiveRecord::Migration[7.0]
+  def change
+    add_column :articles, :max_quantity, :integer
+  end
+end


### PR DESCRIPTION
"max_quantity" column was introduced with v4.9
This commit adds the missing migration