### PR TITLE
Fixes #1330 - Invalid space before conversion button

### DIFF
--- a/app/assets/stylesheets/bootstrap_and_overrides.css.scss
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css.scss
@@ -759,6 +759,10 @@ td.mr-1 > *:last-child {
   display: block;
 }
 
+.numeric-step {
+  min-width: 50px;
+}
+
 
 .form-group .select2-container {
   width: 200px;

--- a/app/views/group_orders/_form.html.haml
+++ b/app/views/group_orders/_form.html.haml
@@ -123,8 +123,8 @@
               %span.unused= number_with_precision(@ordering_data[:order_articles][order_article.id][:quantity] - @ordering_data[:order_articles][order_article.id][:used_quantity], precision: 3, strip_insignificant_zeros: true)
             %td.quantity.group-order-input{class: ('stock-order' if @order.stockit?)}
               .row
-                .col-xs-4.input-group.input-group-sm
-                  %span.input-group-btn.numeric-step
+                .col-xs-4.input-group.input-group-sm.d-flex
+                  %span.input-group-btn.numeric-step{style: 'width: 50px !important'}
                     %button.btn.btn-default.btn-ordering.decrease{type: "button"}
                       %i.glyphicon.glyphicon-minus
                     %button.btn.btn-default.btn-ordering.increase{type: "button"}
@@ -141,8 +141,8 @@
             %td.tolerance.group-order-input{style: ('display:none' if @order.stockit?)}
               - if (order_article.article_version.uses_tolerance?)
                 .row
-                  .col-xs-4.input-group.input-group-sm
-                    %span.input-group-btn
+                  .col-xs-4.input-group.input-group-sm.d-flex
+                    %span.input-group-btn{style: 'width: 50px !important'}
                       %button.btn.btn-default.btn-ordering.decrease{type: "button"}
                         %i.glyphicon.glyphicon-minus
                       %button.btn.btn-default.btn-ordering.increase{type: "button"}

--- a/app/views/group_orders/_form.html.haml
+++ b/app/views/group_orders/_form.html.haml
@@ -123,8 +123,8 @@
               %span.unused= number_with_precision(@ordering_data[:order_articles][order_article.id][:quantity] - @ordering_data[:order_articles][order_article.id][:used_quantity], precision: 3, strip_insignificant_zeros: true)
             %td.quantity.group-order-input{class: ('stock-order' if @order.stockit?)}
               .row
-                .col-xs-4.input-group.input-group-sm.d-flex
-                  %span.input-group-btn.numeric-step{style: 'width: 50px !important'}
+                .col-xs-12.input-group.input-group-sm.d-flex
+                  %span.input-group-btn.numeric-step
                     %button.btn.btn-default.btn-ordering.decrease{type: "button"}
                       %i.glyphicon.glyphicon-minus
                     %button.btn.btn-default.btn-ordering.increase{type: "button"}
@@ -141,8 +141,8 @@
             %td.tolerance.group-order-input{style: ('display:none' if @order.stockit?)}
               - if (order_article.article_version.uses_tolerance?)
                 .row
-                  .col-xs-4.input-group.input-group-sm.d-flex
-                    %span.input-group-btn{style: 'width: 50px !important'}
+                  .col-xs-12.input-group.input-group-sm.d-flex
+                    %span.input-group-btn.numeric-step
                       %button.btn.btn-default.btn-ordering.decrease{type: "button"}
                         %i.glyphicon.glyphicon-minus
                       %button.btn.btn-default.btn-ordering.increase{type: "button"}


### PR DESCRIPTION
Fixes #1330

Buttons and input field are now displayed without white space

<img width="1420" height="118" alt="grafik" src="https://github.com/user-attachments/assets/4622d67d-8569-417e-8b09-be8f01ebf23f" />


