### PR TITLE
Fixes #1282 - `order_result` and `order_received` mails lack units

### DIFF
--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -6,6 +6,9 @@ class Mailer < ActionMailer::Base
   helper :application
   include ApplicationHelper
 
+  helper :articles
+  include ArticlesHelper
+
   layout 'email' # Use views/layouts/email.txt.erb
 
   default from: "#{I18n.t('layouts.foodsoft')} <#{FoodsoftConfig[:email_sender]}>",

--- a/app/views/mailer/order_received.text.haml
+++ b/app/views/mailer/order_received.text.haml
@@ -4,10 +4,10 @@
   = raw "===\n" + t('.abundant_articles') + ":"
   - @abundant_articles.each do |order_article|
     - article = order_article.article_version
-    = raw t('.article_details', name: article.name, ordered: order_article.units_to_order, received: order_article.units_received, unit: article.unit)
+    = raw t('.article_details', name: article.name, ordered: order_article.units_to_order, received: order_article.units_received, unit: format_group_order_unit_with_ratios(article))
 
 - unless @scarce_articles.empty?
   = raw "===\n" + t('.scarce_articles') + ":"
   - @scarce_articles.each do |order_article|
     - article = order_article.article_version
-    = raw t('.article_details', name: article.name, ordered: order_article.units_to_order, received: order_article.units_received, unit: article.unit)
+    = raw t('.article_details', name: article.name, ordered: order_article.units_to_order, received: order_article.units_received, unit: format_group_order_unit_with_ratios(article))

--- a/app/views/mailer/order_result.text.haml
+++ b/app/views/mailer/order_result.text.haml
@@ -4,5 +4,5 @@
 = raw t '.text2'
 - for group_order_article in @group_order.group_order_articles.ordered.includes(:order_article)
   - article = group_order_article.order_article.article_version
-  \- #{article.name}:  #{group_order_article.result} x #{article.unit} = #{group_order_article.result * article.fc_price}
+  \- #{article.name}:  #{group_order_article.result} x #{format_group_order_unit_with_ratios(article)} = #{group_order_article.result * article.fc_price}
 = raw t '.text3', sum: @group_order.price, order_url: group_order_url(@group_order), foodcoop: FoodsoftConfig[:name]


### PR DESCRIPTION
Fixes #1282 by using `format_group_order_unit_with_ratios` to format units.