### PR TITLE
Fix article price field layout

### DIFF
--- a/app/assets/stylesheets/article.scss
+++ b/app/assets/stylesheets/article.scss
@@ -36,3 +36,11 @@
 .sync-table .extra-unit-fields .control-group {
   margin-bottom: 20px;
 }
+
+.input-group .article-price-input {
+  width: 6em;
+}
+
+.article-price-unit {
+  min-width: 7em;
+}

--- a/app/views/articles/_edit_all_table.html.haml
+++ b/app/views/articles/_edit_all_table.html.haml
@@ -64,10 +64,10 @@
             .d-flex.gap-1.align-items-center
               .input-group.ml-1
                 %span.input-group-addon= t 'number.currency.format.unit'
-                = form.text_field 'price', class: 'form-control', style: 'width: 45px'
+                = form.text_field 'price', class: 'form-control article-price-input'
               .input.d-flex.gap-1.ml-1.align-items-center.unit-wrapper
                 %label=t('articles.form.per')
-                = form.input :price_unit, as: :select, collection: [], input_html: {'data-initial-value': article.price_unit, class: 'form-control'}, label: false, wrapper: false, include_blank: false
+                = form.input :price_unit, as: :select, collection: [], input_html: {'data-initial-value': article.price_unit, class: 'form-control article-price-unit'}, label: false, wrapper: false, include_blank: false
           %td= form.text_field 'order_number', class: 'form-control'
           %td= form.text_field 'note', class: 'form-control'
           %td= form.collection_select 'article_category_id', @article_categories,

--- a/app/views/articles/_sync_table.html.haml
+++ b/app/views/articles/_sync_table.html.haml
@@ -94,10 +94,10 @@
             .d-flex.gap-1
               .input-group
                 %span.input-group-addon= t 'number.currency.format.unit'
-                = form.text_field 'price', class: 'form-control', style: 'width: 45px'
+                = form.text_field 'price', class: 'form-control article-price-input'
               .input.d-flex.gap-1.unit-wrapper
                 %label=t('articles.form.per')
-                = form.select :price_unit, [], {include_blank: false}, {'data-initial-value': changed_article.price_unit, class: 'form-control'}
+                = form.select :price_unit, [], {include_blank: false}, {'data-initial-value': changed_article.price_unit, class: 'form-control article-price-unit'}
           %td{:style => highlight_new(attrs, :tax)}
             .input-group
               = form.text_field 'tax', class: 'form-control', style: 'width: 45px; margin-right: 0px'


### PR DESCRIPTION
Fixes #1332.

The bulk edit and synchronization tables now reserve enough space for normal price values and keep the price-unit selector from collapsing in the flex row.

Validation:
- `git diff --check`