### PR TITLE
fix: remove double dutch translation of unece unit

### DIFF
--- a/config/units-of-measure/locales/unece_nl.yml
+++ b/config/units-of-measure/locales/unece_nl.yml
@@ -44,7 +44,7 @@ unece_units:
   XCN:
     name: container
   XPO:
-    name: zakje
+    name: builtje
   XSH:
     name: zakje
   XCB:


### PR DESCRIPTION
Uploading article files containing article units that appear more than once in the UNECE unit translation files causes a the upload to crash. We noticed this problem when trying to upload a file using the "zakje" unit, which currently appears as translation for both XPO and XSH.
We propose to replace the translation of one of the two with the term "builtje", which we see being used by retailers in the Netherlands.