### PR TITLE
1030 synchronize from external database fails with out of range error

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -213,7 +213,7 @@ class Article < ApplicationRecord
         nil
       end
       if fc_unit != 0 && supplier_unit != 0 && fc_unit && supplier_unit && fc_unit =~ supplier_unit
-        conversion_factor = (supplier_unit / fc_unit).to_base.to_r
+        conversion_factor = (supplier_unit / fc_unit).to_base.to_f
         new_price = new_article.price / conversion_factor
         new_unit_quantity = new_article.unit_quantity * conversion_factor
         [new_price, new_unit_quantity]


### PR DESCRIPTION
depends on #1161, which I needed to get rspec running :D

This should resolve the out of range errors that appeared in #1030 

I'm a little bit afraid to touch this convert_units funciton, as it's really a bit messy and quite essential. Maybe someone could do some manual testing too?


Also now reading the discussion around [#1110](https://github.com/foodcoops/foodsoft/issues/1110) I wonder if we even still need this?
And reading [#1092](https://github.com/foodcoops/foodsoft/issues/1092) makes me wonder if it would be safe change to use float instead of rational 
