### PR TITLE
correct invoice balance with stock orders and deliveries 

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -31,21 +31,29 @@ class Invoice < ApplicationRecord
   end
 
   def orders_sum
-    orders
-      .joins(order_articles: [:article_price])
-      .sum('COALESCE(order_articles.units_received, order_articles.units_billed, order_articles.units_to_order)' \
-        + '* article_prices.unit_quantity' \
-        + '* ROUND((article_prices.price + article_prices.deposit) * (100 + article_prices.tax) / 100, 2)')
+    sum = 0
+    for order in orders 
+      sum += order.sum(:groups) 
+    end
+    sum
   end
 
   def orders_transport_sum
     orders.sum(:transport)
   end
-
+  
+  def deliveries_sum
+    sum = 0
+    for delivery in deliveries
+      sum += delivery.sum
+    end
+    sum
+  end
+  
   def expected_amount
     return net_amount unless orders.any?
 
-    orders_sum + orders_transport_sum
+    orders_sum + orders_transport_sum + deliveries_sum
   end
 
   protected

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -220,7 +220,7 @@ class Order < ApplicationRecord
         end
       end
     elsif %i[groups groups_without_markup].include?(type)
-      for go in group_orders.includes(group_order_articles: { order_article: %i[article article_price] })
+      for go in group_orders.includes(group_order_articles: { order_article: %i[article article_price] }).where.not(ordergroup: nil)
         for goa in go.group_order_articles
           case type
           when :groups

--- a/app/views/finance/invoices/show.html.haml
+++ b/app/views/finance/invoices/show.html.haml
@@ -28,12 +28,15 @@
         %dt= heading_helper(Invoice, :orders) + ':'
         %dd><
           - @invoice.orders.order(:ends).each_with_index do |order, index|
+            - sum_og = order.sum(:groups) 
             - sum = order.sum
             - transport = order.transport || 0
-            - total += sum + transport
+            - total += sum_og + transport
             = ', ' if index > 0
             = link_to format_date(order.ends), new_finance_order_path(order_id: order)
-            = ' (' + number_to_currency(sum)
+            = ' (' + number_to_currency(sum_og) 
+            - if sum_og < sum 
+              = ' / ' + number_to_currency(sum)
             - if transport != 0
               = ' + ' + number_to_currency(transport)
             = ')'


### PR DESCRIPTION
According to issue https://github.com/foodcoops/foodsoft/issues/1074, stock orders and deliveries were not correctly considered in invoice balances (invoice view and unpaid invoices), leading to unbalanced invoices in case of deliveries and/or stock orders. 

This patch includes:

- generally ignore stock orders when calculating the groups-sum for an order, since no order-group is charged for it
- invoice view: for the total amount, use only the order sums without stock orders, but display both sums for orders if the sums differ (without/with stock order)
- invoice class: exclude stock orders from orders_sum, new deliveries_sum, consider both orders_sum and deliveries_sum in expected_amount
