### PR TITLE
create/edit article: sort article categories alphabetically

### DIFF
--- a/app/views/articles/_form.html.haml
+++ b/app/views/articles/_form.html.haml
@@ -19,7 +19,8 @@
     = render partial: 'shared/article_fields_price', locals: {f: f, article: @article}
 
     = f.input :note
-    = f.association :article_category
+    = f.association :article_category, collection: ArticleCategory.order(:name)
+
     / TODO labels
     = f.input :origin
     = f.input :manufacturer


### PR DESCRIPTION
actually, categories in the selection field are sorted by id. an alphabetical sorting would make it much easier to find the desired category. 
![grafik](https://github.com/user-attachments/assets/af8612e4-bcc1-4bad-b046-bc3c8302690a)
