### PR TITLE
fix: do not display order url if only email order method available

### DIFF
--- a/app/views/suppliers/_form.html.haml
+++ b/app/views/suppliers/_form.html.haml
@@ -26,3 +26,15 @@
   %div
     = f.button :submit
     = link_to t('ui.or_cancel'), suppliers_path
+
+- content_for :javascript do
+  :javascript
+    $(function() {
+      var urlFormGroup$ = $('#supplier_remote_order_url').closest('.form-group');
+      var methodSelect$ = $('#supplier_remote_order_method');
+      var toggleUrlField = function() {
+        urlFormGroup$.toggle(methodSelect$.val() !== 'email');
+      };
+      methodSelect$.on('change', toggleUrlField);
+      toggleUrlField();
+    });


### PR DESCRIPTION
Fixes #1343

A LLM was used to create this PR. Code was reviewed and tested.

Please test @steffen-unicode 

### How to test

- Open a edit or new form for a supplier
- Only the method dropdown should be displayed not the Order Url field
---
- Activate b85 plugin
- Open a edit or new form for a supplier
- Order method dropdown should include FTP/b85 and Order URL field should be displayed if FTP/b85 is selected.
- Set order url
- Save
- Order method and url should be set.
---
- Edit supplier again
- Set method to email
- Order url field should be hidden