### PR TITLE
Fixes #1353 - Self service - transactions: immediately update credit/balance when creating a transaction

### DIFF
--- a/app/controllers/finance/financial_transactions_controller.rb
+++ b/app/controllers/finance/financial_transactions_controller.rb
@@ -52,6 +52,7 @@ class Finance::FinancialTransactionsController < ApplicationController
     @financial_transaction = FinancialTransaction.new(params[:financial_transaction])
     @financial_transaction.user = current_user
     @financial_transaction.save!
+    find_ordergroup
 
     respond_to do |format|
       format.js


### PR DESCRIPTION
Self service - transactions: immediately update credit/balance when creating a transaction

Fixes #1353