### PR TITLE
always include foodcoop as parameter to a workerjob

### DIFF
--- a/config/initializers/active_job_select_foodcoop.rb
+++ b/config/initializers/active_job_select_foodcoop.rb
@@ -10,9 +10,25 @@ module FoodsoftActiveJobArguments
       end
 
       def deserialize(arguments)
-        FoodsoftConfig.select_multifoodcoop arguments.shift
+        FoodsoftConfig.select_multifoodcoop arguments[0]
         orig_deserialize(arguments)
       end
+    end
+  end
+end
+
+module ActiveJob
+  module Execution
+    # Store the original `_perform_job` method
+    original_perform_job = instance_method(:_perform_job)
+
+    # Override the `_perform_job` method
+    define_method(:_perform_job) do
+      foodsoft_scope = @arguments.shift
+      FoodsoftConfig.select_foodcoop foodsoft_scope
+
+      # Call the original `_perform_job` method
+      original_perform_job.bind(self).call
     end
   end
 end


### PR DESCRIPTION
* the way it was before failed jobs wouldn't run correctly anymore after the had failed because of the wrong scope
* now it is a bit more explicit but jobs can be re-run