### PR TITLE
create fincancial link for invoice

### DIFF
--- a/app/controllers/finance/financial_links_controller.rb
+++ b/app/controllers/finance/financial_links_controller.rb
@@ -46,6 +46,9 @@ class Finance::FinancialLinksController < Finance::BaseController
     if params[:bank_transaction]
       bank_transaction = BankTransaction.find(params[:bank_transaction])
       bank_transaction.update_attribute :financial_link, @financial_link
+    elsif params[:invoice]
+      invoice = Invoice.find(params[:invoice])
+      invoice.update_attribute :financial_link, @financial_link
     end
     redirect_to finance_link_url(@financial_link), notice: t('.notice')
   end

--- a/app/views/finance/invoices/show.html.haml
+++ b/app/views/finance/invoices/show.html.haml
@@ -74,9 +74,11 @@
       %dt= heading_helper(Invoice, :note) + ':'
       %dd= simple_format(@invoice.note)
 
+      %dt= heading_helper(Invoice, :financial_link) + ':'
       - if @invoice.financial_link
-        %dt= heading_helper(Invoice, :financial_link) + ':'
         %dd= link_to t('ui.show'), finance_link_path(@invoice.financial_link)
+      - else 
+        %dd= link_to t('finance.bank_transactions.transactions.add_financial_link'), finance_links_path(invoice: @invoice.id),  method: :post, class: 'btn btn-success btn-mini'
 
     .clearfix
       .form-actions


### PR DESCRIPTION
Currently, financial links can only be created for bank transactions. In this PR, a "add finance link" button is added to the invoice view unless there is already a finance link.
![grafik](https://github.com/user-attachments/assets/9a8cd0f6-0c58-4f6d-b2e8-cda997ef5ab5)

This is useful if invoices are not paid from the bank account of the foodcoop, but from a foodcoop member (e.g. by  credit card). In this case, a foodcoop transaction is required instead of a bank transaction to pay the invoice by crediting the invoice amount to the foodcoop member. After creating a finance link for the invoice, a foodcoop transaction can be easily generated and linked to the invoice.

![grafik](https://github.com/user-attachments/assets/24d192b2-bf23-4c68-895f-c316bda49ab2)
