### PR TITLE
Fix "Article form: Unit label is displayed multiple times" *again*

### DIFF
--- a/app/views/shared/_article_fields_units.html.haml
+++ b/app/views/shared/_article_fields_units.html.haml
@@ -31,7 +31,7 @@
       = f.input_field :minimum_order_quantity, class: 'form-control'
       %span.input-group-addon
 %div
-  = f.input :billing_unit, as: :select, collection: [], input_html: {'data-initial-value': article.billing_unit, class: 'input-group'}, include_blank: false, wrapper_html: { class: 'd-flex' }
+  = f.input :billing_unit, as: :select, collection: [], input_html: {'data-initial-value': article.billing_unit, class: 'input-group'}, include_blank: false, wrapper_html: { class: 'd-flex unit-wrapper' }
 .row
   .col-sm-6
     = f.input :group_order_granularity, wrapper: :custom_form, label_html: { class: 'col-sm-12', style: "width:370px"}, input_html: {class: 'form-control col-sm-3', step: 0.001}, wrapper_html: { class: 'd-flex', }


### PR DESCRIPTION
This fixes an omission in the PR https://github.com/foodcoops/foodsoft/pull/1222/files

see [alternate reproduction case in reopening comment](https://github.com/foodcoops/foodsoft/issues/1221#issuecomment-3563855916)