### PR TITLE
Fix/run send to supplier as job

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -136,7 +136,7 @@ class OrdersController < ApplicationController
 
         flash[:notice] = (s ? I18n.t('orders.receive.notice', msg: s) : I18n.t('orders.receive.notice_none'))
       end
-      NotifyReceivedOrderJob.perform_later(@order)
+      NotifyReceivedOrderJob.perform_later(FoodsoftConfig.scope,@order)
       if current_user.role_orders? || current_user.role_finance?
         redirect_to @order
       elsif current_user.role_pickups?

--- a/app/jobs/notify_finished_order_job.rb
+++ b/app/jobs/notify_finished_order_job.rb
@@ -1,5 +1,6 @@
 class NotifyFinishedOrderJob < ApplicationJob
-  def perform(order)
+  def perform(foodcoop,order)
+    FoodsoftConfig.select_multifoodcoop foodcoop
     order.group_orders.each do |group_order|
       next unless group_order.ordergroup
 

--- a/app/jobs/notify_negative_balance_job.rb
+++ b/app/jobs/notify_negative_balance_job.rb
@@ -1,5 +1,6 @@
 class NotifyNegativeBalanceJob < ApplicationJob
-  def perform(ordergroup, transaction)
+  def perform(foodcoop,ordergroup, transaction)
+    FoodsoftConfig.select_multifoodcoop foodcoop
     ordergroup.users.each do |user|
       next unless user.settings.notify['negative_balance']
 

--- a/app/jobs/notify_received_order_job.rb
+++ b/app/jobs/notify_received_order_job.rb
@@ -1,5 +1,6 @@
 class NotifyReceivedOrderJob < ApplicationJob
-  def perform(order)
+  def perform(foodcoop,order)
+    FoodsoftConfig.select_multifoodcoop foodcoop
     order.group_orders.each do |group_order|
       next unless group_order.ordergroup
 

--- a/app/jobs/send_order_to_supplier_job.rb
+++ b/app/jobs/send_order_to_supplier_job.rb
@@ -1,0 +1,8 @@
+class SendOrderToSupplierJob < ApplicationJob
+  def perform(order)
+    Mailer.deliver_now_with_default_locale do
+      Mailer.order_result_supplier(order.created_by, order)
+    end
+    order.update!(last_sent_mail: Time.now)
+  end
+end

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -149,9 +149,10 @@ class Mailer < ActionMailer::Base
 
   def self.deliver_now
     message = yield
-    message.deliver_now
+    message.deliver_now!
   rescue StandardError => e
     MailDeliveryStatus.create email: message.to[0], message: e.message
+    raise StandardError, e.message
   end
 
   # separate method to allow plugins to mess with the attachments

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -266,7 +266,7 @@ class Order < ApplicationRecord
       ordergroups.each(&:update_stats!)
 
       # Notifications
-      NotifyFinishedOrderJob.perform_later(self)
+      NotifyFinishedOrderJob.perform_later(FoodsoftConfig.scope,self)
     end
   end
 

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -311,10 +311,7 @@ class Order < ApplicationRecord
   end
 
   def send_to_supplier!(user)
-    Mailer.deliver_now_with_default_locale do
-      Mailer.order_result_supplier(user, self)
-    end
-    update!(last_sent_mail: Time.now)
+    SendOrderToSupplierJob.perform_later(FoodsoftConfig.scope,self)
   end
 
   def do_end_action!

--- a/app/models/ordergroup.rb
+++ b/app/models/ordergroup.rb
@@ -91,7 +91,7 @@ class Ordergroup < Group
       t.save!
       update_balance!
       # Notify only when order group had a positive balance before the last transaction:
-      NotifyNegativeBalanceJob.perform_later(self, t) if t.amount < 0 && account_balance < 0 && account_balance - t.amount >= 0
+      NotifyNegativeBalanceJob.perform_later(FoodsoftConfig.scope,self, t) if t.amount < 0 && account_balance < 0 && account_balance - t.amount >= 0
       t
     end
   end

--- a/config/initializers/active_job_select_foodcoop.rb
+++ b/config/initializers/active_job_select_foodcoop.rb
@@ -4,13 +4,8 @@ module FoodsoftActiveJobArguments
       alias_method :orig_deserialize, :deserialize
       alias_method :orig_serialize, :serialize
 
-      def serialize(arguments)
-        ret = orig_serialize(arguments)
-        ret.unshift FoodsoftConfig.scope
-      end
-
       def deserialize(arguments)
-        FoodsoftConfig.select_multifoodcoop arguments.shift
+        FoodsoftConfig.select_multifoodcoop arguments[0]
         orig_deserialize(arguments)
       end
     end

--- a/plugins/messages/app/controllers/messages_controller.rb
+++ b/plugins/messages/app/controllers/messages_controller.rb
@@ -33,7 +33,7 @@ class MessagesController < ApplicationController
   def create
     @message = @current_user.send_messages.new(params[:message])
     if @message.save
-      DeliverMessageJob.perform_later(@message)
+      DeliverMessageJob.perform_later(FoodsoftConfig.scope,@message)
       redirect_to messages_url, notice: I18n.t('messages.create.notice')
     else
       render action: 'new'

--- a/plugins/messages/app/jobs/deliver_message_job.rb
+++ b/plugins/messages/app/jobs/deliver_message_job.rb
@@ -1,5 +1,6 @@
 class DeliverMessageJob < ApplicationJob
-  def perform(message)
+  def perform(foodcoop,message)
+    FoodsoftConfig.select_multifoodcoop foodcoop
     message.message_recipients.each do |message_recipient|
       recipient = message_recipient.user
       if recipient.receive_email?

--- a/plugins/messages/app/mail_receivers/messages_mail_receiver.rb
+++ b/plugins/messages/app/mail_receivers/messages_mail_receiver.rb
@@ -48,7 +48,7 @@ class MessagesMailReceiver
     message.add_recipients [@message.sender_id]
 
     message.save!
-    DeliverMessageJob.perform_later(message)
+    DeliverMessageJob.perform_later(FoodsoftConfig.scope,message)
   end
 
   private


### PR DESCRIPTION
This pull request depends on #1083.

* it will run the send_to_supplier mail in a job
* re-raise any errors in the mail path so it can be re-run

The reason for it is that we had an unnoticed issue with our email setup, which also lead to mails to suppliers not sent from the foodsoft. This errors are not even visible in the email errors overview site since only email problems to members are shown there.