### PR TITLE
Fixes inconsistent `Gemfile.lock` and `db/schema.rb`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -624,6 +624,7 @@ GEM
     zeitwerk (2.6.12)
 
 PLATFORMS
+  ruby
   x86_64-linux
 
 DEPENDENCIES

--- a/db/migrate/20250322103203_fix_schema_inconsistent_with_migration_history.rb
+++ b/db/migrate/20250322103203_fix_schema_inconsistent_with_migration_history.rb
@@ -1,0 +1,13 @@
+class FixSchemaInconsistentWithMigrationHistory < ActiveRecord::Migration[7.0]
+  def up
+    change_column :article_versions, :created_at, :datetime
+  end
+
+  def down
+    change_column :article_versions, :created_at, :datetime, precision: nil
+  end
+
+  def change
+    change_column_null :suppliers, :supplier_category_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_07_26_083744) do
+ActiveRecord::Schema[7.0].define(version: 2025_03_22_103203) do
   create_table "action_text_rich_texts", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.string "name", null: false
     t.text "body", size: :long


### PR DESCRIPTION
Fixes #1142 

The `db/schema.rb` is actually correct in https://github.com/foodcoops/foodsoft/commit/02853a5268742d0641f77d23c4c9f81b83d933ee as far as I can tell, but it was incorrect before for some reason (probably due to an active record upgrade).

So in this PR I added a migration replaying the current schema state. (This migration won't change anything in a database where `schema:load` has already been run, but it will cancel out the uncommitted changes in `db/schema.rb`.)
To avoid such issues in the future, we might add a CI check that fails, if there are uncommitted changes after running migrations from the last commit in the target branch.