### PR TITLE
Closes #1339: Edit all articles: Make "delete ratio" button more distinguishable from "close popup"

### DIFF
--- a/app/assets/javascripts/article-form.js
+++ b/app/assets/javascripts/article-form.js
@@ -291,7 +291,9 @@ class ArticleForm {
       .on('click.article_form_ratio_row', (e) => {
         e.preventDefault();
         e.stopPropagation();
-        this.removeRatioRow($(e.target).closest('tr'));
+        if (confirm($(e.target).closest('a').attr('title') + '?')) {
+          this.removeRatioRow($(e.target).closest('tr'));
+        }
       });
 
     const select$ = $('select[name$="[unit]"]', row$);

--- a/app/views/shared/_article_unit_ratio.haml
+++ b/app/views/shared/_article_unit_ratio.haml
@@ -16,4 +16,4 @@
         %div.unit_multiplier.ml-2
       %div.actions{style: 'width:1em, justify-self: end'}
         = link_to t('.remove'), method: :delete, 'data-remove-ratio' => true, title: t('.remove'), class: 'btn btn-danger btn-xs' do
-          = fa_icon :remove
+          = fa_icon :trash


### PR DESCRIPTION
Edit all articles / Article form: 

- Make "delete ratio" button more distinguishable from "close popup"
- Added confirm before a ratio is actually deleted

Closes #1339