### PR TITLE
Fix: List attributes to allow to search for SharedArticles

### DIFF
--- a/app/models/shared_article.rb
+++ b/app/models/shared_article.rb
@@ -6,6 +6,10 @@ class SharedArticle < ApplicationRecord
 
   belongs_to :shared_supplier, foreign_key: :supplier_id
 
+  def self.ransackable_attributes(_auth_object = nil)
+    %w[category created_on deposit id manufacturer name note number origin price scale_price scale_quantity supplier_id tax unit unit_quantity updated_on]
+  end
+
   def build_new_article(supplier)
     supplier.articles.build(
       name: name,


### PR DESCRIPTION
Without this list the application throws an error message if one tries to search for articles to be imported from a shared suppliers.

From the error message:
`Ransack needs SharedArticle attributes explicitly allowlisted as searchable`