### PR TITLE
order balancing add group to article: sort ordergroup names alphabetically

### DIFF
--- a/app/views/group_order_articles/_form.html.haml
+++ b/app/views/group_order_articles/_form.html.haml
@@ -4,7 +4,7 @@
     = close_button :modal
     %h3= t('.amount_change_for', article: @order_article.article.name)
   .modal-body
-    = form.input :ordergroup_id, as: :select, collection: Ordergroup.undeleted.map { |g| [g.name, g.id] }
+    = form.input :ordergroup_id, as: :select, collection: Ordergroup.undeleted.map { |g| [g.name, g.id] }.sort_by { |name, id| name.downcase }
     = form.input :result, hint: I18n.t('group_order_articles.form.result_hint', unit: @order_article.article.unit) # Why do we need the full prefix?
   .modal-footer
     = link_to t('ui.close'), '#', class: 'btn', data: {dismiss: 'modal'}


### PR DESCRIPTION
In finance > balance orders > article > add ordergroup, the name of the ordergroups is sorted by id, not by name. this makes it hard to find a specific ordergroup in foodcoops with a larger number of ordergroups. An alphabetical sequencing would make it much easier.

actual sorting:
![grafik](https://github.com/user-attachments/assets/a503a16c-779a-44fb-8a12-47cb5851aa2d)


as proposed in this PR:
![grafik](https://github.com/user-attachments/assets/648fe0aa-1890-4d8a-b7f5-4884042d77df)
