### PR TITLE
Closes #1271 - Adapt units/amounts in footer to new unit system

### DIFF
--- a/app/assets/javascripts/group-order-form.js
+++ b/app/assets/javascripts/group-order-form.js
@@ -113,9 +113,9 @@ class GroupOrderForm {
     const tolerance$ = row$.find('.goa-tolerance');
     const usedTolerance$ = row$.find('.used-unused-tolerance .used');
     const unusedTolerance$ = row$.find('.used-unused-tolerance .unused');
-    const totalPacks$ = row$.find('.article-info *[id^="units_"]');
-    const totalQuantity$ = row$.find('.article-info *[id^="q_total_"]');
-    const totalTolerance$ = row$.find('.article-info *[id^="t_total_"]');
+    const totalPacks$ = row$.find('.article-info *[id^="units_"] .quantity');
+    const totalQuantity$ = row$.find('.article-info *[id^="q_total_"] .quantity');
+    const totalTolerance$ = row$.find('.article-info *[id^="t_total_"] .quantity');
     const totalPrice$ = row$.find('*[id^="price_"][id$="_display"]');
 
     const missing$ = row$.find('.missing-units');
@@ -171,7 +171,7 @@ class GroupOrderForm {
 
     totalPacks$.text(packSizeDeterminedBySupplierOrderUnit ? round(totalPacks) : round(totalQuantity));
 
-    totalPacks$.css('color', this.packCompletedFromTolerance(packSize, totalQuantity, totalTolerance) ? 'grey' : 'auto');
+    totalPacks$.css('color', this.packCompletedFromTolerance(packSize, totalQuantity, totalTolerance) ? 'grey' : '');
 
     totalQuantity$.text(round(totalQuantity));
     totalTolerance$.text(round(totalTolerance));

--- a/app/views/group_orders/_form.html.haml
+++ b/app/views/group_orders/_form.html.haml
@@ -155,13 +155,19 @@
                 .article-name= order_article.article_version.name
                 .pull-right
                   = t('.units_full') + ':'
-                  %span{id: "units_#{order_article.id}"}= order_article.article_version.convert_quantity(order_article.units_to_order, order_article.article_version.supplier_order_unit, order_article.article_version.group_order_unit)
+                  %span{id: "units_#{order_article.id}"}
+                    %span.quantity= order_article.units_to_order
+                    %span.unit= ' × ' + format_unit(:supplier_order_unit, order_article.article_version)
                   %br/
                   = t('.units_total') + ':'
-                  %span{id: "q_total_#{order_article.id}"}= @ordering_data[:order_articles][order_article.id][:quantity] + @ordering_data[:order_articles][order_article.id][:others_quantity]
+                  %span{id: "q_total_#{order_article.id}"}
+                    %span.quantity= @ordering_data[:order_articles][order_article.id][:quantity] + @ordering_data[:order_articles][order_article.id][:others_quantity]
+                    %span.unit=' × ' + format_unit_with_ratios(:group_order_unit, order_article.article_version)
                   %br/
                   = t('.total_tolerance') + ':'
-                  %span{id: "t_total_#{order_article.id}"}= @ordering_data[:order_articles][order_article.id][:tolerance] + @ordering_data[:order_articles][order_article.id][:others_tolerance]
+                  %span{id: "t_total_#{order_article.id}"}
+                    %span.quantity= @ordering_data[:order_articles][order_article.id][:tolerance] + @ordering_data[:order_articles][order_article.id][:others_tolerance]
+                    %span.unit=' × ' + format_unit_with_ratios(:group_order_unit, order_article.article_version)
                   %br/
                 .pull-left
                   #{heading_helper Article, :manufacturer}: #{order_article.article_version.manufacturer}
@@ -170,7 +176,7 @@
                   - if @order.stockit?
                     #{order_article.article_version.article.quantity_available}
                   - elsif order_article.article_version.uses_tolerance?
-                    #{format_supplier_order_unit_with_ratios(order_article.article_version)}
+                    #{format_unit_with_ratios(:supplier_order_unit, order_article.article_version)}
                   - else
                     #{format_group_order_unit_with_ratios(order_article.article_version)}
 


### PR DESCRIPTION
Add units to all applicable fields in the footer of the group order form.