### PR TITLE
Fixes #1357 - Add `overflow: auto` for root element

### DIFF
--- a/app/assets/stylesheets/bootstrap_and_overrides.css.scss
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css.scss
@@ -254,10 +254,11 @@ table {
   left: 30px;
 
   .article-name {
-    text-align: center;
     margin: 2px 0;
     margin-bottom: 5px;
-    width: 100%;
+    width: 75%;
+    text-overflow: ellipsis;
+    overflow: hidden;
     font-weight: bold;
   }
   .pull-right {
@@ -301,6 +302,8 @@ tr.order-article .article-info {
     margin-bottom: 5px;
     border: 1px solid rgb(104,153,70);
     padding: 2px;
+    max-width: 90vw;
+    overflow: auto;
   }
 }
 
@@ -732,6 +735,10 @@ td.mr-1 > *:last-child {
 
 .gap-8 {
   gap: 2rem;
+}
+
+.overflow-auto {
+  overflow: auto;
 }
 
 .overflow-hidden {

--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -440,7 +440,6 @@ table#order {
         background-color: red; }
 
 #order-footer {
-  width: 100%;
   right: 0;
   left: 0; }
 

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -32,7 +32,7 @@
       .navbar-collapse.collapse
         = render_navigation expand_all: true, renderer: :bootstrap3
 
-  #main.container-fluid
+  #main.container-fluid.overflow-auto
     .row
       - if content_for?(:sidebar)
         .col-md-3


### PR DESCRIPTION
Fixes #1357

Add `overflow: auto` for root element to avoid visual viewport scrolling on mobile devices

This will affect **all** pages as the root element style is changed.

- [x] Do smoke tests, to check if this causes side effects on other pages.