### PR TITLE
Fixes #1152 - Accounting & receive: Can't add article ("has already been taken")

### DIFF
--- a/app/controllers/order_articles_controller.rb
+++ b/app/controllers/order_articles_controller.rb
@@ -18,7 +18,7 @@ class OrderArticlesController < ApplicationController
     # The article may be ordered with zero units - in that case do not complain.
     #   If order_article is ordered and a new order_article is created, an error message will be
     #   given mentioning that the article already exists, which is desired.
-    @order_article = @order.order_articles.joins(:article_version).where(id: params[:order_article][:article_version_id]).first
+    @order_article = @order.order_articles.where(article_version_id: params[:order_article][:article_version_id]).first
     @order_article = @order.order_articles.build(params[:order_article]) unless @order_article && @order_article.units_to_order == 0
     @order_article.save!
   rescue StandardError


### PR DESCRIPTION
Fixes invalid existing article check in `OrderArticles#create` (checked the wrong ID!)