### PR TITLE
fix(grouporder): improves order footer for mobile devices

### DIFF
--- a/app/assets/stylesheets/bootstrap_and_overrides.css.scss
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css.scss
@@ -230,14 +230,6 @@ table {
   width: 200px;
 }
 
-/* Hide the orders article info for small screens
-   to prevent the "save order" button to disappear */
-@media only screen and (max-width: 950px) {
-  tr.order-article:hover .article-info {
-    display: none;
-  }
-}
-
 #order-footer {
   width: 100%;
   right: 0;
@@ -272,6 +264,21 @@ tr.order-article .article-info {
 
 tr.order-article:hover .article-info {
   display: block;
+}
+
+
+/* Hide the orders article info for small screens
+   to prevent the "save order" button to disappear */
+@media only screen and (max-width: 950px) {
+  tr.order-article:hover .article-info {
+    display: none;
+  }
+
+  #order-footer {
+    #total-sum {
+      float: left;
+    }
+  }
 }
 
 tr.order-article {


### PR DESCRIPTION
Since the overlapping of article info with order button on group-order page is still a very annoying bug when using foodsoft on mobile devices, this PR is a quick fix for small devices.

It fixes display: none of article-info for small devices, as already implemented, but in wrong order. 
Additionally it aligns order sum + button left for easier access.

URL:
/demo/group_orders/new?order_id=1

Fixes #676