### PR TITLE
On #766: Fixes bug with floating points in self-service

### DIFF
--- a/app/views/group_order_articles/update.js.erb
+++ b/app/views/group_order_articles/update.js.erb
@@ -6,7 +6,7 @@ $(document).trigger({
   group_order_article_id: <%= @group_order_article.id %>,
   group_order_article_price: <%= @group_order_article.total_price %>,
   group_order_article_availability_data: {
-    availability: <%= number_with_precision(@group_order_article.order_article.availability, precision: 3, strip_insignificant_zeros: true)%>,
+    availability: '<%= number_with_precision(@group_order_article.order_article.availability, precision: 3, strip_insignificant_zeros: true)%>',
     title: '<%= j(render('shared/articles_by/availability_explanation', goa: @group_order_article))%>'
   },
   available_funds: '<%= @ordergroup.nil? ? '?' : j(number_to_currency(@ordergroup.get_available_funds)) %>'


### PR DESCRIPTION
The self-service functionality had been cherry-picked from a pre-unit-changes state, where availability was always an integer. In the new state it threw a JS error, if availability included a float.