### PR TITLE
Add qr-code link to supplier invoices sum in unpaid invoices view

### DIFF
--- a/app/views/finance/invoices/unpaid.html.haml
+++ b/app/views/finance/invoices/unpaid.html.haml
@@ -13,6 +13,7 @@
       - invoices_text << invoice.number
       = link_to finance_invoice_path(invoice) do
         = format_date invoice.date
+        = ' ' + invoice.number
       = ' ' 
       - if invoice.amount>0
         - url = "https://epc-qr.eu/?#{{iban: supplier.iban, euro: invoice.amount, bname: supplier.name, info: invoice.number}.to_query}"

--- a/app/views/finance/invoices/unpaid.html.haml
+++ b/app/views/finance/invoices/unpaid.html.haml
@@ -19,7 +19,6 @@
         = link_to(number_to_currency(invoice.amount), url)
       - else
         = number_to_currency(invoice.amount)
-      = ' ' + number_to_currency(invoice.amount)
       - if invoice_amount_diff != 0
         %span{style: "color:#{invoice_amount_diff < 0 ? 'red' : 'green'}"}
           = invoice_amount_diff > 0 ? '+' : '-'

--- a/app/views/finance/invoices/unpaid.html.haml
+++ b/app/views/finance/invoices/unpaid.html.haml
@@ -35,4 +35,5 @@
       = invoices_text.join(', ')
       %br/
       %b= t('.invoices_sum') + ':'
-      = number_to_currency invoices_sum
+      - url = "https://epc-qr.eu/?#{{iban: supplier.iban, euro: invoices_sum, bname: supplier.name, info: invoices_text.join(', ')}.to_query}"
+      = link_to number_to_currency(invoices_sum), url  

--- a/app/views/finance/invoices/unpaid.html.haml
+++ b/app/views/finance/invoices/unpaid.html.haml
@@ -13,7 +13,12 @@
       - invoices_text << invoice.number
       = link_to finance_invoice_path(invoice) do
         = format_date invoice.date
-        = ' ' + invoice.number
+      = ' ' 
+      - if invoice.amount>0
+        - url = "https://epc-qr.eu/?#{{iban: supplier.iban, euro: invoice.amount, bname: supplier.name, info: invoice.number}.to_query}"
+        = link_to(number_to_currency(invoice.amount), url)
+      - else
+        = number_to_currency(invoice.amount)
       = ' ' + number_to_currency(invoice.amount)
       - if invoice_amount_diff != 0
         %span{style: "color:#{invoice_amount_diff < 0 ? 'red' : 'green'}"}

--- a/app/views/finance/invoices/unpaid.html.haml
+++ b/app/views/finance/invoices/unpaid.html.haml
@@ -15,7 +15,7 @@
         = format_date invoice.date
         = ' ' + invoice.number
       = ' ' 
-      - if invoice.amount>0
+      - if invoice.amount>0 && supplier.iban.present?
         - url = "https://epc-qr.eu/?#{{iban: supplier.iban, euro: invoice.amount, bname: supplier.name, info: invoice.number}.to_query}"
         = link_to(number_to_currency(invoice.amount), url)
       - else
@@ -40,5 +40,8 @@
       = invoices_text.join(', ')
       %br/
       %b= t('.invoices_sum') + ':'
-      - url = "https://epc-qr.eu/?#{{iban: supplier.iban, euro: invoices_sum, bname: supplier.name, info: invoices_text.join(', ')}.to_query}"
-      = link_to number_to_currency(invoices_sum), url  
+      - if invoices_sum>0 && supplier.iban.present?
+        - url = "https://epc-qr.eu/?#{{iban: supplier.iban, euro: invoices_sum, bname: supplier.name, info: invoices_text.join(', ')}.to_query}"
+        = link_to number_to_currency(invoices_sum), url      
+      - else 
+        = number_to_currency(invoices_sum)


### PR DESCRIPTION
An URL  is added to the amount of individual invoices and to the sum of invoices of each supplier in the unpaid invoices view that leads to a qr-code that can be used in the banking app to pay these invoices.