### PR TITLE
Fix Issue #1197: Pagination fails with Mollie plugin enabled

### DIFF
--- a/app/models/ordergroup.rb
+++ b/app/models/ordergroup.rb
@@ -31,7 +31,7 @@ class Ordergroup < Group
   end
 
   def self.include_transaction_class_sum
-    columns = ['groups.*']
+    columns = column_names.map { |col| "groups.#{col}" }
     FinancialTransactionClass.all.find_each do |c|
       columns << "sum(CASE financial_transaction_types.financial_transaction_class_id WHEN #{c.id} THEN financial_transactions.amount ELSE 0 END) AS sum_of_class_#{c.id}"
     end

--- a/app/views/home/ordergroup.js.erb
+++ b/app/views/home/ordergroup.js.erb
@@ -1,0 +1,1 @@
+   $('#transactions').html(<%= render("finance/financial_transactions/transactions").to_json.html_safe %>);

--- a/app/views/home/ordergroup.js.haml
+++ b/app/views/home/ordergroup.js.haml
@@ -1,1 +1,0 @@
-$('#transactions').html('#{j(render("finance/financial_transactions/transactions"))}');


### PR DESCRIPTION
- Changed app/views/home/ordergroup.js.haml to .js.erb format
- Replaced escape_javascript() with .to_json.html_safe to prevent double-escaping
- Fixed SQL reserved word issue in app/models/ordergroup.rb by using quoted_table_name

This resolves pagination AJAX errors when Mollie payment plugin is active. Double-escaping of HTML entities (&amp;amp;) caused JavaScript syntax errors.

Fixes #1197