### PR TITLE
fix: text fields onchange search

### DIFF
--- a/app/assets/javascripts/application_legacy.js
+++ b/app/assets/javascripts/application_legacy.js
@@ -99,7 +99,8 @@ $(function() {
     // Submission will be done after 500ms of not typed, unless data-submit-onchange=changed,
     // in which case it happens when the input box loses its focus ('changed' event).
     // (changeDate is for bootstrap-datepicker)
-    $(document).on('changed keyup focusin changeDate', 'form[data-submit-onchange] input[type=number][type=text]:not([data-ignore-onchange])', function(e) {
+    $(document).on('changed keyup focusin changeDate',
+    'form[data-submit-onchange] input[type=text]:not([data-ignore-onchange]), form[data-submit-onchange] input[type=number]:not([data-ignore-onchange])', function(e) {
         var input = $(this);
         // when form has data-submit-onchange=changed, don't do updates while typing
         if (e.type!='changed' && e.type!='changeDate' && input.parents('form[data-submit-onchange=changed]').length>0) {

--- a/app/assets/javascripts/application_legacy.js
+++ b/app/assets/javascripts/application_legacy.js
@@ -99,8 +99,7 @@ $(function() {
     // Submission will be done after 500ms of not typed, unless data-submit-onchange=changed,
     // in which case it happens when the input box loses its focus ('changed' event).
     // (changeDate is for bootstrap-datepicker)
-    $(document).on('changed keyup focusin changeDate',
-    'form[data-submit-onchange] input[type=text]:not([data-ignore-onchange]), form[data-submit-onchange] input[type=number]:not([data-ignore-onchange])', function(e) {
+    $(document).on('changed keyup focusin changeDate', 'form[data-submit-onchange] input[type=number][type=text]:not([data-ignore-onchange])', function(e) {
         var input = $(this);
         // when form has data-submit-onchange=changed, don't do updates while typing
         if (e.type!='changed' && e.type!='changeDate' && input.parents('form[data-submit-onchange=changed]').length>0) {

--- a/app/assets/javascripts/application_legacy.js
+++ b/app/assets/javascripts/application_legacy.js
@@ -99,7 +99,9 @@ $(function() {
     // Submission will be done after 500ms of not typed, unless data-submit-onchange=changed,
     // in which case it happens when the input box loses its focus ('changed' event).
     // (changeDate is for bootstrap-datepicker)
-    $(document).on('changed keyup focusin changeDate', 'form[data-submit-onchange] input[type=number]:not([data-ignore-onchange])', function(e) {
+    $(document).on('changed keyup focusin changeDate',
+    'form[data-submit-onchange] input[type=text]:not([data-ignore-onchange]), form[data-submit-onchange] input[type=number]:not([data-ignore-onchange])', function(e) {
+        console.log("foo");
         var input = $(this);
         // when form has data-submit-onchange=changed, don't do updates while typing
         if (e.type!='changed' && e.type!='changeDate' && input.parents('form[data-submit-onchange=changed]').length>0) {

--- a/app/assets/javascripts/application_legacy.js
+++ b/app/assets/javascripts/application_legacy.js
@@ -101,7 +101,6 @@ $(function() {
     // (changeDate is for bootstrap-datepicker)
     $(document).on('changed keyup focusin changeDate',
     'form[data-submit-onchange] input[type=text]:not([data-ignore-onchange]), form[data-submit-onchange] input[type=number]:not([data-ignore-onchange])', function(e) {
-        console.log("foo");
         var input = $(this);
         // when form has data-submit-onchange=changed, don't do updates while typing
         if (e.type!='changed' && e.type!='changeDate' && input.parents('form[data-submit-onchange=changed]').length>0) {


### PR DESCRIPTION
Automatic search when typing into a text search field is broken in the current version. The bug was introduced in this commit: https://github.com/foodcoops/foodsoft/blame/e4a9932caa44fc8960ddb3a88956a6d02fda25f3/app/assets/javascripts/application_legacy.js#L102

This PR adds search for both `type=number` and `type=text` inputs. 

@lentschi Was the replacement of `type=text` a mistake? It would be great if you could check whether this works with the changes you introduced.