### PR TITLE
Bugfix: Deleting article categories fails

### DIFF
--- a/app/controllers/article_categories_controller.rb
+++ b/app/controllers/article_categories_controller.rb
@@ -12,7 +12,8 @@ class ArticleCategoriesController < ApplicationController
   end
 
   def destroy
-    destroy!
+    resource.mark_as_deleted
+    redirect_to article_categories_path, notice: I18n.t('flash.actions.destroy.notice', resource_name: resource.class.model_name.human)
   rescue StandardError => e
     redirect_to article_categories_path, alert: I18n.t('article_categories.destroy.error', message: e.message)
   end
@@ -20,6 +21,6 @@ class ArticleCategoriesController < ApplicationController
   protected
 
   def collection
-    @article_categories = ArticleCategory.order('name')
+    @article_categories = ArticleCategory.undeleted.order('name')
   end
 end

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -3,7 +3,7 @@ class ArticlesController < ApplicationController
 
   before_action :load_article, only: %i[edit update]
   before_action :load_article_units, only: %i[edit update new create]
-  before_action :load_article_categories, only: %i[edit_all copy migrate_units update_all]
+  before_action :load_article_categories, only: %i[edit new edit_all copy migrate_units update_all]
   before_action :new_empty_article_ratio,
                 only: %i[edit edit_all migrate_units update new create parse_upload sync update_synchronized]
 
@@ -400,7 +400,10 @@ class ArticlesController < ApplicationController
   end
 
   def load_article_categories
-    @article_categories = ArticleCategory.all
+    @article_categories = ArticleCategory.undeleted.order(:name)
+
+    current_category_id = @article&.latest_article_version&.article_category_id
+    @article_categories = @article_categories.or(ArticleCategory.where(id: current_category_id)) unless current_category_id.nil?
   end
 
   def new_empty_article_ratio

--- a/app/models/article_category.rb
+++ b/app/models/article_category.rb
@@ -5,12 +5,12 @@ class ArticleCategory < ApplicationRecord
   # @!attrubute description
   #   @return [String] Description (currently unused)
 
-  # @!attribute articles
-  #   @return [Array<Article>] Articles with this category.
-  has_many :articles
+  # @!attribute article_versions
+  #   @return [Array<ArticleVersion>] ArticleVersions with this category.
+  has_many :article_versions
   # @!attribute order_articles
   #   @return [Array<OrderArticle>] Order articles with this category.
-  has_many :order_articles, through: :articles
+  has_many :order_articles, through: :article_versions
   # @!attribute orders
   #   @return [Array<Order>] Orders with articles in this category.
   has_many :orders, through: :order_articles
@@ -52,9 +52,9 @@ class ArticleCategory < ApplicationRecord
 
   protected
 
-  # Deny deleting the category when there are associated articles.
+  # Deny deleting the category when there are associated undeleted article_versions.
   def check_for_associated_articles
-    return unless articles.undeleted.exists?
+    return unless article_versions.latest.undeleted.exists?
 
     raise I18n.t('activerecord.errors.has_many_left',
                  collection: Article.model_name.human)

--- a/app/models/article_version.rb
+++ b/app/models/article_version.rb
@@ -59,6 +59,8 @@ class ArticleVersion < ApplicationRecord
     joins(latest_outer_join_sql("#{table_name}.article_id")).where(later_article_versions: { id: nil })
   }
 
+  scope :undeleted, -> { includes(:article).where(articles: { deleted_at: nil }) }
+
   def self.latest_outer_join_sql(article_field_name)
     %(
       LEFT OUTER JOIN #{table_name} later_article_versions

--- a/app/views/articles/_form.html.haml
+++ b/app/views/articles/_form.html.haml
@@ -19,7 +19,7 @@
     = render partial: 'shared/article_fields_price', locals: {f: f, article: @article}
 
     = f.input :note
-    = f.association :article_category, collection: ArticleCategory.order(:name)
+    = f.association :article_category, collection: @article_categories
 
     / TODO labels
     = f.input :origin

--- a/db/migrate/20250523191049_add_deleted_at_to_article_category.rb
+++ b/db/migrate/20250523191049_add_deleted_at_to_article_category.rb
@@ -1,0 +1,26 @@
+class AddDeletedAtToArticleCategory < ActiveRecord::Migration[7.0]
+  def up
+    add_column :article_categories, :deleted_at, :datetime
+    add_index :article_categories, :deleted_at
+
+    reassign_orphaned_article_versions
+  end
+
+  def down
+    remove_column :article_categories, :deleted_at, :datetime
+  end
+
+  private
+
+  def reassign_orphaned_article_versions
+    first_article_category = select_one('SELECT id FROM article_categories LIMIT 1')
+
+    return if first_article_category.nil?
+
+    update(%(
+        UPDATE article_versions
+        SET article_category_id = #{quote first_article_category['id']}
+        WHERE article_category_id NOT IN (SELECT id FROM article_categories)
+      ))
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_03_22_103203) do
+ActiveRecord::Schema[7.0].define(version: 2025_05_23_191049) do
   create_table "action_text_rich_texts", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.string "name", null: false
     t.text "body", size: :long
@@ -52,6 +52,8 @@ ActiveRecord::Schema[7.0].define(version: 2025_03_22_103203) do
   create_table "article_categories", id: :integer, charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.string "name", default: "", null: false
     t.string "description"
+    t.datetime "deleted_at"
+    t.index ["deleted_at"], name: "index_article_categories_on_deleted_at"
     t.index ["name"], name: "index_article_categories_on_name", unique: true
   end
 

--- a/spec/models/article_category_spec.rb
+++ b/spec/models/article_category_spec.rb
@@ -5,13 +5,13 @@ describe ArticleCategory do
   let(:article_category) { create(:article_category, article_versions: [article.latest_article_version]) }
 
   it 'cannot be destroyed if there are associated undeleted articles' do
-    expect { article_category.destroy! }.to raise_error(RuntimeError)
-    expect(article_category).not_to be_destroyed
+    expect { article_category.mark_as_deleted }.to raise_error(RuntimeError)
+    expect(article_category).not_to be_deleted
   end
 
   it 'can be destroyed unless there are associated undeleted articles' do
     article.mark_as_deleted
-    article_category.destroy!
-    expect(article_category).to be_destroyed
+    article_category.mark_as_deleted
+    expect(article_category).to be_deleted
   end
 end

--- a/spec/models/article_category_spec.rb
+++ b/spec/models/article_category_spec.rb
@@ -1,0 +1,17 @@
+require_relative '../spec_helper'
+
+describe ArticleCategory do
+  let(:article) { create(:article) }
+  let(:article_category) { create(:article_category, article_versions: [article.latest_article_version]) }
+
+  it 'cannot be destroyed if there are associated undeleted articles' do
+    expect { article_category.destroy! }.to raise_error(RuntimeError)
+    expect(article_category).not_to be_destroyed
+  end
+
+  it 'can be destroyed unless there are associated undeleted articles' do
+    article.mark_as_deleted
+    article_category.destroy!
+    expect(article_category).to be_destroyed
+  end
+end


### PR DESCRIPTION
*In theory* this fixes #1175 

(Associations in the `ArticleCategory` model had not been updated to the new `ArticleVersion` db structure.)

**However:** There has been a logical issue with `ArticleCategory` deletion - even in v4.9.1 (before the article unit upgrade). Steps to reproduce:

1. Create a new ArticleCategory 'TestCat'
2. Create a new Supplier 'TestSupplier123'
3. Create a new Article 'TestArticle123' in 'TestSupplier123' and set its category to 'TestCat'
4. Create a new Order for 'TestSupplier123'
5. Place a GroupOrder for this Order and 'TestArticle123' 
6. Close the Order
7. Delete 'TestArticle123' in the supplier's article list (now possible as the associated Order has been closed)
8. Delete 'TestCat' (now possible as all associated articles have been marked as deleted)
9. Open the closed order (e.g. through "Manage orders" -> "TestSupplier123" -> Show
-> Error: "undefined method name' for nil:NilClass" in /app/app/views/orders/_articles.html.haml:14 - `a.article.article_category.name` (The closed order's view tries to show the deleted Article, which would be possible as it has only been soft-deleted. However the associated ArticleCategory has been hard-deleted, so we see the error.)

I think the best fix for this would be to make ArticleCategory soft-deletable (same as `Article#mark_as_deleted`).
What do you think @henning-unicode?

Even if we do, I'd say we can continue using `check_for_associated_articles` in `ArticleCategory` as it would avoid not being able to select an category in the article edit form of a new article despite it still being visible as the current selection in an existing article.

**EDIT**

Fixes #1175 as well as the above mentioned issue - also see https://github.com/foodcoops/foodsoft/pull/1184#issuecomment-2902058794 