### PR TITLE
Automatic FTP synchronization

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,3 +12,7 @@ AllCops:
 Gemspec/OrderedDependencies:
   Exclude:
     - 'plugins/*/*.gemspec'
+
+Metrics/BlockLength:
+  Exclude:
+    - 'lib/tasks/foodsoft.rake'

--- a/app/controllers/suppliers_controller.rb
+++ b/app/controllers/suppliers_controller.rb
@@ -80,6 +80,6 @@ class SuppliersController < ApplicationController
       .require(:supplier)
       .permit(:name, :address, :phone, :phone2, :fax, :email, :url, :contact_person, :customer_number,
               :iban, :custom_fields, :delivery_days, :order_howto, :note, :supplier_category_id,
-              :min_order_quantity, :shared_sync_method, :supplier_remote_source)
+              :min_order_quantity, :shared_sync_method, :supplier_remote_source, :remote_auto_sync)
   end
 end

--- a/app/services/supplier_sync_service.rb
+++ b/app/services/supplier_sync_service.rb
@@ -12,17 +12,49 @@ class SupplierSyncService
     false
   end
 
-  private
+  # Persists changes to articles
+  # @param created [Array<Article>] New articles to be created
+  # @param deleted [Array<Article>] Articles to be marked as deleted
+  # @param updated [Array<Article>, Array<Array<Article, Hash>>] Articles to be updated
+  #   If updated is an array of articles, each article is expected to have its attributes already set
+  #   If updated is an array of [article, attributes] pairs, the attributes will be assigned to the article
+  # @param enable_unit_migration [Boolean] Whether to enable unit migration for the supplier
+  # @return [Boolean] Whether all operations succeeded
+  def persist(created, deleted, updated, enable_unit_migration: false)
+    has_error = false
+    Article.transaction do
+      # re-enable unit migration if requested
+      @supplier.update_attribute(:unit_migration_completed, nil) if enable_unit_migration
 
-  def persist(created, deleted, updated)
-    has_errors = !created.map(&:save).all?
-    has_errors ||= !deleted.map(&:mark_as_deleted).all?
-    result = updated.map do |article, attributes|
-      article.latest_article_version.article_unit_ratios.clear
-      article.latest_article_version.assign_attributes(attributes)
-      article.save
+      # delete articles
+      begin
+        has_error = !deleted.map(&:mark_as_deleted).all? unless deleted.empty?
+      rescue StandardError
+        # raises an exception when used in current order
+        has_error = true
+      end
+
+      # Update articles
+      if updated.first.is_a?(Array)
+        # Handle [article, attributes] pairs
+        updated.each do |article, attributes|
+          article.latest_article_version.article_unit_ratios.clear
+          article.latest_article_version.assign_attributes(attributes)
+          article.save or (has_error = true)
+        end
+      else
+        # Handle articles with attributes already set
+        updated.each do |article|
+          article.save or (has_error = true)
+        end
+      end
+
+      # Add new articles
+      created.each { |a| a.save or has_error = true } unless created.empty?
+
+      raise ActiveRecord::Rollback if has_error
     end
-    has_errors ||= !result.all?
-    !has_errors
+
+    !has_error
   end
 end

--- a/app/services/supplier_sync_service.rb
+++ b/app/services/supplier_sync_service.rb
@@ -1,0 +1,28 @@
+# app/services/supplier_sync_service.rb
+class SupplierSyncService
+  def initialize(supplier)
+    @supplier = supplier
+  end
+
+  def sync
+    updated, deleted, created = @supplier.sync_from_remote
+    persist(created, deleted, updated)
+  rescue StandardError => e
+    Rails.logger.error("Error syncing supplier #{@supplier.id}: #{e.message}")
+    false
+  end
+
+  private
+
+  def persist(created, deleted, updated)
+    has_errors = !created.map(&:save).all?
+    has_errors ||= !deleted.map(&:mark_as_deleted).all?
+    result = updated.map do |article, attributes|
+      article.latest_article_version.article_unit_ratios.clear
+      article.latest_article_version.assign_attributes(attributes)
+      article.save
+    end
+    has_errors ||= !result.all?
+    !has_errors
+  end
+end

--- a/app/views/suppliers/_form.html.haml
+++ b/app/views/suppliers/_form.html.haml
@@ -20,6 +20,7 @@
   = f.input :supplier_remote_source
   = render 'shared/custom_form_fields', f: f, type: :supplier
   = f.input :shared_sync_method, collection: shared_sync_method_collection, input_html: {class: 'input-xlarge'}, include_blank: true
+  = f.input :remote_auto_sync
   .form-actions
     = f.submit class: 'btn'
     = link_to t('ui.or_cancel'), suppliers_path

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -220,7 +220,7 @@ de:
         order_howto: Kurzanleitung Bestellen
         phone: Telefon
         phone2: Telefon 2
-        remote_auto_sync: Synchronisation automatisch ausführen
+        remote_auto_sync: Synchronisation automatisch ausführen (täglich)
         supplier_remote_source: Synchronisierungsquelle
         shared_sync_method: Syncronisierungsmethode
         url: Webseite

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -220,6 +220,7 @@ de:
         order_howto: Kurzanleitung Bestellen
         phone: Telefon
         phone2: Telefon 2
+        remote_auto_sync: Synchronisation automatisch ausführen
         supplier_remote_source: Synchronisierungsquelle
         shared_sync_method: Syncronisierungsmethode
         url: Webseite

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -222,7 +222,7 @@ en:
         order_howto: How to order
         phone: Phone
         phone2: Phone 2
-        remote_auto_sync: Perform synchronization automatically
+        remote_auto_sync: Perform synchronization automatically (daily)
         supplier_remote_source: Supplier remote source
         shared_sync_method: How to synchronize
         url: Homepage

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -222,6 +222,7 @@ en:
         order_howto: How to order
         phone: Phone
         phone2: Phone 2
+        remote_auto_sync: Perform synchronization automatically
         supplier_remote_source: Supplier remote source
         shared_sync_method: How to synchronize
         url: Homepage

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -191,6 +191,7 @@ nl:
         order_howto: Hoe te bestellen
         phone: Telefoon
         phone2: Telefoon 2
+        remote_auto_sync: Synchronisatie automatisch uitvoeren (dagelijks)
         shared_sync_method: Hoe synchroniseren
         url: Homepage
       supplier_category:

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -22,3 +22,8 @@ end
 every 1.minute do
   rake 'multicoops:run TASK=foodsoft:finish_ended_orders'
 end
+
+# Daily supplier synchronization
+every :day, at: '3:00 am' do
+  rake 'multicoops:run TASK=foodsoft:remote_sync_suppliers'
+end

--- a/db/migrate/20250528114335_add_remote_auto_sync_to_suppliers.rb
+++ b/db/migrate/20250528114335_add_remote_auto_sync_to_suppliers.rb
@@ -1,0 +1,5 @@
+class AddRemoteAutoSyncToSuppliers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :suppliers, :remote_auto_sync, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_05_23_191049) do
+ActiveRecord::Schema[7.0].define(version: 2025_05_28_114335) do
   create_table "action_text_rich_texts", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.string "name", null: false
     t.text "body", size: :long
@@ -546,6 +546,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_05_23_191049) do
     t.string "supplier_remote_source"
     t.string "external_uuid"
     t.datetime "unit_migration_completed", precision: nil
+    t.boolean "remote_auto_sync", default: false, null: false
     t.index ["external_uuid"], name: "index_suppliers_on_external_uuid", unique: true
     t.index ["name"], name: "index_suppliers_on_name", unique: true
   end

--- a/lib/tasks/foodsoft.rake
+++ b/lib/tasks/foodsoft.rake
@@ -93,6 +93,19 @@ namespace :foodsoft do
       rake_say "Please configure your app_config.yml accordingly:\nattachment_retention_days: <number of days>"
     end
   end
+
+  desc 'Synchronize suppliers with remote_auto_sync flag'
+  task remote_sync_suppliers: :environment do
+    suppliers = Supplier.undeleted.where(remote_auto_sync: true)
+    rake_say "Starting sync for #{suppliers.count} suppliers"
+
+    suppliers.each do |supplier|
+      rake_say "Syncing supplier: #{supplier.name}"
+      result = SupplierSyncService.new(supplier).sync
+      status = result ? 'successful' : 'failed'
+      rake_say "Sync for #{supplier.name} #{status}"
+    end
+  end
 end
 
 # Helper

--- a/spec/controllers/articles_controller_spec.rb
+++ b/spec/controllers/articles_controller_spec.rb
@@ -1,0 +1,82 @@
+require_relative '../spec_helper'
+
+describe ArticlesController do
+  let(:user) { create(:user, groups: [create(:workgroup, role_article_meta: true)]) }
+  let(:supplier) { create(:supplier) }
+  let!(:article_category) { create(:article_category) }
+
+  before do
+    login user
+  end
+
+  describe 'POST #update_synchronized' do
+    context 'with outlisted articles' do
+      let!(:article_to_outlist) { create(:article, supplier: supplier) }
+
+      it 'marks articles as deleted' do
+        post_with_defaults :update_synchronized, params: {
+          supplier_id: supplier.id,
+          outlisted_articles: { '0' => article_to_outlist.latest_article_version.id },
+          from_action: 'sync'
+        }
+
+        expect(article_to_outlist.reload.deleted?).to be true
+        expect(response).to redirect_to(supplier_articles_path(supplier))
+        expect(flash[:notice]).to eq I18n.t('articles.controller.update_sync.notice')
+      end
+    end
+
+    context 'with updated articles' do
+      let!(:article_to_update) { create(:article, supplier: supplier, name: 'Old Name') }
+
+      it 'updates article attributes' do
+        post_with_defaults :update_synchronized, params: {
+          supplier_id: supplier.id,
+          articles: { '0' => { id: article_to_update.latest_article_version.id, name: 'New Name' } },
+          from_action: 'sync'
+        }
+
+        expect(article_to_update.reload.name).to eq 'New Name'
+        expect(response).to redirect_to(supplier_articles_path(supplier))
+        expect(flash[:notice]).to eq I18n.t('articles.controller.update_sync.notice')
+      end
+    end
+
+    context 'with new articles' do
+      it 'creates new articles' do
+        expect do
+          post_with_defaults :update_synchronized, params: {
+            supplier_id: supplier.id,
+            new_articles: {
+              '0' => {
+                name: 'New Article',
+                article_category_id: article_category.id,
+                price: 1.99,
+                tax: 7,
+                unit: 'kg'
+              }
+            },
+            from_action: 'sync'
+          }
+        end.to change(Article, :count).by(1)
+
+        expect(Article.last.name).to eq 'New Article'
+        expect(response).to redirect_to(supplier_articles_path(supplier))
+        expect(flash[:notice]).to eq I18n.t('articles.controller.update_sync.notice')
+      end
+    end
+
+    context 'with validation errors' do
+      it 'renders the form again with errors' do
+        post_with_defaults :update_synchronized, params: {
+          supplier_id: supplier.id,
+          new_articles: { '0' => { name: '' } }, # Name is required
+          from_action: 'sync'
+        }
+
+        expect(response).to have_http_status(:ok)
+        expect(flash[:alert]).to eq I18n.t('articles.controller.error_invalid')
+      end
+    end
+  end
+end

--- a/spec/rake/tasks_foodsoft_spec.rb
+++ b/spec/rake/tasks_foodsoft_spec.rb
@@ -1,0 +1,47 @@
+require_relative '../spec_helper'
+require 'rake'
+
+describe Rake::Task do
+  describe 'foodsoft:remote_sync_suppliers' do
+    before do
+      Foodsoft::Application.load_tasks unless described_class.task_defined?('foodsoft:remote_sync_suppliers')
+      # Reset the Rake task before each test
+      described_class['foodsoft:remote_sync_suppliers'].reenable
+    end
+
+    it 'syncs suppliers with remote_auto_sync flag' do
+      supplier1 = create(:supplier, remote_auto_sync: true)
+      supplier2 = create(:supplier, remote_auto_sync: true)
+      supplier3 = create(:supplier, remote_auto_sync: false)
+
+      service1 = instance_double(SupplierSyncService)
+      service2 = instance_double(SupplierSyncService)
+      allow(service1).to receive(:sync).and_return(true)
+      allow(service2).to receive(:sync).and_return(true)
+      allow(SupplierSyncService).to receive(:new).with(supplier1).and_return(service1)
+      allow(SupplierSyncService).to receive(:new).with(supplier2).and_return(service2)
+      allow(SupplierSyncService).to receive(:new).with(supplier3).and_return(nil)
+
+      described_class['foodsoft:remote_sync_suppliers'].invoke
+
+      expect(SupplierSyncService).to have_received(:new).with(supplier1)
+      expect(SupplierSyncService).to have_received(:new).with(supplier2)
+      expect(SupplierSyncService).not_to have_received(:new).with(supplier3)
+      expect(service1).to have_received(:sync)
+      expect(service2).to have_received(:sync)
+    end
+
+    it 'handles sync failures gracefully' do
+      supplier = create(:supplier, remote_auto_sync: true)
+
+      service = instance_double(SupplierSyncService)
+      allow(service).to receive(:sync).and_return(false)
+      allow(SupplierSyncService).to receive(:new).and_return(service)
+
+      described_class['foodsoft:remote_sync_suppliers'].invoke
+
+      expect(SupplierSyncService).to have_received(:new).with(supplier)
+      expect(service).to have_received(:sync)
+    end
+  end
+end

--- a/spec/services/supplier_sync_service_spec.rb
+++ b/spec/services/supplier_sync_service_spec.rb
@@ -1,0 +1,23 @@
+require_relative '../spec_helper'
+
+describe SupplierSyncService do
+  describe '#sync' do
+    let(:supplier) { create(:supplier) }
+
+    it 'returns true when no changes are needed' do
+      allow(supplier).to receive(:sync_from_remote).and_return([[], [], []])
+      expect(described_class.new(supplier).sync).to be true
+    end
+
+    it 'returns true when changes are applied' do
+      article = create(:article, supplier: supplier)
+      allow(supplier).to receive(:sync_from_remote).and_return([[[article, { name: 'New Name' }]], [], []])
+      expect(described_class.new(supplier).sync).to be true
+    end
+
+    it 'handles exceptions gracefully' do
+      allow(supplier).to receive(:sync_from_remote).and_raise(StandardError.new('Test error'))
+      expect(described_class.new(supplier).sync).to be false
+    end
+  end
+end


### PR DESCRIPTION
The changes enable:

- In future, synchronization with a remote supplier can also take place via FTP (regardless of the format, so far only Foodsoft JSON).
- In the case of FTP synchronization, it is possible to specify a simple glob style pattern so that multiple files can also be imported.
- If `remote_auto_sync` is set for a supplier, synchronization is carried out automatically on a daily basis. This allows the catalog in Foodsoft to serve as a mirror of the remote catalog.

Together with #1173, the changes serve as the basis for a SharedLists replacement. In a subsequent pull request, the functionalities are linked and then enable:

1. a local mirror supplier can be created for each remote supplier. This is where *all* articles are automatically transferred to on a daily basis. This supplier serves as a kind of replacement for the SharedLists database.
2. to keep the order lists manageable, an additional order supplier is created. The articles are synchronized individually and, if desired, with the local mirror supplier. This functionality has already been implemented with the Units PR and serves as a replacement for access to the SharedLists database.