### PR TITLE
Fixes #1329 - Increase scale and precision of the `result` in `group_order_articles`

### DIFF
--- a/db/migrate/20260711191316_alter_group_order_articles_increase_precision.rb
+++ b/db/migrate/20260711191316_alter_group_order_articles_increase_precision.rb
@@ -1,0 +1,15 @@
+class AlterGroupOrderArticlesIncreasePrecision < ActiveRecord::Migration[7.2]
+  def up
+    change_table :group_order_articles do |t|
+      t.change :result, :decimal, precision: 12, scale: 6
+      t.change :result_computed, :decimal, precision: 12, scale: 6
+    end
+  end
+
+  def down
+    change_table :group_order_articles do |t|
+      t.change :result, :decimal, precision: 8, scale: 3
+      t.change :result_computed, :decimal, precision: 8, scale: 3
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_06_01_093453) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_11_191316) do
   create_table "action_text_rich_texts", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.string "name", null: false
     t.text "body", size: :long
@@ -75,7 +75,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_06_01_093453) do
 
   create_table "article_versions", id: :integer, charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.integer "article_id", null: false
-    t.decimal "price", precision: 12, scale: 6, default: "0.0", null: false, comment: "stored in `article_versions.supplier_order_unit`"
+    t.decimal "price", precision: 11, scale: 6, default: "0.0", null: false, comment: "stored in `article_versions.supplier_order_unit`"
     t.decimal "tax", precision: 8, scale: 2, default: "0.0", null: false
     t.decimal "deposit", precision: 8, scale: 2, default: "0.0", null: false
     t.datetime "created_at"
@@ -211,8 +211,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_06_01_093453) do
     t.decimal "quantity", precision: 8, scale: 3, default: "0.0", null: false
     t.decimal "tolerance", precision: 8, scale: 3, default: "0.0", null: false
     t.datetime "updated_on", precision: nil, null: false
-    t.decimal "result", precision: 8, scale: 3
-    t.decimal "result_computed", precision: 8, scale: 3
+    t.decimal "result", precision: 12, scale: 6
+    t.decimal "result_computed", precision: 12, scale: 6
     t.index ["group_order_id", "order_article_id"], name: "goa_index", unique: true
     t.index ["group_order_id"], name: "index_group_order_articles_on_group_order_id"
     t.index ["order_article_id"], name: "index_group_order_articles_on_order_article_id"
@@ -366,11 +366,11 @@ ActiveRecord::Schema[7.2].define(version: 2025_06_01_093453) do
     t.integer "order_id", default: 0, null: false
     t.decimal "quantity", precision: 8, scale: 3, default: "0.0", null: false, comment: "stored in `article_versions.group_order_unit`"
     t.decimal "tolerance", precision: 8, scale: 3, default: "0.0", null: false, comment: "stored in `article_versions.group_order_unit`"
-    t.decimal "units_to_order", precision: 12, scale: 6, default: "0.0", null: false, comment: "stored in `article_versions.supplier_order_unit`"
+    t.decimal "units_to_order", precision: 11, scale: 6, default: "0.0", null: false, comment: "stored in `article_versions.supplier_order_unit`"
     t.integer "lock_version", default: 0, null: false
     t.integer "article_version_id", null: false
-    t.decimal "units_billed", precision: 12, scale: 6, comment: "stored in `article_versions.supplier_order_unit`"
-    t.decimal "units_received", precision: 12, scale: 6, comment: "stored in `article_versions.supplier_order_unit`"
+    t.decimal "units_billed", precision: 11, scale: 6, comment: "stored in `article_versions.supplier_order_unit`"
+    t.decimal "units_received", precision: 11, scale: 6, comment: "stored in `article_versions.supplier_order_unit`"
     t.index ["article_version_id"], name: "index_order_articles_on_article_version_id"
     t.index ["order_id", "article_version_id"], name: "index_order_articles_on_order_id_and_article_version_id", unique: true
     t.index ["order_id"], name: "index_order_articles_on_order_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -75,7 +75,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_11_191316) do
 
   create_table "article_versions", id: :integer, charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.integer "article_id", null: false
-    t.decimal "price", precision: 11, scale: 6, default: "0.0", null: false, comment: "stored in `article_versions.supplier_order_unit`"
+    t.decimal "price", precision: 12, scale: 6, default: "0.0", null: false, comment: "stored in `article_versions.supplier_order_unit`"
     t.decimal "tax", precision: 8, scale: 2, default: "0.0", null: false
     t.decimal "deposit", precision: 8, scale: 2, default: "0.0", null: false
     t.datetime "created_at"
@@ -366,11 +366,11 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_11_191316) do
     t.integer "order_id", default: 0, null: false
     t.decimal "quantity", precision: 8, scale: 3, default: "0.0", null: false, comment: "stored in `article_versions.group_order_unit`"
     t.decimal "tolerance", precision: 8, scale: 3, default: "0.0", null: false, comment: "stored in `article_versions.group_order_unit`"
-    t.decimal "units_to_order", precision: 11, scale: 6, default: "0.0", null: false, comment: "stored in `article_versions.supplier_order_unit`"
+    t.decimal "units_to_order", precision: 12, scale: 6, default: "0.0", null: false, comment: "stored in `article_versions.supplier_order_unit`"
     t.integer "lock_version", default: 0, null: false
     t.integer "article_version_id", null: false
-    t.decimal "units_billed", precision: 11, scale: 6, comment: "stored in `article_versions.supplier_order_unit`"
-    t.decimal "units_received", precision: 11, scale: 6, comment: "stored in `article_versions.supplier_order_unit`"
+    t.decimal "units_billed", precision: 12, scale: 6, comment: "stored in `article_versions.supplier_order_unit`"
+    t.decimal "units_received", precision: 12, scale: 6, comment: "stored in `article_versions.supplier_order_unit`"
     t.index ["article_version_id"], name: "index_order_articles_on_article_version_id"
     t.index ["order_id", "article_version_id"], name: "index_order_articles_on_order_id_and_article_version_id", unique: true
     t.index ["order_id"], name: "index_order_articles_on_order_id"


### PR DESCRIPTION
Fixes #1329: Increase scale and precision of `group_order_articles.result` and `group_order_articles.result_computed`

Also see discussion about possible better solutions to this in #1092