### PR TITLE
Make v4.x -> v5.x migrations more tolerant to existing db issues

### DIFF
--- a/db/migrate/20240726083741_alter_articles_add_more_unit_logic.rb
+++ b/db/migrate/20240726083741_alter_articles_add_more_unit_logic.rb
@@ -7,7 +7,7 @@ class AlterArticlesAddMoreUnitLogic < ActiveRecord::Migration[5.2]
       t.column :group_order_unit, :string, length: 3
       t.column :group_order_granularity, :decimal, precision: 8, scale: 3, null: false, default: 1
       t.column :minimum_order_quantity, :float
-      t.change :price, :decimal, precision: 11, scale: 6, null: false, default: '0.0', comment: 'stored in `article_versions.supplier_order_unit`'
+      t.change :price, :decimal, precision: 12, scale: 6, null: false, default: '0.0', comment: 'stored in `article_versions.supplier_order_unit`'
       t.change :unit, :string, null: true, default: nil
     end
 
@@ -37,7 +37,7 @@ class AlterArticlesAddMoreUnitLogic < ActiveRecord::Migration[5.2]
         SET unit = #{quote compound_unit},
           group_order_granularity = #{quote 1},
           group_order_unit = #{quote 'XPP'},
-          price = #{quote article_version['price'].to_f * article_version['unit_quantity']},
+          price = LEAST(#{quote article_version['price'].to_f * article_version['unit_quantity']}, 999999),
           price_unit = #{quote 'XPP'},
           billing_unit = #{quote 'XPP'}
         WHERE article_versions.id = #{quote article_version['id']}
@@ -51,9 +51,9 @@ class AlterArticlesAddMoreUnitLogic < ActiveRecord::Migration[5.2]
     change_table :order_articles do |t|
       t.change :quantity, :decimal, precision: 8, scale: 3, null: false, default: '0.0', comment: 'stored in `article_versions.group_order_unit`'
       t.change :tolerance, :decimal, precision: 8, scale: 3, null: false, default: '0.0', comment: 'stored in `article_versions.group_order_unit`'
-      t.change :units_to_order, :decimal, precision: 11, scale: 6, null: false, default: '0.0', comment: 'stored in `article_versions.supplier_order_unit`'
-      t.change :units_billed, :decimal, precision: 11, scale: 6, null: true, default: nil, comment: 'stored in `article_versions.supplier_order_unit`'
-      t.change :units_received, :decimal, precision: 11, scale: 6, null: true, default: nil, comment: 'stored in `article_versions.supplier_order_unit`'
+      t.change :units_to_order, :decimal, precision: 12, scale: 6, null: false, default: '0.0', comment: 'stored in `article_versions.supplier_order_unit`'
+      t.change :units_billed, :decimal, precision: 12, scale: 6, null: true, default: nil, comment: 'stored in `article_versions.supplier_order_unit`'
+      t.change :units_received, :decimal, precision: 12, scale: 6, null: true, default: nil, comment: 'stored in `article_versions.supplier_order_unit`'
     end
 
     change_table :group_order_articles do |t|

--- a/db/migrate/20250322103203_fix_schema_inconsistent_with_migration_history.rb
+++ b/db/migrate/20250322103203_fix_schema_inconsistent_with_migration_history.rb
@@ -1,13 +1,16 @@
 class FixSchemaInconsistentWithMigrationHistory < ActiveRecord::Migration[7.0]
   def up
+    update(%(
+        UPDATE suppliers
+        SET suppliers.supplier_category_id = (SELECT id FROM supplier_categories LIMIT 1)
+        WHERE suppliers.supplier_category_id IS NULL
+    ))
+    change_column_null :suppliers, :supplier_category_id, false
     change_column :article_versions, :created_at, :datetime
   end
 
   def down
+    change_column_null :suppliers, :supplier_category_id, true
     change_column :article_versions, :created_at, :datetime, precision: nil
-  end
-
-  def change
-    change_column_null :suppliers, :supplier_category_id, false
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_06_01_093453) do
+ActiveRecord::Schema[7.2].define(version: 2025_06_01_093453) do
   create_table "action_text_rich_texts", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.string "name", null: false
     t.text "body", size: :long
@@ -75,7 +75,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_06_01_093453) do
 
   create_table "article_versions", id: :integer, charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.integer "article_id", null: false
-    t.decimal "price", precision: 11, scale: 6, default: "0.0", null: false, comment: "stored in `article_versions.supplier_order_unit`"
+    t.decimal "price", precision: 12, scale: 6, default: "0.0", null: false, comment: "stored in `article_versions.supplier_order_unit`"
     t.decimal "tax", precision: 8, scale: 2, default: "0.0", null: false
     t.decimal "deposit", precision: 8, scale: 2, default: "0.0", null: false
     t.datetime "created_at"
@@ -366,11 +366,11 @@ ActiveRecord::Schema[7.0].define(version: 2025_06_01_093453) do
     t.integer "order_id", default: 0, null: false
     t.decimal "quantity", precision: 8, scale: 3, default: "0.0", null: false, comment: "stored in `article_versions.group_order_unit`"
     t.decimal "tolerance", precision: 8, scale: 3, default: "0.0", null: false, comment: "stored in `article_versions.group_order_unit`"
-    t.decimal "units_to_order", precision: 11, scale: 6, default: "0.0", null: false, comment: "stored in `article_versions.supplier_order_unit`"
+    t.decimal "units_to_order", precision: 12, scale: 6, default: "0.0", null: false, comment: "stored in `article_versions.supplier_order_unit`"
     t.integer "lock_version", default: 0, null: false
     t.integer "article_version_id", null: false
-    t.decimal "units_billed", precision: 11, scale: 6, comment: "stored in `article_versions.supplier_order_unit`"
-    t.decimal "units_received", precision: 11, scale: 6, comment: "stored in `article_versions.supplier_order_unit`"
+    t.decimal "units_billed", precision: 12, scale: 6, comment: "stored in `article_versions.supplier_order_unit`"
+    t.decimal "units_received", precision: 12, scale: 6, comment: "stored in `article_versions.supplier_order_unit`"
     t.index ["article_version_id"], name: "index_order_articles_on_article_version_id"
     t.index ["order_id", "article_version_id"], name: "index_order_articles_on_order_id_and_article_version_id", unique: true
     t.index ["order_id"], name: "index_order_articles_on_order_id"


### PR DESCRIPTION
During my experiments migrating real life foodsoft dbs I stumbled across three issues:

1. Precision of `units_to_order`, `units_billed`, `units_received` and `price`  was not big enough to hold old values -> increased it from 11 to 12.
2. When multiplying `price` with `unit_quantity` (new `price` value is always stored in supplier order unit), some crazy values still wouldn't fit -> limit those with 999999 as nothing a foodcoop supplier sells will ever be _that_ expensive.
3. When setting `Supplier.supplier_category_id` to non-nullable (see https://github.com/foodcoops/foodsoft/pull/1143 ), ensure that existing nullable fields are first updated with the first category in the db.