### PR TITLE
feat: group_order form show a button to my_order_group when insufficient funds

### DIFF
--- a/app/assets/javascripts/ordering.js
+++ b/app/assets/javascripts/ordering.js
@@ -184,8 +184,13 @@ function updateBalance() {
     if (balance < minimumBalance) {
         bgcolor = '#FF0000';
         $('#submit_button').attr('disabled', 'disabled')
+        $('#submit_button').attr('title', I18n.t('js.ordering.balance_too_low'));
+        $('#submit_button').css('background-color', '#ABABAB');
+        $('#account-statement-button').removeClass('hidden');
+
     } else {
         $('#submit_button').removeAttr('disabled')
+        $('#account-statement-button').addClass('hidden');
     }
     // update bgcolor
     for (i in itemTotal) {

--- a/app/views/group_orders/_form.html.haml
+++ b/app/views/group_orders/_form.html.haml
@@ -173,8 +173,9 @@
           %td.currency
             %strong
               %span#new_balance= number_to_currency(old_balance - @group_order.price)
-      #order-button
+      %span#order-button
         = submit_tag( t('.action_save'), id: 'submit_button', class: 'btn btn-primary' )
-        #{link_to t('ui.or_cancel'), group_orders_path}
+        = link_to t('.account_statement'), my_ordergroup_path, class: 'btn btn-secondary btn-small hidden', id: 'account-statement-button'
+      #{link_to t('ui.or_cancel'), group_orders_path}
   %input#total_balance{name: "total_balance", type: "hidden", value: @ordergroup.account_balance - @group_order.price}/
   %input{name: "version", type: "hidden", value: @version}/

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1054,6 +1054,7 @@ de:
       notfound: Fehlerhafte URL, das ist nicht Deine Bestellung.
     form:
       action_save: Bestellung speichern
+      account_statement: Kontostand
       new_funds: Neuer Kontostand
       price: Preis
       reset_article_search: Suche zurücksetzen

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1054,6 +1054,7 @@ en:
       notfound: Incorrect URL, this is not your order.
     form:
       action_save: Save order
+      account_statement: Account Statement
       new_funds: New account balance
       price: Price
       reset_article_search: Reset search

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1045,6 +1045,7 @@ es:
       notfound: Enlace incorrecto, este no es tu pedido
     form:
       action_save: Guardar pedido
+      account_statement: Estado de cuenta
       new_funds: Nuevo balance de cuenta
       price: Precio
       reset_article_search: Reinicia la búsqueda

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -669,6 +669,7 @@ fr:
       notfound: ' Mauvaise adresse, ce n''est pas ta commande.'
     form:
       action_save: Enregistrer ta commande
+      account_statement: Relevé de compte
       new_funds: Nouveau solde
       price: Prix
       reset_article_search: Réinitialiser la recherche

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -1045,6 +1045,7 @@ nl:
       notfound: Foute URL, dit is niet jouw bestelling.
     form:
       action_save: Bestelling opslaan
+      account_statement: Rekeningafschrift
       new_funds: Nieuw tegoed
       price: Prijs
       reset_article_search: Alles tonen

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -1044,6 +1044,7 @@ tr:
       notfound: Yanlış URL, bu sizin siparişiniz değil.
     form:
       action_save: Siparişi kaydet
+      account_statement: Hesap Özeti
       new_funds: Yeni hesap bakiyesi
       price: Fiyat
       reset_article_search: Arama sıfırla


### PR DESCRIPTION
This adds a "Account Statement" button to the footer in a group-order-form. When a ordergroup has insufficient funds for this order, the order button is disabled and the Account-Statement button is shown. It'll redirect to /home/ordergroup. 

![image](https://github.com/user-attachments/assets/70ca3458-227d-457a-aeaf-8c94ed97e15d)
