### PR TITLE
Fixes #1304 - sync/upload: wrong ID was used to identify articles to delete

### DIFF
--- a/app/views/articles/_sync.html.haml
+++ b/app/views/articles/_sync.html.haml
@@ -9,7 +9,7 @@
     %ul
       - @outlisted_articles.each_with_index do |article, index|
         %li
-          = hidden_field_tag "outlisted_articles[#{index}]", article.id
+          = hidden_field_tag "outlisted_articles[#{index}]", article.latest_article_version.id
           = article.name
           - if article.in_open_order
             .alert= t '.outlist.alert_used', article: article.name


### PR DESCRIPTION
Fixes #1304

`articles.id` (incorrect, imprecise) instead of `article_versions.id` (correct) was used to identify articles to delete