### PR TITLE
fix(mollie): skip payment method if pricing is empty

### DIFF
--- a/plugins/mollie/app/controllers/payments/mollie_controller.rb
+++ b/plugins/mollie/app/controllers/payments/mollie_controller.rb
@@ -78,6 +78,8 @@ class Payments::MollieController < ApplicationController
   def payment_methods
     @payment_methods = fetch_mollie_methods
     @payment_methods_fees = @payment_methods.to_h do |method|
+      next [method.id, []] if method.pricing.blank?
+
       [method.id, method.pricing.map do |pricing|
         {
           description: pricing.description,


### PR DESCRIPTION
hotfix for #1178 
it fixes the problem only partially. It's still not possible to calculate the transaction fees, but when disabling the option to charge transaction fees the plugin can already be used again. 