### PR TITLE
fix: use input-group and input-group-btn for units received input

### DIFF
--- a/app/assets/javascripts/receive-order-form.js
+++ b/app/assets/javascripts/receive-order-form.js
@@ -132,7 +132,7 @@
 
     unlockReceiveInputField(unlockButton$) {
       $('.units_received', unlockButton$.closest('tr')).prop('disabled', false).focus();
-      unlockButton$.closest('.input-prepend').prop('title', I18n.t('orders.edit_amount.field_unlocked_title'));
+      unlockButton$.closest('.input-group-btn').prop('title', I18n.t('orders.edit_amount.field_unlocked_title'));
       unlockButton$.replaceWith('<i class="glyphicon glyphicon-warning-sign"></i>');
     }
   }

--- a/app/helpers/orders_helper.rb
+++ b/app/helpers/orders_helper.rb
@@ -134,18 +134,20 @@ module OrdersHelper
                                                   data: data,
                                                   disabled: order_article.result_manually_changed?,
                                                   autocomplete: 'off'
-    span_html = if order_article.result_manually_changed?
-                  content_tag(:span, class: 'input-prepend input-append intable d-flex',
-                                     title: t('orders.edit_amount.field_locked_title', default: '')) do
-                    button_tag(nil, type: :button, class: 'btn unlocker') {
-                      content_tag(:i, nil, class: 'glyphicon glyphicon-lock')
-                    } + input_html
-                  end
-                else
-                  content_tag(:span, class: 'btn-group numeric-step d-flex') { input_html }
-                end
+    wrapper_html = if order_article.result_manually_changed?
+                     content_tag(:div, class: 'input-group') do
+                       content_tag(:span, class: 'input-group-btn',
+                                          title: t('orders.edit_amount.field_locked_title', default: '')) do
+                         button_tag(nil, type: :button, class: 'btn btn-default unlocker') {
+                           content_tag(:i, nil, class: 'glyphicon glyphicon-lock')
+                         }
+                       end + input_html
+                     end
+                   else
+                     content_tag(:div, class: 'input-group') { input_html }
+                   end
 
-    span_html.html_safe
+    wrapper_html.html_safe
   end
 
   def ratio_quantity_data(order_article, default_unit = nil)


### PR DESCRIPTION
Received units widgets was still using bootstrap 2 classes for the unlock button. 