### PR TITLE
Improve CSV re-import

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -29,7 +29,7 @@ class ArticlesController < ApplicationController
                                                                                         type: nil)
 
     if request.format.csv?
-      send_data ArticlesCsv.new(@articles, encoding: 'utf-8').to_csv, filename: 'articles.csv', type: 'text/csv'
+      send_data ArticlesCsv.new(@articles, encoding: 'utf-8', foodsoft_url: root_url).to_csv, filename: 'articles.csv', type: 'text/csv'
       return
     end
 
@@ -251,7 +251,8 @@ class ArticlesController < ApplicationController
   # Update articles from a spreadsheet
   def parse_upload
     uploaded_file = params[:articles]['file'] or raise I18n.t('articles.controller.parse_upload.no_file')
-    options = { filename: uploaded_file.original_filename }
+    options = { filename: uploaded_file.original_filename, foodsoft_url: root_url }
+    options[:delete_unavailable] = (params[:articles]['delete_unavailable'] == '1')
     options[:outlist_absent] = (params[:articles]['outlist_absent'] == '1')
     options[:convert_units] = (params[:articles]['convert_units'] == '1')
     @enable_unit_migration = (params[:articles]['activate_unit_migration'] == '1')

--- a/app/lib/articles_csv.rb
+++ b/app/lib/articles_csv.rb
@@ -20,7 +20,8 @@ class ArticlesCsv < RenderCsv
       Article.human_attribute_name(:note),
       Article.human_attribute_name(:article_category),
       Article.human_attribute_name(:origin),
-      Article.human_attribute_name(:manufacturer)
+      Article.human_attribute_name(:manufacturer),
+      @options[:foodsoft_url]
     ]
   end
 
@@ -44,7 +45,8 @@ class ArticlesCsv < RenderCsv
         article.note,
         article.article_category.try(:name),
         article.origin,
-        article.manufacturer
+        article.manufacturer,
+        article.id
       ]
     end
   end

--- a/app/lib/foodsoft_file.rb
+++ b/app/lib/foodsoft_file.rb
@@ -4,9 +4,11 @@ class FoodsoftFile
   # returns two arrays with articles and outlisted_articles
   # the parsed article is a simple hash
   def self.parse(file, options = {})
+    foodsoft_url = nil
     articles = []
-    SpreadsheetFile.parse file, options do |row|
-      next if row[2].blank?
+    SpreadsheetFile.parse file, options do |row, index|
+      foodsoft_url = row[18] if index == 1
+      next if index == 1 || row[2].blank?
 
       article = { availability: row[0]&.strip == I18n.t('simple_form.yes'),
                   order_number: row[1],
@@ -26,6 +28,7 @@ class FoodsoftFile
                   article_category: row[15],
                   origin: row[16],
                   manufacturer: row[17] }
+      article[:id] = row[18] unless foodsoft_url.blank? || foodsoft_url != options[:foodsoft_url]
       articles << article
     end
 

--- a/app/lib/spreadsheet_file.rb
+++ b/app/lib/spreadsheet_file.rb
@@ -10,11 +10,8 @@ class SpreadsheetFile
 
     row_index = 1
     s.each do |row|
-      if row_index == 1
-        # @todo try to detect headers; for now using the index is ok
-      else
-        yield row, row_index
-      end
+      # header detection must be done by using code (e.g. based on index)
+      yield row, row_index
       row_index += 1
     end
     row_index

--- a/app/models/supplier.rb
+++ b/app/models/supplier.rb
@@ -123,10 +123,15 @@ class Supplier < ApplicationRecord
     new_articles = []
 
     data[:articles].each do |new_attrs|
-      article = articles.includes(:latest_article_version).undeleted.where(article_versions: { order_number: new_attrs[:order_number] }).first
+      undeleted_articles = articles.includes(:latest_article_version).undeleted
+      article = if new_attrs[:id]
+                  undeleted_articles.where(id: new_attrs[:id]).first
+                else
+                  undeleted_articles.where(article_versions: { order_number: new_attrs[:order_number] }).first
+                end
       new_article = foodsoft_file_attrs_to_article(new_attrs)
 
-      if new_attrs[:availability]
+      if new_attrs[:availability] || !(options[:delete_unavailable])
         if article.nil?
           new_articles << new_article
         else

--- a/app/views/articles/upload.html.haml
+++ b/app/views/articles/upload.html.haml
@@ -97,6 +97,9 @@
     = f.file_field "file"
 
   .control-group
+    %label(for="articles_delete_unavailable")
+      = f.check_box "delete_unavailable"
+      = t '.options.delete_unavailable'
     %label(for="articles_outlist_absent")
       = f.check_box "outlist_absent"
       = t '.options.outlist_absent'

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -12,6 +12,7 @@ de:
         fc_share: FoodCoop-Aufschlag
         fc_share_short: FC-Aufschlag
         gross_price: Bruttopreis
+        id: Foodsoft-ID
         manufacturer: Produzent
         name: Name
         note: Notiz
@@ -614,6 +615,7 @@ de:
         convert_units: Derzeitige Einheiten beibehalten, berechne Mengeneinheit und Preis (wie Synchronisieren).
         outlist_absent: Artikel löschen, die nicht in der hochgeladenen Datei sind.
         activate_unit_migration: "Einheitenmigration erneut freischalten."
+        delete_unavailable: "Nicht verfügbare Artikel löschen."
       sample:
         juices: Säfte
         nuts: Nüsse

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,6 +12,7 @@ en:
         fc_share: FoodCoop margin
         fc_share_short: FC margin
         gross_price: Gross price
+        id: Foodsoft id
         manufacturer: Manufacturer
         name: Name
         note: Note
@@ -616,6 +617,7 @@ en:
         convert_units: Keep current units, recompute unit quantity and price (like synchronize).
         outlist_absent: Delete articles not in uploaded file.
         activate_unit_migration: "Re-enable unit migration."
+        delete_unavailable: "Delete unavailable articles."
       sample:
         juices: Juices
         nuts: Nuts


### PR DESCRIPTION
- Unavailable articles are not removed by default upon CSV import. There is a new option if one wants this behaviour. When activated, an old article database cannot be restored, because unavailable articles are missing after import.
- Assignment of CSV articles to Foodsoft articles is now done by a new and optional column "Foodsoft ID" in the CSV. Otherwise we couldn't re-import articles without order number.

Depends on #1157 and #1159 

Fixes #1128 