### PR TITLE
On #1271 Fix superfluous multiplier symbol before SI units

### DIFF
--- a/app/helpers/articles_helper.rb
+++ b/app/helpers/articles_helper.rb
@@ -60,8 +60,8 @@ module ArticlesHelper
 
   private
 
-  def format_unit_with_ratios(unit_property, article_version, reference_unit = :group_order_unit)
-    base = format_unit(unit_property, article_version)
+  def format_unit_with_ratios(unit_property, article_version, reference_unit = :group_order_unit, prepend_multiplier_symbol_for_non_si_units: false)
+    base = format_unit(unit_property, article_version, prepend_multiplier_symbol_for_non_si_units: prepend_multiplier_symbol_for_non_si_units)
 
     factorized_unit_str = get_factorized_unit_str(article_version, unit_property, reference_unit) unless reference_unit.nil?
     return base if factorized_unit_str.nil?
@@ -69,11 +69,12 @@ module ArticlesHelper
     "#{base} (#{factorized_unit_str})"
   end
 
-  def format_unit(unit_property, article)
+  def format_unit(unit_property, article, prepend_multiplier_symbol_for_non_si_units: false)
     unit_code = article.send(unit_property)
-    return article.unit if unit_code.nil?
+    prefix = prepend_multiplier_symbol_for_non_si_units && !ArticleUnitsLib.unit_is_si_convertible(unit_code) ? ' × ' : ''
+    return prefix + article.unit if unit_code.nil?
 
-    ArticleUnitsLib.human_readable_unit(unit_code)
+    prefix + ArticleUnitsLib.human_readable_unit(unit_code)
   end
 
   def get_factorized_unit_str(article_version, unit_property, reference_unit)

--- a/app/views/group_orders/_form.html.haml
+++ b/app/views/group_orders/_form.html.haml
@@ -159,17 +159,17 @@
                   = t('.units_full') + ':'
                   %span{id: "units_#{order_article.id}"}
                     %span.quantity= order_article.units_to_order
-                    %span.unit= ' × ' + format_unit(:supplier_order_unit, order_article.article_version)
+                    %span.unit= format_unit(:supplier_order_unit, order_article.article_version, prepend_multiplier_symbol_for_non_si_units: true)
                   %br/
                   = t('.units_total') + ':'
                   %span{id: "q_total_#{order_article.id}"}
                     %span.quantity= @ordering_data[:order_articles][order_article.id][:quantity] + @ordering_data[:order_articles][order_article.id][:others_quantity]
-                    %span.unit=' × ' + format_unit_with_ratios(:group_order_unit, order_article.article_version)
+                    %span.unit= format_unit_with_ratios(:group_order_unit, order_article.article_version, :group_order_unit, prepend_multiplier_symbol_for_non_si_units: true)
                   %br/
                   = t('.total_tolerance') + ':'
                   %span{id: "t_total_#{order_article.id}"}
                     %span.quantity= @ordering_data[:order_articles][order_article.id][:tolerance] + @ordering_data[:order_articles][order_article.id][:others_tolerance]
-                    %span.unit=' × ' + format_unit_with_ratios(:group_order_unit, order_article.article_version)
+                    %span.unit= format_unit_with_ratios(:group_order_unit, order_article.article_version, :group_order_unit, prepend_multiplier_symbol_for_non_si_units: true)
                   %br/
                 .pull-left
                   #{heading_helper Article, :manufacturer}: #{order_article.article_version.manufacturer}


### PR DESCRIPTION
Fixes a minor design issue with #1271: SI units shouldn't be prefixed with the multplier symbol.
E.g. `12 × piece`, but **not** `12 × kg` (Just `12 kg` is enough).