### PR TITLE
Fix_1181_add_translations_for_message_groups

### DIFF
--- a/plugins/messages/config/locales/de.yml
+++ b/plugins/messages/config/locales/de.yml
@@ -26,6 +26,21 @@ de:
       message: Nachricht
       messagegroup: Nachrichtengruppe
   admin:
+    messagegroups:
+      index:
+        title: Nachrichtengruppe
+        first_paragraph: Here you can administer Foodsoft message groups. You can %{url}, edit or remove them.
+        second_paragraph: ' '
+        new_messagegroup: Neue Nachrichtengruppe
+        new_messagegroups: neue Nachrichtengruppen
+      new:
+        title: Neue Nachrichtengruppe
+      edit:
+        title: Nachrichtengruppe bearbeiten
+      show:
+        confirm: Bist Du sicher?
+        title: Nachrichtengruppe %{name}
+        send_message: Nachricht senden
     ordergroups:
       show:
         send_message: Nachricht senden

--- a/plugins/messages/config/locales/en.yml
+++ b/plugins/messages/config/locales/en.yml
@@ -32,6 +32,21 @@ en:
     users:
       show:
         send_message: Send message
+    messagegroups:
+      index:
+        title: Message groups
+        first_paragraph: Here you can administer Foodsoft message groups. You can %{url}, edit or remove them.
+        second_paragraph: ' '
+        new_messagegroup: Add
+        new_messagegroups: add message groups
+      new:
+        title: New message group
+      edit:
+        title: Edit message group
+      show:
+        title: Message group %{name}
+        send_message: Send message
+    confirm: Are you sure you want to delete %{name}?
   config:
     hints:
       mailing_list: Mailing-list email address to use instead of the messaging system for mail to all members.

--- a/plugins/messages/config/locales/nl.yml
+++ b/plugins/messages/config/locales/nl.yml
@@ -32,6 +32,21 @@ nl:
     users:
       show:
         send_message: Bericht sturen
+    messagegroups:
+      index:
+        title: Berichtgroepen
+        first_paragraph: Hier kun je %{url} toevoegen, bewerken en wissen.
+        second_paragraph: ' '
+        new_messagegroup: Toevoegen
+        new_messagegroups: nieuwe berichtengroepen
+      new:
+        title: Nieuwe berichtgroep
+      edit:
+        title: Berichtgroep bewerken
+      show:
+        title: Berichtgroep %{name}
+        send_message: Bericht sturen
+    confirm: Weet je het zeker dat je %{name} wil verwijderen?
   config:
     hints:
       mailing_list: Mailing-lijst adres om te gebruiken in plaats van het berichtensysteem voor emails naar alle leden.


### PR DESCRIPTION
Fixes #1181 

Added translations for EN, NL en DE for the messages plugin

Question: the plugin `admin.confirm` label is not picked up when a global `admin.confirm` exists (which it does). This seems inconsistent as it prevents defining specific messages like `Do you want to delete message group %{name}` as example. Where on other cases specific context related messages are supported.
If this _is_ the intended behaviour a new issue may be created 😁 