### PR TITLE
Fix "Article form: Unit label is displayed multiple times"

### DIFF
--- a/app/assets/javascripts/article-form.js
+++ b/app/assets/javascripts/article-form.js
@@ -428,7 +428,7 @@ class ArticleForm {
 
     unitSelect$.trigger('change');
 
-    unitSelect$.parents('.price-unit-wrapper').find('.immutable_unit_label').remove();
+    unitSelect$.parents('.unit-wrapper').find('.immutable_unit_label').remove();
     if (units.length === 1) {
       unitSelect$.hide();
       unitSelect$.after($(`<div class="immutable_unit_label control-label pull-left">${units[0].label}</div>`))

--- a/app/views/articles/_edit_all_table.html.haml
+++ b/app/views/articles/_edit_all_table.html.haml
@@ -39,7 +39,7 @@
               = form.input :unit, input_html: {class: 'form-control ml-1'}, label: false
               %div.btn-link.toggle-extra-units.text-decoration-none.default-values
                 = fa_icon :cog
-            %div.extra-unit-fields.price-unit-wrapper.form-horizontal
+            %div.extra-unit-fields.unit-wrapper.form-horizontal
               .form-group.d-flex.w-full
                 %label.col-sm-3.control-label{for: 'unit_ratios'}
                   = "Unit ratios"
@@ -58,14 +58,14 @@
               .row
                 .col-sm-6
                   = form.input :group_order_granularity, wrapper: :custom_form, label: "Allow orders per", label_html: {class: 'col-sm-12'}, input_html: {class: 'form-control col-sm-3', style:"width:150px", title: "steps in which ordergroups can order this article"}, wrapper_html: {class: 'd-flex'}
-                .col-sm-6.price-unit-wrapper
+                .col-sm-6.unit-wrapper
                   = form.input :group_order_unit, as: :select, wrapper: :custom_form, collection: [], label_html: {style: 'width:50px;text-align: center;' }, input_html: {'data-initial-value': article.group_order_unit, class: 'form-control', style:"width:262px"}, label: '&times;'.html_safe, include_blank: false, wrapper_html: {class: 'd-flex', style:"313px"}
           %td
             .d-flex.gap-1.align-items-center
               .input-group.ml-1
                 %span.input-group-addon= t 'number.currency.format.unit'
                 = form.text_field 'price', class: 'form-control', style: 'width: 45px'
-              .input.d-flex.gap-1.ml-1.align-items-center.price-unit-wrapper
+              .input.d-flex.gap-1.ml-1.align-items-center.unit-wrapper
                 %label=t('articles.form.per')
                 = form.input :price_unit, as: :select, collection: [], input_html: {'data-initial-value': article.price_unit, class: 'form-control'}, label: false, wrapper: false, include_blank: false
           %td= form.text_field 'order_number', class: 'form-control'

--- a/app/views/shared/_article_fields_price.html.haml
+++ b/app/views/shared/_article_fields_price.html.haml
@@ -5,7 +5,7 @@
         %span.input-group-addon= t 'number.currency.format.unit'
         = f.input_field :price, class: 'form-control'
   .col-sm-6
-    = f.input :price_unit, as: :select, wrapper: :custom_form, collection: [], label_html: { style: "width:50px;text-align: center; "}, input_html: {'data-initial-value': article.price_unit, class: 'form-control', style: 'margin-right:12px'}, label: t('articles.form.per'), include_blank: false,  wrapper_html: { class: 'd-flex'}
+    = f.input :price_unit, as: :select, wrapper: :custom_form, collection: [], label_html: { style: "width:50px;text-align: center; "}, input_html: {'data-initial-value': article.price_unit, class: 'form-control', style: 'margin-right:12px'}, label: t('articles.form.per'), include_blank: false,  wrapper_html: { class: 'd-flex unit-wrapper'}
 %div
   = f.input :tax do
     .input-group

--- a/app/views/shared/_article_fields_units.html.haml
+++ b/app/views/shared/_article_fields_units.html.haml
@@ -36,4 +36,4 @@
   .col-sm-6
     = f.input :group_order_granularity, wrapper: :custom_form, label_html: { class: 'col-sm-12', style: "width:370px"}, input_html: {class: 'form-control col-sm-3', step: 0.001}, wrapper_html: { class: 'd-flex', }
   .col-sm-6
-    = f.input :group_order_unit, as: :select, wrapper: :custom_form, collection: [], label_html: { style: "width:50px;text-align: center; "}, input_html: {'data-initial-value': article.group_order_unit, class: 'input-group', style: 'margin-right:12px'}, label: '&times;'.html_safe, include_blank: false, wrapper_html: { class: 'd-flex'}
+    = f.input :group_order_unit, as: :select, wrapper: :custom_form, collection: [], label_html: { style: "width:50px;text-align: center; "}, input_html: {'data-initial-value': article.group_order_unit, class: 'input-group', style: 'margin-right:12px'}, label: '&times;'.html_safe, include_blank: false, wrapper_html: { class: 'd-flex unit-wrapper'}


### PR DESCRIPTION
Fixes #1221

see https://github.com/foodcoops/foodsoft/pull/1146#issuecomment-3284410814 <- The fix mentioned here seems to have caused a regression with the edit articles form.

1. Renamed the new `price-unit-wrapper` to just `unit-wrapper` as it affects non-price units as well.
2. Added the class to the erroneous fields.