### PR TITLE
chore(build): improve Dockerfile and build swagger docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.4.6
+FROM ruby:3.4.6 AS base
 
 RUN supercronicUrl=https://github.com/aptible/supercronic/releases/download/v0.1.3/supercronic-linux-amd64 && \
     supercronicBin=/usr/local/bin/supercronic && \
@@ -6,6 +6,42 @@ RUN supercronicUrl=https://github.com/aptible/supercronic/releases/download/v0.1
     curl -fsSL -o "$supercronicBin" "$supercronicUrl" && \
     echo "$supercronicSha1sum  $supercronicBin" | sha1sum -c - && \
     chmod +x "$supercronicBin"
+
+ENV RAILS_ENV=production
+
+WORKDIR /usr/src/app
+
+COPY Gemfile Gemfile.lock ./
+COPY config/schedule.rb ./config/schedule.rb
+COPY plugins/ ./plugins
+
+# install dependencies and generate crontab
+RUN buildDeps='libmagic-dev' && \
+    apt-get update && \
+    apt-get install --no-install-recommends -y $buildDeps && \
+    echo 'gem: --no-document' >> ~/.gemrc && \
+    gem install bundler -v 2.4.22 && \
+    bundle config build.nokogiri "--use-system-libraries" && \
+    bundle config set --local without 'test development' && \
+    bundle config set --local deployment true && \
+    bundle install -j 4 && \
+    apt-get purge -y --auto-remove $buildDeps && \
+    rm -Rf /var/lib/apt/lists/* /var/cache/apt/* ~/.gemrc ~/.bundle && \
+    bundle exec whenever >crontab
+
+# Build swagger openapi docs
+FROM base AS swagger
+
+WORKDIR /usr/src/app
+
+COPY . ./
+
+RUN bundle config set --local without 'development' && \
+    bundle config set --local with 'test' && \
+    bundle install && \
+    RAILS_ENV=test DATABASE_URL=nulldb://nohost bundle exec rails rswag
+
+FROM base AS production
 
 ENV PORT=3000 \
     SMTP_SERVER_PORT=2525 \
@@ -17,35 +53,18 @@ WORKDIR /usr/src/app
 
 COPY . ./
 
-# install dependencies and generate crontab
-RUN buildDeps='libmagic-dev' && \
-    apt-get update && \
-    apt-get install --no-install-recommends -y $buildDeps && \
-    echo 'gem: --no-document' >> ~/.gemrc && \
-    gem install bundler -v 2.4.22 && \
-    bundle config build.nokogiri "--use-system-libraries" && \
-    bundle install --deployment --without development test -j 4 && \
-    apt-get purge -y --auto-remove $buildDeps && \
-    rm -Rf /var/lib/apt/lists/* /var/cache/apt/* ~/.gemrc ~/.bundle && \
-    \
-    bundle exec whenever >crontab
+# Copy swagger openapi docs
+COPY --from=swagger /usr/src/app/swagger ./swagger
 
 # compile assets with temporary mysql server
-RUN export DATABASE_URL=mysql2://localhost/temp?encoding=utf8 && \
-    export SECRET_KEY_BASE=thisisnotimportantnow && \
-    export DEBIAN_FRONTEND=noninteractive && \
+RUN export SECRET_KEY_BASE=thisisnotimportantnow && \
     apt-get update && \
-    apt-get install -y mariadb-server nodejs && \
-    /etc/init.d/mariadb start && \
-    mariadb -e "CREATE DATABASE temp" && \
+    apt-get install -y nodejs && \
     cp config/app_config.yml.SAMPLE config/app_config.yml && \
     cp config/database.yml.MySQL_SAMPLE config/database.yml && \
     cp config/storage.yml.SAMPLE config/storage.yml && \
-    bundle exec rake db:setup assets:precompile && \
-    rm -Rf tmp/* && \
-    /etc/init.d/mariadb stop && \
-    rm -Rf /run/mysqld /tmp/* /var/tmp/* /var/lib/mysql /var/log/mysql* && \
-    apt-get purge -y --auto-remove mariadb-server && \
+    DATABASE_URL=nulldb://nohost bundle exec rake assets:precompile && \
+    rm -Rf tmp/* \
     rm -Rf /var/lib/apt/lists/* /var/cache/apt/*
 
 # Make relevant dirs and files writable for app user

--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,9 @@ gem 'ruby-filemagic'
 gem 'spreadsheet'
 gem 'terser', '~> 1.1'
 
+# Only needed for building assets and swagger docs in docker build
+gem 'activerecord-nulldb-adapter'
+
 # we use a fork with Ruby 3 support of acts_as_versioned, and need to include it in this Gemfile
 gem 'acts_as_versioned', git: 'https://github.com/assembla/acts_as_versioned.git'
 gem 'foodsoft_discourse', path: 'plugins/discourse'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,6 +135,8 @@ GEM
       activemodel (= 7.2.3.1)
       activesupport (= 7.2.3.1)
       timeout (>= 0.4.0)
+    activerecord-nulldb-adapter (1.2.2)
+      activerecord (>= 6.1, < 8.2)
     activestorage (7.2.3.1)
       actionpack (= 7.2.3.1)
       activejob (= 7.2.3.1)
@@ -718,6 +720,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_serializers (~> 0.10.0)
+  activerecord-nulldb-adapter
   acts_as_tree
   acts_as_versioned!
   apparition


### PR DESCRIPTION
- use multi-stage Dockerfile
- add building of swagger docs to Dockerfile
- replace temp mysql server in assets build step with nulldb

fixes #998 

build time should be about the same as it is on master now

Still open:
- [ ] api-docs are currently served on the top level not scoped to foodcoops => other issue?
- [ ] further testing needed, especially with multi-foodcoop setups