### PR TITLE
feat: allow to re-enable unit migration

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -254,6 +254,7 @@ class ArticlesController < ApplicationController
     options = { filename: uploaded_file.original_filename }
     options[:outlist_absent] = (params[:articles]['outlist_absent'] == '1')
     options[:convert_units] = (params[:articles]['convert_units'] == '1')
+    @supplier.update_attribute(:unit_migration_completed, nil) if params[:articles]['activate_unit_migration'] == '1'
     @updated_article_pairs, @outlisted_articles, @new_articles, import_data = @supplier.sync_from_file(uploaded_file.tempfile,
                                                                                                        options)
 

--- a/app/views/articles/upload.html.haml
+++ b/app/views/articles/upload.html.haml
@@ -103,6 +103,9 @@
     %label(for="articles_convert_units")
       = f.check_box "convert_units"
       = t '.options.convert_units'
+    %label(for="articles_activate_unit_migration")
+      = f.check_box "activate_unit_migration"
+      = t '.options.activate_unit_migration'
 
   .form-actions
     = submit_tag t('.submit'), class: 'btn btn-primary'

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -613,6 +613,7 @@ de:
       options:
         convert_units: Derzeitige Einheiten beibehalten, berechne Mengeneinheit und Preis (wie Synchronisieren).
         outlist_absent: Artikel löschen, die nicht in der hochgeladenen Datei sind.
+        activate_unit_migration: "Einheitenmigration erneut aktivieren."
       sample:
         juices: Säfte
         nuts: Nüsse

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -615,6 +615,7 @@ en:
       options:
         convert_units: Keep current units, recompute unit quantity and price (like synchronize).
         outlist_absent: Delete articles not in uploaded file.
+        activate_unit_migration: "Re-activate unit migration."
       sample:
         juices: Juices
         nuts: Nuts


### PR DESCRIPTION
When uploading a CSV an option is shown to re-activate the unit migration feature. This is useful when restoring the article database from CSV and starting the migration once again.

Refs #1127